### PR TITLE
feat(studio,web): make training optional for referees

### DIFF
--- a/apps/studio/schema.json
+++ b/apps/studio/schema.json
@@ -5272,7 +5272,7 @@
             }
           }
         },
-        "optional": false
+        "optional": true
       },
       "isSportGroup": {
         "type": "objectAttribute",
@@ -5656,7 +5656,7 @@
             }
           }
         },
-        "optional": false
+        "optional": true
       },
       "isSportGroup": {
         "type": "objectAttribute",
@@ -6040,7 +6040,7 @@
             }
           }
         },
-        "optional": false
+        "optional": true
       },
       "isSportGroup": {
         "type": "objectAttribute",
@@ -6424,7 +6424,7 @@
             }
           }
         },
-        "optional": false
+        "optional": true
       },
       "isSportGroup": {
         "type": "objectAttribute",
@@ -6808,7 +6808,7 @@
             }
           }
         },
-        "optional": false
+        "optional": true
       },
       "isSportGroup": {
         "type": "objectAttribute",
@@ -7192,7 +7192,7 @@
             }
           }
         },
-        "optional": false
+        "optional": true
       },
       "isSportGroup": {
         "type": "objectAttribute",

--- a/apps/studio/utils/documents/group.tsx
+++ b/apps/studio/utils/documents/group.tsx
@@ -136,10 +136,20 @@ export function getGroupDocument({ icon, isSportGroup = true, name, title }: Gro
 						type: 'array',
 					}),
 				],
-				hidden: !isSportGroup,
-				validation: isSportGroup
-					? Rule => [Rule.required().error('Trainingszeiten und -orte sind erforderlich')]
-					: undefined,
+				hidden: ({ document }) =>
+					(document?.title as string)?.toLowerCase() === 'schiedsrichter' || !isSportGroup,
+				validation: Rule => [
+					Rule.custom((value, context) => {
+						if (
+							isSportGroup &&
+							(context.document?.title as string)?.toLowerCase() !== 'schiedsrichter' &&
+							!value
+						) {
+							return 'Trainingszeiten und -orte sind erforderlich';
+						}
+						return true;
+					}),
+				],
 			}),
 
 			defineField({
@@ -152,6 +162,7 @@ export function getGroupDocument({ icon, isSportGroup = true, name, title }: Gro
 				validation: Rule => [Rule.required().error('"Ist Sportgruppe" ist erforderlich')],
 			}),
 		],
