### PR TITLE
feat(studio): add `taskDescription` to `person.affiliations`

### DIFF
--- a/apps/studio/schemas/documents/person.ts
+++ b/apps/studio/schemas/documents/person.ts
@@ -51,10 +51,22 @@ const person = defineType({
 						}),
 
 						defineField({
+							title: 'Aufgabenbeschreibung',
+							name: 'taskDescription',
+							type: 'text',
+							description:
+								'Kurze Aufgabenbeschreibung zum Posten der Person (ca. 270 bis 330 Zeichen).',
+							validation: _rule => [
+								// minLengthRule(rule, 270, 'Die Beschreibung (Vision)'),
+								// maxLengthRule(rule, 330, 'Die Beschreibung (Vision)'),
+							],
+						}),
+
+						defineField({
 							title: 'Beschreibung (Vision)',
 							name: 'description',
 							type: 'text',
-							description: 'Eine kurze Beschreibung der Person.',
+							description: 'Kurze Beschreibung als Vision der Person.',
 							validation: _rule => [
 								// minLengthRule(rule, 32, 'Die Beschreibung (Vision)'),
 								// maxLengthRule(rule, 200, 'Die Beschreibung (Vision)'),


### PR DESCRIPTION
closes #106


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new field, `taskDescription`, in the affiliations section of the person document to allow for brief task descriptions related to a person's position.
  
- **Updates**
	- Revised the existing `description` field to clarify its purpose as a short vision of the person.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->