### PR TITLE
feat(studio): add season to training selection

### DIFF
--- a/apps/studio/schemas/objects/training-time.ts
+++ b/apps/studio/schemas/objects/training-time.ts
@@ -1,3 +1,5 @@
+/* cSpell:words monday tuesday wednesday thursday friday saturday sunday */
+
 import { RiLinksLine } from 'react-icons/ri';
 import { defineField } from 'sanity';
 
@@ -11,11 +13,33 @@ const trainingTimeField = defineField({
 	icon: RiLinksLine,
 	fields: [
 		defineField({
+			title: 'Jahreszeit',
+			name: 'season',
+			type: 'string',
+			options: {
+				list: [
+					{ title: 'Ganzjährig', value: 'yearly' },
+					{ title: 'Sommer', value: 'summer' },
+					{ title: 'Winter', value: 'winter' },
+				],
+			},
+			validation: Rule => [Rule.required().error('Jahreszeit ist erforderlich')],
+		}),
+
+		defineField({
 			title: 'Wochentag',
 			name: 'weekday',
 			type: 'string',
 			options: {
-				list: ['Montag', 'Dienstag', 'Mittwoch', 'Donnerstag', 'Freitag', 'Samstag', 'Sonntag'],
+				list: [
+					{ title: 'Montag', value: 'monday' },
+					{ title: 'Dienstag', value: 'tuesday' },
+					{ title: 'Mittwoch', value: 'wednesday' },
+					{ title: 'Donnerstag', value: 'thursday' },
+					{ title: 'Freitag', value: 'friday' },
+					{ title: 'Samstag', value: 'saturday' },
+					{ title: 'Sonntag', value: 'sunday' },
+				],
 			},
 			validation: Rule => [Rule.required().error('Wochentag ist erforderlich')],
 		}),
@@ -51,12 +75,13 @@ const trainingTimeField = defineField({
 		}),
 	],
 	preview: {
-		prepare: ({ weekday, endTime, location, startTime }) => ({
-			title: `${weekday}, ${startTime} - ${endTime} | ${location}`,
+		prepare: ({ weekday, endTime, location, startTime, season }) => ({
+			title: `${season} | ${weekday}, ${startTime} - ${endTime} | ${location}`,
 		}),
 		select: {
 			endTime: 'endTime',
 			location: 'location.title',
+			season: 'season',
 			startTime: 'startTime',
 			weekday: 'weekday',
 		},


### PR DESCRIPTION
Resolves #154


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a `season` field to training time schema with options for yearly, summer, and winter
  - Enhanced weekday field with more structured data representation

- **Improvements**
  - Updated preview and selection logic to incorporate the new season field
  - Improved data schema with more detailed weekday information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->