### PR TITLE
feat(studio): add `email` to `group`

### DIFF
--- a/apps/studio/schemas/documents/group.tsx
+++ b/apps/studio/schemas/documents/group.tsx
@@ -20,6 +20,14 @@ const group = defineType({
 		}),
 
 		defineField({
+			title: 'E-Mail',
+			name: 'email',
+			type: 'email',
+			description: 'Die E-Mail-Adresse der Gruppe bzw. Mannschaft.',
+			// validation: rule => [requiredRule(rule, 'Die E-Mail')],
+		}),
+
+		defineField({
 			title: 'Beschreibung',
 			name: 'description',
 			type: 'simpleBlockContent',


### PR DESCRIPTION
closes #107


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an 'E-Mail' field in the group document schema to store email addresses for groups or teams.
  
- **Documentation**
	- Added a description for the new email field to clarify its purpose.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->