### PR TITLE
feat(studio): add `sortOrder` to person schematype

### DIFF
--- a/apps/studio/schemas/documents/person.ts
+++ b/apps/studio/schemas/documents/person.ts
@@ -134,6 +134,14 @@ const person = defineType({
 								),
 							],
 						}),
+
+						defineField({
+							description:
+								'Die optionale Sortierreihenfolge kann für die Ansprechpartner-Sortierung notwendig sein. Im Zweifel einfach leer lassen.',
+							name: 'sortOrder',
+							title: 'Sortierreihenfolge',
+							type: 'number',
+						}),
 					],
 					preview: {
 						prepare: ({ team, role }) => ({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional numeric field “Sortierreihenfolge” to affiliations within Person entries, enabling editors to set a custom display order.
  * The field supports empty values and appears after the task description in the affiliation section. Leaving it blank preserves existing behavior.
  * Provides finer control over how affiliations are ordered in listings and presentations without affecting existing data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->