### PR TITLE
fix(studio): allow 200 chars on `person.vision`

### DIFF
--- a/apps/studio/schemas/documents/person.ts
+++ b/apps/studio/schemas/documents/person.ts
@@ -4,6 +4,7 @@ import { defineField, defineType } from 'sanity';
 import { additionalInformation, contact, personal } from '@/shared/field-groups';
 import { emailField, phoneField } from '@/shared/fields/contact';
 import { firstNameField, lastNameField, portraitPictureField } from '@/shared/fields/personal';
+import { getMaxLengthRule, getMinLengthRule, getRequiredRole } from '@/shared/validation-rules';
 
 const person = defineType({
 	title: 'Ansprechpartner',
@@ -23,27 +24,24 @@ const person = defineType({
 
 		// additionalInformation
 		defineField({
+			title: 'Abteilung, Gruppe etc.',
+			name: 'department',
+			type: 'string',
 			description: 'Die Gruppe oder Abteilung der Person.',
 			group: 'additionalInformation',
-			name: 'department',
-			title: 'Abteilung, Gruppe etc.',
-			type: 'string',
 			validation: rule => [
-				rule
-					.required()
-					.min(2)
-					.error('Die Gruppe oder Abteilung muss mindestens 2 Zeichen lang sein.'),
-				rule.max(64).warning('Die Gruppe oder Abteilung sollte maximal 64 Zeichen lang sein.'),
+				getMinLengthRule(rule, 2, 'Die Gruppe oder Abteilung'),
+				getMaxLengthRule(rule, 64, 'Die Gruppe oder Abteilung'),
 			],
 		}),
 		defineField({
+			title: 'Rolle',
+			name: 'role',
+			type: 'reference',
+			to: [{ type: 'group' }],
 			description: 'Die Rolle oder Funktion der Person (z.B. Vorstand Finanzen).',
 			group: 'additionalInformation',
-			name: 'role',
-			title: 'Rolle',
-			to: [{ type: 'group' }],
-			type: 'reference',
-			validation: rule => [rule.required().error('Die Rolle oder Funktion ist erforderlich.')],
+			validation: rule => [getRequiredRole(rule, 'Rolle oder Funktion')],
 		}),
 		defineField({
 			title: 'Beschreibung (Vision)',
@@ -52,8 +50,8 @@ const person = defineType({
 			description: 'Eine kurze Beschreibung der Person.',
 			group: 'additionalInformation',
 			validation: rule => [
-				rule.required().min(32).error('Die Beschreibung muss mindestens 32 Zeichen lang sein.'),
-				rule.max(64).warning('Die Beschreibung sollte maximal 64 Zeichen lang sein.'),
+				getMinLengthRule(rule, 32, 'Die Beschreibung (Vision)'),
+				getMaxLengthRule(rule, 200, 'Die Beschreibung (Vision)'),
 			],
 		}),
 	],

--- a/apps/studio/schemas/single-pages/about-us/gallery.ts
+++ b/apps/studio/schemas/single-pages/about-us/gallery.ts
@@ -2,7 +2,7 @@ import { RiLinksLine } from 'react-icons/ri';
 import { defineField } from 'sanity';
 
 import { getDefaultPageFieldsWithGroup } from '@/shared/fields/general';
-import { getLengthRule } from '@/shared/validation-rules';
+import { getExactLengthRule } from '@/shared/validation-rules';
 
 export const galleryField = defineField({
 	title: 'Galerie',
@@ -15,11 +15,13 @@ export const galleryField = defineField({
 
 		defineField({
 			title: 'Bilder',
-			name: 'venues',
+			name: 'images',
 			type: 'array',
 			of: [{ type: 'extendedImage' }],
 			description: 'Diese gewählten Bilder werden in der gewünschten Reihenfolge angezeigt.',
-			validation: rule => [getLengthRule(rule, 3, 'Es müssen genau 3 Bilder ausgewählt werden.')],
+			validation: rule => [
+				getExactLengthRule(rule, 3, 'Es müssen genau 3 Bilder ausgewählt werden.'),
+			],
 		}),
 	],
 });

--- a/apps/studio/schemas/single-pages/single-group/gallery.ts
+++ b/apps/studio/schemas/single-pages/single-group/gallery.ts
@@ -15,7 +15,7 @@ export const galleryField = defineField({
 
 		defineField({
 			title: 'Bilder',
-			name: 'venues',
+			name: 'images',
 			type: 'array',
 			of: [{ type: 'extendedImage' }],
 			description: 'Diese gewählten Bilder werden in der gewünschten Reihenfolge angezeigt.',

--- a/apps/studio/shared/validation-rules.ts
+++ b/apps/studio/shared/validation-rules.ts
@@ -17,7 +17,7 @@ interface RequiredRule<Rule> extends BaseRule<Rule> {
 	required: () => Rule;
 }
 
-interface LengthRule<Rule> extends BaseRule<Rule>, RequiredRule<Rule> {
+interface ExactLengthRule<Rule> extends BaseRule<Rule>, RequiredRule<Rule> {
 	length: (length: number) => Rule;
 }
 
@@ -34,7 +34,7 @@ function getTextByInputType(inputType: RuleOptions['inputType'], length: number)
 	return inputType === 'array' ? arrayOutput : 'Zeichen';
 }
 
-export function getLengthRule<Rule extends LengthRule<Rule>>(
+export function getExactLengthRule<Rule extends ExactLengthRule<Rule>>(
 	rule: Rule,
 	length: number,
 	title: string,


### PR DESCRIPTION
### **User description**
closes #48


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Updated validation rules for `department`, `role`, and `description` fields in `person.ts`.
- Increased maximum length for `description` field to 200 characters.
- Refactored validation rules to use shared functions.
- Renamed `venues` field to `images` in gallery schemas.
- Updated validation rule to use `getExactLengthRule` in gallery schemas.
- Renamed `getLengthRule` to `getExactLengthRule` and updated interface name in `validation-rules.ts`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>person.ts</strong><dd><code>Update validation rules and increase description length</code>&nbsp; &nbsp; </dd></summary>
<hr>

apps/studio/schemas/documents/person.ts
<li>Updated validation rules for <code>department</code>, <code>role</code>, and <code>description</code> fields.<br> <li> Increased maximum length for <code>description</code> field to 200 characters.<br> <li> Refactored validation rules to use shared functions.<br>


</details>
    

  </td>
  <td><a href="https://github.com/mheob/tsg-irlich-web/pull/49/files#diff-b5d1e4a838f06a5545229f96bc4516a22abec58c7589fd105dc9093730ead351">+13/-15</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>gallery.ts</strong><dd><code>Rename field and update validation rule</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio/schemas/single-pages/about-us/gallery.ts
<li>Renamed <code>venues</code> field to <code>images</code>.<br> <li> Updated validation rule to use <code>getExactLengthRule</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/mheob/tsg-irlich-web/pull/49/files#diff-a6f21e36861b8bc7729df33b6bbb639bcf9f1c714cf551f8b776d5ca83f72e6b">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>gallery.ts</strong><dd><code>Rename field from venues to images</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio/schemas/single-pages/single-group/gallery.ts
- Renamed `venues` field to `images`.



</details>
    

  </td>
  <td><a href="https://github.com/mheob/tsg-irlich-web/pull/49/files#diff-4964412f0e1776adcbf2da32a8df0321be31bb12a23b0aff900efd3bb8c2ae09">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>validation-rules.ts</strong><dd><code>Rename validation rule and interface</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

apps/studio/shared/validation-rules.ts
<li>Renamed <code>getLengthRule</code> to <code>getExactLengthRule</code>.<br> <li> Updated interface name from <code>LengthRule</code> to <code>ExactLengthRule</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/mheob/tsg-irlich-web/pull/49/files#diff-e93f4590a8d9f05e518c771c3a8aa8ad67ccd8a3275749c29b42b9311cf31aaf">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

