### PR TITLE
feat(studio): add more dynamic content to `news.article`

### DIFF
--- a/apps/studio/schemas/documents/news.article.ts
+++ b/apps/studio/schemas/documents/news.article.ts
@@ -29,7 +29,13 @@ const newsArticle = defineType({
 		// content
 		defineField({
 			...contentField,
-			of: [{ type: 'grid' }, { type: 'mainImage' }, { type: 'blockContent' }, { type: 'spacer' }],
+			of: [
+				{ type: 'grid' },
+				{ type: 'mainImage' },
+				{ type: 'simpleBlockContent' },
+				{ type: 'blockquote' },
+				{ type: 'spacer' },
+			],
 		}),
 	],
 	initialValue: () => ({ publishedAt: new Date().toISOString() }),

--- a/apps/studio/schemas/index.ts
+++ b/apps/studio/schemas/index.ts
@@ -18,6 +18,7 @@ import simpleBlockContent from './objects/simple-block-content';
 import socialFields from './objects/social-fields';
 import stats from './objects/stats';
 import blockContent from './sections/block-content';
+import blockquote from './sections/blockquote';
 import grid from './sections/grid';
 import mainImage from './sections/main-image';
 import spacer from './sections/spacer';
@@ -63,6 +64,7 @@ export const schemaTypes = [
 
 	// Sections
 	blockContent,
+	blockquote,
 	grid,
 	mainImage,
 	spacer,

--- a/apps/studio/schemas/sections/block-content.ts
+++ b/apps/studio/schemas/sections/block-content.ts
@@ -22,46 +22,13 @@ const blockContent = defineField({
 						decorators: [
 							{ title: 'Strong', value: 'strong' },
 							{ title: 'Italic', value: 'em' },
-							{ title: 'Underline', value: 'underline' },
 							{ title: 'Code', value: 'code' },
 						],
 					},
 					styles: [
 						{ title: 'Normal', value: 'normal' },
-						{ title: 'H1', value: 'h1' },
 						{ title: 'H2', value: 'h2' },
 						{ title: 'H3', value: 'h3' },
-						{ title: 'H4', value: 'h4' },
-						{ title: 'H5', value: 'h5' },
-						{ title: 'H6', value: 'h6' },
-						{
-							title: 'Normal Center',
-							value: 'normal+center',
-						},
-						{
-							title: 'H1 Center',
-							value: 'h1+center',
-						},
-						{
-							title: 'H2 Center',
-							value: 'h2+center',
-						},
-						{
-							title: 'H3 Center',
-							value: 'h3+center',
-						},
-						{
-							title: 'H4 Center',
-							value: 'h4+center',
-						},
-						{
-							title: 'H5 Center',
-							value: 'h5+center',
-						},
-						{
-							title: 'H6 Center',
-							value: 'h6+center',
-						},
 						{ title: 'Quote', value: 'blockquote' },
 					],
 				},

--- a/apps/studio/schemas/sections/blockquote.ts
+++ b/apps/studio/schemas/sections/blockquote.ts
@@ -1,0 +1,25 @@
+import { RiChatQuoteLine } from 'react-icons/ri';
+import { defineField } from 'sanity';
+
+const blockquote = defineField({
+	title: 'Zitat-Block',
+	name: 'blockquote',
+	type: 'object',
+	description: 'A blockquote component with the quote and author',
+	icon: RiChatQuoteLine,
+	hidden: true,
+	fields: [
+		defineField({
+			title: 'Zitat',
+			name: 'quote',
+			type: 'text',
+		}),
+		defineField({
+			title: 'Autor',
+			name: 'author',
+			type: 'string',
+		}),
+	],
+});
+
+export default blockquote;

--- a/apps/studio/schemas/sections/spacer.ts
+++ b/apps/studio/schemas/sections/spacer.ts
@@ -19,7 +19,6 @@ const spacer = defineField({
 					{ title: 'Small', value: 'small' },
 					{ title: 'Medium', value: 'medium' },
 					{ title: 'Large', value: 'large' },
-					{ title: 'X-Large', value: 'xlarge' },
 				],
 			},
 		},


### PR DESCRIPTION
closes #15


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced support for new content types in news articles, allowing for `simpleBlockContent` and `blockquote`.
	- Added a new `blockquote` schema for encapsulating quotes and authors.
  
- **Improvements**
	- Streamlined styling options for `blockContent`, enhancing usability and design consistency.
	- Removed the 'X-Large' option from the `spacer` field to simplify choices.

- **Bug Fixes**
	- Ensured backward compatibility while updating the content structure in news articles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->