### PR TITLE
feat(web,studio): randomize testimonials

### DIFF
--- a/apps/studio/schema.json
+++ b/apps/studio/schema.json
@@ -4491,13 +4491,6 @@
           "type": "string"
         },
         "optional": false
-      },
-      "show": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "boolean"
-        },
-        "optional": true
       }
     }
   },

--- a/apps/studio/schemas/documents/testimonial.ts
+++ b/apps/studio/schemas/documents/testimonial.ts
@@ -39,14 +39,6 @@ const testimonial = defineType({
 				Rule.max(350).warning('Das Zitat sollte nicht länger als 350 Zeichen sein'),
 			],
 		}),
-		defineField({
-			title: 'Zitat anzeigen',
-			name: 'show',
-			type: 'boolean',
-			description: 'Das Zitat soll aktuell angezeigt werden.',
-			group: 'quote',
-			initialValue: false,
-		}),
 	],
 	preview: {
 		prepare: ({ media, firstName, lastName, role }) => ({

--- a/apps/web/src/app/_home/testimonial-group.tsx
+++ b/apps/web/src/app/_home/testimonial-group.tsx
@@ -5,7 +5,6 @@ import { Quote } from 'lucide-react';
 import Image from 'next/image';
 import type { HTMLAttributes } from 'react';
 
-import { ArrowButtonGroup } from '@/components/ui/arrow-button';
 import { useMediaQuery } from '@/hooks/use-media-query';
 import { urlForImage } from '@/lib/sanity/utils';
 import type { HomePageTestimonialsQueryResult } from '@/types/sanity.types';
@@ -112,11 +111,9 @@ export function TestimonialGroup({ testimonials }: Readonly<TestimonialGroupProp
 		<div>
 			<div className="bg-primary-border-primary-foreground mt-10 ml-6 rounded-xl shadow-xl md:mt-0 md:ml-0 md:py-16 md:pr-28 md:pl-12">
 				{testimonials.map((props, index) => (
-					<TestimonialItem {...props} isHighlighted={index === 1} key={props.lastName} />
+					<TestimonialItem {...props} isHighlighted={index === 1} key={props._id} />
 				))}
 			</div>
-
-			<ArrowButtonGroup className="mt-10 md:mt-24" />
 		</div>
 	);
 }

--- a/apps/web/src/app/_home/testimonials.tsx
+++ b/apps/web/src/app/_home/testimonials.tsx
@@ -1,3 +1,5 @@
+import { shuffleArray } from '@tsgi-web/shared';
+
 import { SectionHeader } from '@/components/ui/section-header';
 import type { Home, HomePageTestimonialsQueryResult } from '@/types/sanity.types';
 
@@ -11,11 +13,13 @@ interface TestimonialsProps extends TestimonialsSectionProps {
 }
 
 export function Testimonials({ subtitle, testimonials, title }: Readonly<TestimonialsProps>) {
+	const shuffledTestimonials = testimonials ? shuffleArray(testimonials).slice(0, 3) : [];
+
 	return (
 		<section className={`${styles.bg} bg-background-low-contrast relative z-0`}>
 			<div className="container mx-auto px-5 py-10 md:grid md:grid-cols-[40%_60%] md:py-32">
 				<SectionHeader isCenteredOnDesktop={false} subTitle={subtitle} title={title} isCentered />
-				<TestimonialGroup testimonials={testimonials ?? []} />
+				<TestimonialGroup testimonials={shuffledTestimonials} />
 			</div>
 		</section>
 	);

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -16,6 +16,8 @@ import { Hero } from './_home/hero';
 import { News } from './_home/news';
 import { Testimonials } from './_home/testimonials';
 
+const TESTIMONIALS_REVALIDATE_SECONDS = 60 * 60 * 12; /* 12 hours */
+
 export const metadata: Metadata = {
 	description:
 		'Die TSG Irlich bietet für jedermann, der sich gerne bewegt und mit Menschen zusammen ist, etwas. In 18 verschiedenen Sparten findest du alles, was du benötigst.',
@@ -25,7 +27,11 @@ export const metadata: Metadata = {
 export default async function HomePage() {
 	const [page, testimonials, newsArticles] = await Promise.all([
 		client.fetch(homePageQuery),
-		client.fetch(homePageTestimonialsQuery),
+		client.fetch(
+			homePageTestimonialsQuery,
+			{},
+			{ next: { revalidate: TESTIMONIALS_REVALIDATE_SECONDS } },
+		),
 		client.fetch(newsArticlesQuery),
 	]);
 

--- a/apps/web/src/lib/sanity/queries/pages/home.ts
+++ b/apps/web/src/lib/sanity/queries/pages/home.ts
@@ -28,12 +28,12 @@ export const homePageQuery = defineQuery(`
  * @returns The testimonials for the home page
  */
 export const homePageTestimonialsQuery = defineQuery(`
-	*[_type == 'home'][0].content.testimonialSection.testimonials[0..2]-> {
+	*[_type == 'home'][0].content.testimonialSection.testimonials[]-> {
+		_id,
 		firstName,
 		lastName,
 		image,
 		quote,
 		role,
-		show,
 	}
 `);

--- a/apps/web/src/types/sanity.types.generated.ts
+++ b/apps/web/src/types/sanity.types.generated.ts
@@ -777,7 +777,6 @@ export type Testimonial = {
 	image: ExtendedImage;
 	role: string;
 	quote: string;
-	show?: boolean;
 };
 
 export type HonoraryMember = {
@@ -1813,14 +1812,14 @@ export type HomePageQueryResult = {
 	};
 } | null;
 // Variable: homePageTestimonialsQuery
-// Query: *[_type == 'home'][0].content.testimonialSection.testimonials[0..2]-> {		firstName,		lastName,		image,		quote,		role,		show,	}
+// Query: *[_type == 'home'][0].content.testimonialSection.testimonials[]-> {		_id,		firstName,		lastName,		image,		quote,		role,	}
 export type HomePageTestimonialsQueryResult = Array<{
+	_id: string;
 	firstName: string;
 	lastName: string;
 	image: ExtendedImage;
 	quote: string;
 	role: string;
-	show: boolean | null;
 }> | null;
 
 // Source: ./src/lib/sanity/queries/pages/imprint.ts
@@ -2498,7 +2497,7 @@ declare module '@sanity/client' {
 		'\n\t*[_type == \'aboutUs\'][0] {\n\t\t...,\n\t\tcontent {\n\t\t\t...,\n\t\t\tcontactPersonsSection {\n\t\t\t\t...,\n\t\t\t\tcontactPersons[]-> {\n\t\t\t\t\t\n  firstName,\n  lastName,\n  phone,\n  image,\n  contactAs,\n  "email": affiliations[0].role->email,\n  "role": affiliations[0].role->title,\n  "taskDescription": affiliations[0].taskDescription,\n\n\t\t\t\t}\n\t\t\t}\n\t\t}\n\t}\n': AboutUsPageQueryResult;
 		'\n\t*[_type == \'contact\'][0] {\n\t\t...,\n\t\tcontent {\n\t\t\t...,\n\t\t\tcontactPersonsSection {\n\t\t\t\t...,\n\t\t\t\tcontactPersons[]-> {\n\t\t\t\t\t\n  firstName,\n  lastName,\n  phone,\n  image,\n  contactAs,\n  "email": affiliations[0].role->email,\n  "role": affiliations[0].role->title,\n  "taskDescription": affiliations[0].taskDescription,\n\n\t\t\t\t}\n\t\t\t}\n\t\t}\n\t}\n': ContactPageQueryResult;
 		'\n\t*[_type == \'home\'][0] {\n\t\t...,\n\t\tcontent {\n\t\t\t...,\n\t\t\tcontactPersonsSection {\n\t\t\t\t...,\n\t\t\t\tcontactPersons[]-> {\n\t\t\t\t\t\n  firstName,\n  lastName,\n  phone,\n  image,\n  contactAs,\n  "email": affiliations[0].role->email,\n  "role": affiliations[0].role->title,\n  "taskDescription": affiliations[0].taskDescription,\n\n\t\t\t\t}\n\t\t\t}\n\t\t}\n\t}\n': HomePageQueryResult;
-		"\n\t*[_type == 'home'][0].content.testimonialSection.testimonials[0..2]-> {\n\t\tfirstName,\n\t\tlastName,\n\t\timage,\n\t\tquote,\n\t\trole,\n\t\tshow,\n\t}\n": HomePageTestimonialsQueryResult;
+		"\n\t*[_type == 'home'][0].content.testimonialSection.testimonials[]-> {\n\t\t_id,\n\t\tfirstName,\n\t\tlastName,\n\t\timage,\n\t\tquote,\n\t\trole,\n\t}\n": HomePageTestimonialsQueryResult;
 		'\n\t*[_type == \'imprint\'][0] {\n\t\t...,\n\t\t"contactForm": contactForm {\n\t\t\ttitle,\n\t\t\t"slug": link->slug.current\n\t\t}\n\t}\n': ImprintPageQueryResult;
 		'\n\t{\n\t\t"membership": *[_type == \'membership\'][0] {\n\t\t\t...,\n\t\t\tdownloadsSection {\n\t\t\t\t...,\n\t\t\t\tdownloads[] {\n\t\t\t\t\t...,\n\t\t\t\t\tdocument {\n\t\t\t\t\t\t...,\n\t\t\t\t\t\tasset->\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t},\n\t\t\tcontactPersonsSection {\n\t\t\t\t...,\n\t\t\t\tcontactPersons[]-> {\n\t\t\t\t\t\n  firstName,\n  lastName,\n  phone,\n  image,\n  contactAs,\n  "email": affiliations[0].role->email,\n  "role": affiliations[0].role->title,\n  "taskDescription": affiliations[0].taskDescription,\n\n\t\t\t\t}\n\t\t\t}\n\t\t},\n\t\t"pricingSection": *[_type == \'home\'][0].content.pricingSection\n\t}\n': MembershipPageQueryResult;
 		"\n\t*[_type == 'news-article-page'][0] {\n\t\ttitle,\n\t\tsubtitle,\n\t}\n": NewsArticleHeroQueryResult;

--- a/packages/shared/src/utils/array.ts
+++ b/packages/shared/src/utils/array.ts
@@ -1,0 +1,14 @@
+/**
+ * Shuffles an array using the Fisher-Yates shuffle algorithm.
+ *
+ * @param array - The array to shuffle.
+ * @returns The shuffled array.
+ */
+export function shuffleArray<T>(array: T[]): T[] {
+	const shuffled = [...array];
+	for (let i = shuffled.length - 1; i > 0; i--) {
+		const index = Math.floor(Math.random() * (i + 1));
+		[shuffled[i], shuffled[index]] = [shuffled[index], shuffled[i]];
+	}
+	return shuffled;
+}

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -1,1 +1,2 @@
+export * from './array';
 export * from './cn';


### PR DESCRIPTION
## Summary

Randomize the display of testimonials on the homepage instead of showing a fixed selection.

## Changes

- Remove the `show` field from testimonial schema (no longer needed for manual selection)
- Fetch all testimonials from Sanity instead of a fixed subset
- Shuffle testimonials randomly and display 3 on each page load
- Add `shuffleArray` utility function to the shared package
- Add 12-hour revalidation period for testimonials query
- Remove `ArrowButtonGroup` component (manual navigation no longer needed)
- Use `_id` as React key instead of `lastName` for uniqueness

## Motivation

Previously, testimonials were manually selected via a `show` flag in the CMS. This required editors to manually toggle which testimonials to display. The new approach automatically rotates through all available testimonials, providing variety for visitors while reducing editorial overhead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Testimonials are now randomly selected and shuffled, displaying a diverse subset each time visitors view the page.

* **Chores**
  * Removed an unused field from testimonial configuration.
  * Enhanced caching strategy for improved testimonial data loading performance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->