### PR TITLE
fix(web): set bg images of hero to `object-fit: cover;`

### DIFF
--- a/apps/web/src/components/section/hero.tsx
+++ b/apps/web/src/components/section/hero.tsx
@@ -22,7 +22,12 @@ export default function Hero({ children, image, subTitle, title, ...props }: Rea
 			{...props}
 		>
 			{image?.alt && image.src && (
-				<Image alt={image.alt} className="absolute inset-0 -z-10" src={image.src} fill />
+				<Image
+					alt={image.alt}
+					className="absolute inset-0 -z-10 object-cover"
+					src={image.src}
+					fill
+				/>
 			)}
 
 			<div className="flex h-full flex-col items-center justify-center pt-40">


### PR DESCRIPTION
Fixes #153


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated image styling in the Hero component to ensure the image covers its container while maintaining aspect ratio.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->