### PR TITLE
feat(studio): add `email` to `role`

### DIFF
--- a/apps/studio/schemas/documents/role.tsx
+++ b/apps/studio/schemas/documents/role.tsx
@@ -20,6 +20,13 @@ const role = defineType({
 				maxLengthRule(rule, 64, 'Der Name'),
 			],
 		}),
+
+		defineField({
+			title: 'E-Mail',
+			name: 'email',
+			type: 'email',
+			description: 'Die E-Mail-Adresse der Rolle. Sie muss NUR bei Vorstandsämtern gesetzt werden!',
+		}),
 	],
 	orderings: [
 		{
@@ -27,6 +34,7 @@ const role = defineType({
 			name: 'titleAsc',
 			by: [{ field: 'title', direction: 'asc' }],
 		},
+
 		{
 			title: 'nach Name - absteigend',
 			name: 'titleDesc',

--- a/apps/web/src/lib/sanity/queries/pages/home.ts
+++ b/apps/web/src/lib/sanity/queries/pages/home.ts
@@ -204,9 +204,9 @@ export async function getContactPersonsSection() {
 					contactPersons[]-> {
 						firstName,
 						lastName,
-						email,
 						phone,
 						image,
+						"email": affiliations[department->title == 'Vorstand'][0].role->email,
 						"role": affiliations[department->title == 'Vorstand'][0].role->title,
 						"vision": affiliations[department->title == 'Vorstand'][0].description,
 					}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added an email field to the role document schema, applicable for board positions.
	- Enhanced the contact persons section to dynamically fetch email and role based on department criteria.

- **Bug Fixes**
	- Improved data retrieval logic for contact persons, ensuring accurate email and role information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->