+
 		preview: {
 			prepare: ({ sortOrder, title }) => ({
 				subtitle: `Sortierreihenfolge: ${sortOrder}`,
@@ -162,6 +173,7 @@ export function getGroupDocument({ icon, isSportGroup = true, name, title }: Gro
 				title: 'title',
 			},
 		},
+
 		orderings: [
 			{
 				by: [{ direction: 'asc', field: 'title' }],

--- a/apps/web/src/app/angebot/[group]/[singleGroup]/page.tsx
+++ b/apps/web/src/app/angebot/[group]/[singleGroup]/page.tsx
@@ -83,7 +83,9 @@ export default async function SingleGroupsPage({
 				gallery={groupData.images ?? []}
 				title={groupData.title ?? ''}
 			/>
-			<Training title={page.content.trainingSection.title ?? ''} training={groupData.training} />
+			{groupData.training && (
+				<Training title={page.content.trainingSection.title ?? ''} training={groupData.training} />
+			)}
 			<ContactPersons {...page.content.contactPersonsSection} contactPersons={coaches} />
 			<Newsletter />
 		</>

--- a/apps/web/src/types/sanity.types.generated.ts
+++ b/apps/web/src/types/sanity.types.generated.ts
@@ -920,7 +920,7 @@ export type GroupTaekwondo = {
 		_type: 'extendedImage';
 		_key: string;
 	}>;
-	training: {
+	training?: {
 		trainingDescription?: SimpleBlockContent;
 		trainingTimes?: Array<
 			{
@@ -990,7 +990,7 @@ export type GroupSoccer = {
 		_type: 'extendedImage';
 		_key: string;
 	}>;
-	training: {
+	training?: {
 		trainingDescription?: SimpleBlockContent;
 		trainingTimes?: Array<
 			{
@@ -1060,7 +1060,7 @@ export type GroupOtherSports = {
 		_type: 'extendedImage';
 		_key: string;
 	}>;
-	training: {
+	training?: {
 		trainingDescription?: SimpleBlockContent;
 		trainingTimes?: Array<
 			{
@@ -1130,7 +1130,7 @@ export type GroupDance = {
 		_type: 'extendedImage';
 		_key: string;
 	}>;
-	training: {
+	training?: {
 		trainingDescription?: SimpleBlockContent;
 		trainingTimes?: Array<
 			{
@@ -1200,7 +1200,7 @@ export type GroupCourses = {
 		_type: 'extendedImage';
 		_key: string;
 	}>;
-	training: {
+	training?: {
 		trainingDescription?: SimpleBlockContent;
 		trainingTimes?: Array<
 			{
@@ -1270,7 +1270,7 @@ export type GroupChildrenGymnastics = {
 		_type: 'extendedImage';
 		_key: string;
 	}>;
-	training: {
+	training?: {
 		trainingDescription?: SimpleBlockContent;
 		trainingTimes?: Array<
 			{
@@ -2450,96 +2450,6 @@ export type OfferGroupsGroupPageGroupsQueryResult =
 			images: null;
 			title: string;
 			training: null;
-	  }
-	| {
-			description: SimpleBlockContent;
-			featuredImage: {
-				asset?: {
-					_ref: string;
-					_type: 'reference';
-					_weak?: boolean;
-					[internalGroqTypeReferenceTo]?: 'sanity.imageAsset';
-				};
-				media?: unknown;
-				hotspot?: SanityImageHotspot;
-				crop?: SanityImageCrop;
-				alt: string;
-				description?: string;
-				_type: 'extendedImage';
-			};
-			images: Array<{
-				asset?: {
-					_ref: string;
-					_type: 'reference';
-					_weak?: boolean;
-					[internalGroqTypeReferenceTo]?: 'sanity.imageAsset';
-				};
-				media?: unknown;
-				hotspot?: SanityImageHotspot;
-				crop?: SanityImageCrop;
-				alt: string;
-				description?: string;
-				_type: 'extendedImage';
-				_key: string;
-			}> | null;
-			title: string;
-			training: {
-				trainingDescription: SimpleBlockContent | null;
-				trainingTimes: Array<{
-					_key: string;
-					_type: 'trainingTime';
-					season: 'summer' | 'winter' | 'yearly';
-					weekday:
-						| 'friday'
-						| 'monday'
-						| 'saturday'
-						| 'sunday'
-						| 'thursday'
-						| 'tuesday'
-						| 'wednesday';
-					startTime: string;
-					endTime: string;
-					venue: {
-						_id: string;
-						_type: 'venue';
-						_createdAt: string;
-						_updatedAt: string;
-						_rev: string;
-						title: string;
-						description: SimpleBlockContent;
-						type:
-							| 'artificial-turf'
-							| 'cinder'
-							| 'grass'
-							| 'hall-1'
-							| 'hall-2'
-							| 'hall-3'
-							| 'hybrid';
-						mainImage?: {
-							asset?: {
-								_ref: string;
-								_type: 'reference';
-								_weak?: boolean;
-								[internalGroqTypeReferenceTo]?: 'sanity.imageAsset';
-							};
-							media?: unknown;
-							hotspot?: SanityImageHotspot;
-							crop?: SanityImageCrop;
-							alt: string;
-							description?: string;
-							_type: 'image';
-						};
-						location?: {
-							name: string;
-							street: string;
-							houseNumber: string;
-							zipCode?: string;
-							city: string;
-						};
-					};
-					note?: string;
-				}> | null;
-			};
 	  }
 	| {
 			description: SimpleBlockContent;


### PR DESCRIPTION
## Summary

This PR makes the training field optional for groups that don't require training information, specifically the "Schiedsrichter" (referee) group.

## Changes

- **Studio Schema**: Updated validation logic to make training field optional based on group title
- **Studio UI**: Added conditional hiding and validation for training field when group is "Schiedsrichter"
- **Web App**: Added conditional rendering of Training component when training data is present
- **Types**: Regenerated Sanity types to reflect optional training field

## Motivation

The referee group doesn't have traditional training times and locations like other sport groups. Making this field optional provides a better content editing experience and prevents validation errors for groups where training information is not applicable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Training times and locations are now optional for groups, enabling flexible content creation and management without mandatory training data.
  * Certain group types, including Referee groups, can now be created and managed successfully without training information requirements.
  * Training information displays conditionally based on availability, improving the experience for all group types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->