### PR TITLE
fix(studio): use `precess.env` instead of `import.meta.env`

### DIFF
--- a/apps/studio/sanity.config.ts
+++ b/apps/studio/sanity.config.ts
@@ -1,3 +1,5 @@
+/* eslint-disable node/prefer-global/process */
+
 import { assist } from '@sanity/assist';
 import { deDELocale } from '@sanity/locale-de-de';
 import { visionTool } from '@sanity/vision';
@@ -10,7 +12,7 @@ import { schemaTypes } from './src/schemas';
 import { deskStructure } from './src/structure';
 
 export default defineConfig({
-	dataset: import.meta.env.SANITY_STUDIO_DATASET,
+	dataset: process.env.SANITY_API_DATASET || 'production',
 	icon: Logo,
 	name: 'default',
 	plugins: [
@@ -20,9 +22,10 @@ export default defineConfig({
 		deDELocale(),
 		assist(),
 	],
-	projectId: import.meta.env.SANITY_STUDIO_PROJECT_ID,
+	projectId: process.env.SANITY_API_PROJECT_ID || 'MISSING_PROJECT_ID_IN_ENV',
 	schema: {
 		types: schemaTypes,
 	},
 	title: 'TSG Irlich 1882',
+	token: process.env.SANITY_API_WRITE_TOKEN,
 });


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Replaced `import.meta.env` with `process.env` for environment variables in the Sanity configuration file.
- Added fallback values for `dataset` and `projectId` to ensure default values are used if environment variables are missing.
- Introduced a new `token` configuration using `process.env.SANITY_API_WRITE_TOKEN`.
- Disabled the ESLint rule `node/prefer-global/process` to allow global `process` usage.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sanity.config.ts</strong><dd><code>Replace <code>import.meta.env</code> with <code>process.env</code> for environment variables</code></dd></summary>
<hr>

apps/studio/sanity.config.ts
<li>Disabled ESLint rule for global <code>process</code> usage.<br> <li> Replaced <code>import.meta.env</code> with <code>process.env</code> for environment variables.<br> <li> Added fallback values for <code>dataset</code> and <code>projectId</code>.<br> <li> Introduced a new <code>token</code> configuration using <code>process.env</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/mheob/tsg-irlich-web/pull/30/files#diff-cbdf7bb6617bf103d32b01ba59d6ebbdd05cae38aa06750c80129594cd4c1542">+5/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

