### PR TITLE
feat(web): add `news` section to home

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -56,6 +56,7 @@
 		"Porträtbild",
 		"pragent",
 		"Preact",
+		"seitfallzieher",
 		"Shitposting",
 		"Showtanz",
 		"sonarcloud",

--- a/apps/web/src/components/cards/NewsArticleWide.astro
+++ b/apps/web/src/components/cards/NewsArticleWide.astro
@@ -1,0 +1,31 @@
+---
+interface Props {
+	author: { imageSrc: string; name: string };
+	categories: { source: string; title: string }[];
+	description: string;
+	imageSrc: string;
+	slug: string;
+	title: string;
+}
+
+const { author, categories, description, imageSrc, slug, title } = Astro.props;
+---
+
+<article class="group grid grid-cols-[50%,50%] rounded-xl bg-white text-black">
+	<a class="overflow-hidden rounded-l-xl" href={slug}>
+		<img alt={title} class="transform-cpu duration-500 group-hover:scale-110" src={imageSrc} />
+	</a>
+
+	<div class="flex flex-col justify-between gap-2 px-14 py-8">
+		<p class="flex gap-6 text-lg">
+			{categories.map(category => <a href={category.source}>{category.title}</a>)}
+		</p>
+		<h3 class="line-clamp-2 text-3xl font-bold"><a href={slug}>{title}</a></h3>
+		<p class="line-clamp-3 text-xl">{description}</p>
+
+		<div class="flex items-center gap-3">
+			<img alt="Author" class="rounded-full" src={author.imageSrc} />
+			<p class="text-xl">{author.name}</p>
+		</div>
+	</div>
+</article>

--- a/apps/web/src/components/cards/index.ts
+++ b/apps/web/src/components/cards/index.ts
@@ -1,3 +1,4 @@
 export { default as FeatureCard } from './FeatureCard.astro';
+export { default as NewsArticleWide } from './NewsArticleWide.astro';
 export { default as OfferCard } from './OfferCard.astro';
 export { default as PriceTableCard } from './PriceTableCard.astro';

--- a/apps/web/src/components/page-sections/home/News.astro
+++ b/apps/web/src/components/page-sections/home/News.astro
@@ -1,0 +1,79 @@
+---
+import type { ComponentProps } from 'astro/types';
+
+import { NewsArticleWide } from '@/components/cards';
+import { CtaButton, SectionHeader } from '@/components/items';
+
+const articles: ComponentProps<typeof NewsArticleWide>[] = [
+	{
+		author: { imageSrc: 'https://placehold.co/50x50', name: 'Anabel Autor' },
+		categories: [{ source: '#!', title: 'Fußball' }],
+		description:
+			'Lorem ipsum dolor sit amet consectetur. Adipiscing in eu tempus feugiat enim placerat. Cursus commodo lorem sit fringilla augue.',
+		imageSrc: 'https://placehold.co/800x450',
+		slug: '#!',
+		title: 'Lorem ipsum dolor sit amet consectetur - Adipiscing in eu tempus feugiat enim placerat',
+	},
+	{
+		author: { imageSrc: 'https://placehold.co/50x50', name: 'Anabel Autor' },
+		categories: [{ source: '#!', title: 'Badminton' }],
+		description: 'Reprehenderit rerum maiores magnam aut voluptate eos cum dolorum minus.',
+		imageSrc: 'https://placehold.co/800x450',
+		slug: '#!',
+		title: 'Figma ipsum component variant main layer - Comment background',
+	},
+	{
+		author: { imageSrc: 'https://placehold.co/50x50', name: 'Anabel Autor' },
+		categories: [
+			{ source: '#!', title: 'Pilates' },
+			{ source: '#!', title: 'Yoga' },
+		],
+		description:
+			'Neque aut quasi quidem et et praesentium molestias veniam atque. Et incidunt delectus. Reiciendis vel eaque voluptas eaque. Velit voluptate error vitae possimus iste inventore. Et eveniet aliquid iste sunt recusandae. Ratione neque illo veniam inventore aut ex.',
+		imageSrc: 'https://placehold.co/800x450',
+		slug: '#!',
+		title: 'Office ipsum you must be muted see event charts done hit',
+	},
+];
+---
+
+<section class="bg-brand relative z-0 text-white">
+	<div class="container mx-auto px-5 pb-40 pt-28">
+		<SectionHeader
+			descriptionClass="text-white"
+			subTitle="Aktuelles"
+			title="Neuigkeiten rund um die TSG"
+			isCentered
+		>
+			Lorem ipsum dolor sit amet consectetur. Adipiscing in eu tempus feugiat enim placerat. Cursus
+			commodo lorem sit fringilla augue.
+		</SectionHeader>
+
+		<div class="mt-32 flex flex-col justify-center gap-12">
+			{articles.map(article => <NewsArticleWide {...article} />)}
+		</div>
+
+		<footer class="mt-20 text-center">
+			<CtaButton href="#!" type="secondary">Alle Neuigkeiten ansehen</CtaButton>
+		</footer>
+	</div>
+</section>
+
+<style>
+	section {
+		&::before {
+			content: '';
+			position: absolute;
+			inset: 0;
+			background-image: url('../../../icons/design/bg-silhouette-wandern.svg'),
+				url('../../../icons/design/bg-silhouette-fussball-seitfallzieher.svg');
+			background-position:
+				0% 10%,
+				100% 110%;
+			background-repeat: no-repeat;
+			background-size: 250px, 300px;
+			opacity: 0.15;
+			z-index: -1;
+		}
+	}
+</style>

--- a/apps/web/src/components/page-sections/home/index.ts
+++ b/apps/web/src/components/page-sections/home/index.ts
@@ -4,6 +4,7 @@ export { default as Counter } from './Counter.astro';
 export { default as Features } from './Features.astro';
 export { default as Groups } from './Groups.astro';
 export { default as Hero } from './Hero.astro';
+export { default as News } from './News.astro';
 export { default as PriceTable } from './PriceTable.astro';
 export { default as Testimonials } from './Testimonials.astro';
 export { default as Vision } from './Vision.astro';

--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -6,6 +6,7 @@ import {
 	Features,
 	Groups,
 	Hero,
+	News,
 	PriceTable,
 	Testimonials,
 	Vision,
@@ -23,4 +24,6 @@ import { BaseLayout } from '@/layouts';
 	<Testimonials />
 	<ContactPersons />
 	<ContactForm />
+	<News />
+	<div class="bg-gray-lightest h-96"></div>
 </BaseLayout>


### PR DESCRIPTION
closes #82

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced the `NewsArticleWide` component for displaying wide-format news articles.
	- Added a new `News` section to aggregate and present news content.
	- Integrated the `News` component into the main page layout.

- **Enhancements**
	- Expanded spell checker vocabulary with the addition of the term "seitfallzieher."
	- Improved visual layout with responsive design and styling updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->