### PR TITLE
feat(studio,web): rename testimonial field

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -21,11 +21,14 @@ jobs:
           node-version: 22
           cache: pnpm
 
+      - name: Install NI
+        run: pnpm install -g @antfu/ni
+
       - name: Install Dependencies
-        run: pnpm install --frozen-lockfile
+        run: nci
 
       - name: Build and Lint files
-        run: pnpm run build lint
+        run: nlx turbo build lint
         env:
           NEXT_PUBLIC_SANITY_DATASET: ${{ secrets.SANITY_DATASET }}
           NEXT_PUBLIC_SANITY_PROJECT_ID: ${{ secrets.SANITY_PROJECT_ID }}

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
+
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@master
         env:

--- a/apps/studio/schema.json
+++ b/apps/studio/schema.json
@@ -4483,7 +4483,7 @@
         },
         "optional": false
       },
-      "showAlways": {
+      "show": {
         "type": "objectAttribute",
         "value": {
           "type": "boolean"

--- a/apps/studio/schemas/documents/testimonial.ts
+++ b/apps/studio/schemas/documents/testimonial.ts
@@ -40,10 +40,10 @@ const testimonial = defineType({
 			],
 		}),
 		defineField({
-			title: 'Zitat immer anzeigen',
-			name: 'showAlways',
+			title: 'Zitat anzeigen',
+			name: 'show',
 			type: 'boolean',
-			description: 'Das Zitat soll immer angezeigt werden.',
+			description: 'Das Zitat soll aktuell angezeigt werden.',
 			group: 'quote',
 			initialValue: false,
 		}),

--- a/apps/web/src/lib/sanity/queries/pages/home.ts
+++ b/apps/web/src/lib/sanity/queries/pages/home.ts
@@ -30,7 +30,7 @@ export const homePageTestimonialsQuery = defineQuery(`
 		image,
 		quote,
 		role,
-		showAlways,
+		show,
 	}
 `);
 

--- a/apps/web/src/types/sanity.types.generated.ts
+++ b/apps/web/src/types/sanity.types.generated.ts
@@ -780,7 +780,7 @@ export type Testimonial = {
 	};
 	role: string;
 	quote: string;
-	showAlways?: boolean;
+	show?: boolean;
 };
 
 export type HonoraryMember = {
@@ -1537,7 +1537,7 @@ export type HomePageGroupsQueryResult = Array<{
 		| 'Yoga';
 }>;
 // Variable: homePageTestimonialsQuery
-// Query: *[_type == 'home'][0].content.testimonialSection.testimonials[0..2]-> {		firstName,		lastName,		image,		quote,		role,		showAlways,	}
+// Query: *[_type == 'home'][0].content.testimonialSection.testimonials[0..2]-> {		firstName,		lastName,		image,		quote,		role,		show,	}
 export type HomePageTestimonialsQueryResult = Array<{
 	firstName: string;
 	lastName: string;
@@ -1556,7 +1556,7 @@ export type HomePageTestimonialsQueryResult = Array<{
 	};
 	quote: string;
 	role: string;
-	showAlways: boolean | null;
+	show: boolean | null;
 }> | null;
 // Variable: homePageContactPersonsQuery
 // Query: *[_type == 'home'][0].content.contactPersonsSection.contactPersons[]-> {			firstName,	lastName,	phone,	image,	"email": affiliations[department->title == $department][0].role->email,	"role": affiliations[department->title == $department][0].role->title,	"vision": affiliations[department->title == $department][0].taskDescription,	}
@@ -1907,7 +1907,7 @@ declare module '@sanity/client' {
 		'\n\t*[_type == \'contact\'][0].content.contactPersonsSection.contactPersons[]-> {\n\t\t\n\tfirstName,\n\tlastName,\n\tphone,\n\timage,\n\t"email": affiliations[department->title == $department][0].role->email,\n\t"role": affiliations[department->title == $department][0].role->title,\n\t"vision": affiliations[department->title == $department][0].taskDescription,\n\n\t}\n': ContactPageContactPersonsQueryResult;
 		"\n\t*[_type == 'home'][0] {\n\t\t...,\n\t\tcontent {\n\t\t\t...,\n\t\t\tcontactPersonsSection {\n\t\t\t\tintro,\n\t\t\t\tsubtitle,\n\t\t\t\ttitle,\n\t\t\t}\n\t\t}\n\t}\n": HomePageQueryResult;
 		"\n\t*[_type == 'group'][] {\n\t\ttitle,\n\t\ticon,\n\t}\n": HomePageGroupsQueryResult;
-		"\n\t*[_type == 'home'][0].content.testimonialSection.testimonials[0..2]-> {\n\t\tfirstName,\n\t\tlastName,\n\t\timage,\n\t\tquote,\n\t\trole,\n\t\tshowAlways,\n\t}\n": HomePageTestimonialsQueryResult;
+		"\n\t*[_type == 'home'][0].content.testimonialSection.testimonials[0..2]-> {\n\t\tfirstName,\n\t\tlastName,\n\t\timage,\n\t\tquote,\n\t\trole,\n\t\tshow,\n\t}\n": HomePageTestimonialsQueryResult;
 		'\n\t*[_type == \'home\'][0].content.contactPersonsSection.contactPersons[]-> {\n\t\t\n\tfirstName,\n\tlastName,\n\tphone,\n\timage,\n\t"email": affiliations[department->title == $department][0].role->email,\n\t"role": affiliations[department->title == $department][0].role->title,\n\t"vision": affiliations[department->title == $department][0].taskDescription,\n\n\t}\n': HomePageContactPersonsQueryResult;
 		"\n\t*[_type == 'news-article-page'][0] {\n\t\ttitle,\n\t\tsubtitle,\n\t}\n": NewsArticleHeroQueryResult;
 		'\n\t*[_type == \'news.article\' && slug.current == $slug][0] {\n\t\tauthor -> {\n\t\t\temail,\n\t\t\tfirstName,\n\t\t\timage,\n\t\t\tlastName,\n\t\t\tjobTitle,\n\t\t},\n\t\tbody[],\n\t\tcategories[] -> {\n\t\t\t"slug": slug.current,\n\t\t\ttitle\n\t\t},\n\t\tfeaturedImage,\n\t\tpublishedAt,\n\t\t"slug": slug.current,\n\t\ttitle,\n\t}\n': NewsArticleContentQueryResult;

--- a/package.json
+++ b/package.json
@@ -40,6 +40,6 @@
 	},
 	"packageManager": "pnpm@9.15.4",
 	"engines": {
-		"node": "22.13.0"
+		"node": "22.13.1"
 	}
 }


### PR DESCRIPTION
closes #162


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **CI/CD Updates**
  - Added SonarCloud scan to GitHub Actions workflow
  - Updated GitHub Actions workflow to use new dependency installation method

- **Schema Changes**
  - Renamed `showAlways` field to `show` in testimonial document type
  - Updated field description and title for testimonial display

- **Type Updates**
  - Adjusted type definitions to reflect testimonial field renaming

- **Node.js**
  - Updated Node.js version to 22.13.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->