### PR TITLE
feat(web,studio): add meta & OG support

### DIFF
--- a/apps/studio/schema.json
+++ b/apps/studio/schema.json
@@ -244,14 +244,6 @@
         },
         "optional": false
       },
-      "meta": {
-        "type": "objectAttribute",
-        "value": {
-          "type": "inline",
-          "name": "metaFields"
-        },
-        "optional": true
-      },
       "content": {
         "type": "objectAttribute",
         "value": {
@@ -3338,7 +3330,7 @@
         "value": {
           "type": "string"
         },
-        "optional": true
+        "optional": false
       },
       "logo": {
         "type": "objectAttribute",
@@ -3385,7 +3377,7 @@
             }
           }
         },
-        "optional": true
+        "optional": false
       }
     }
   },
@@ -3802,6 +3794,14 @@
           "name": "slug"
         },
         "optional": false
+      },
+      "meta": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "inline",
+          "name": "metaFields"
+        },
+        "optional": true
       }
     }
   },
@@ -4647,6 +4647,14 @@
         },
         "optional": false
       },
+      "meta": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "inline",
+          "name": "metaFields"
+        },
+        "optional": true
+      },
       "overviewTitle": {
         "type": "objectAttribute",
         "value": {
@@ -4880,6 +4888,14 @@
           "type": "string"
         },
         "optional": false
+      },
+      "meta": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "inline",
+          "name": "metaFields"
+        },
+        "optional": true
       },
       "overviewTitle": {
         "type": "objectAttribute",
@@ -5115,6 +5131,14 @@
         },
         "optional": false
       },
+      "meta": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "inline",
+          "name": "metaFields"
+        },
+        "optional": true
+      },
       "overviewTitle": {
         "type": "objectAttribute",
         "value": {
@@ -5348,6 +5372,14 @@
           "type": "string"
         },
         "optional": false
+      },
+      "meta": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "inline",
+          "name": "metaFields"
+        },
+        "optional": true
       },
       "overviewTitle": {
         "type": "objectAttribute",
@@ -5583,6 +5615,14 @@
         },
         "optional": false
       },
+      "meta": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "inline",
+          "name": "metaFields"
+        },
+        "optional": true
+      },
       "overviewTitle": {
         "type": "objectAttribute",
         "value": {
@@ -5817,6 +5857,14 @@
         },
         "optional": false
       },
+      "meta": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "inline",
+          "name": "metaFields"
+        },
+        "optional": true
+      },
       "overviewTitle": {
         "type": "objectAttribute",
         "value": {
@@ -6050,6 +6098,14 @@
           "type": "string"
         },
         "optional": false
+      },
+      "meta": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "inline",
+          "name": "metaFields"
+        },
+        "optional": true
       },
       "overviewTitle": {
         "type": "objectAttribute",

--- a/apps/studio/schemas/documents/news.category.ts
+++ b/apps/studio/schemas/documents/news.category.ts
@@ -1,19 +1,23 @@
 import { RiBookletLine } from 'react-icons/ri';
 import { defineType } from 'sanity';
 
-import { general } from '@/shared/field-groups';
+import { general, meta } from '@/shared/field-groups';
 import { slugField, titleField } from '@/shared/fields/general';
+import { metaField } from '@/shared/fields/meta';
 
 const newsCategory = defineType({
 	title: 'News-Kategorie',
 	name: 'news.category',
 	type: 'document',
 	icon: RiBookletLine,
-	groups: [general],
+	groups: [general, meta],
 	fields: [
 		// general
 		titleField,
 		slugField,
+
+		// meta
+		metaField,
 	],
 	preview: {
 		prepare: ({ title }) => ({ title }),

--- a/apps/studio/schemas/single-pages/news-overview-category.ts
+++ b/apps/studio/schemas/single-pages/news-overview-category.ts
@@ -1,9 +1,8 @@
 import { RiBookletLine, RiLinksLine } from 'react-icons/ri';
 import { defineField, defineType } from 'sanity';
 
-import { content, general, meta } from '@/shared/field-groups';
+import { content, general } from '@/shared/field-groups';
 import { defaultHeroFields } from '@/shared/fields/general';
-import { metaField } from '@/shared/fields/meta';
 import { contactPersonsSectionField } from '@/shared/sections/contact-persons';
 
 const newsOverviewCategory = defineType({
@@ -11,15 +10,12 @@ const newsOverviewCategory = defineType({
 	name: 'newsOverviewCategory',
 	type: 'document',
 	icon: RiBookletLine,
-	groups: [general, meta, content],
+	groups: [general, content],
 	fields: [
 		// ?: the "slug" comes from the news category itself; this page is rather the layout
 
 		// general
 		...defaultHeroFields,
-
-		// meta
-		metaField,
 
 		// content
 		defineField({

--- a/apps/studio/utils/documents/group.tsx
+++ b/apps/studio/utils/documents/group.tsx
@@ -4,6 +4,7 @@ import { defineField, defineType } from 'sanity';
 
 import { emailField } from '@/shared/fields/contact';
 import { slugField } from '@/shared/fields/general';
+import { metaField } from '@/shared/fields/meta';
 
 import { getFieldWithoutGroup } from '../fields';
 
@@ -44,6 +45,8 @@ export function getGroupDocument({ icon, isSportGroup = true, name, title }: Gro
 			getFieldWithoutGroup(slugField),
 
 			getFieldWithoutGroup(emailField),
+
+			getFieldWithoutGroup(metaField),
 
 			defineField({
 				description: 'Optional, Fallback: Name. Wird für die Gruppen-Übersicht verwendet.',

--- a/apps/web/src/actions/send-contact-form.ts
+++ b/apps/web/src/actions/send-contact-form.ts
@@ -1,19 +1,11 @@
 'use server';
 
-import process from 'node:process';
-
 import { ContactForwardEmail } from '@tsgi-web/email';
 
 import { actionClient } from '@/lib/actions/safe-action';
 import { resend } from '@/lib/resend';
 import { contactFormSchema } from '@/lib/validations/contact-form';
-
-let baseUrl = 'http://localhost:3000';
-if (process.env.VERCEL_PROJECT_PRODUCTION_URL) {
-	baseUrl = `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`;
-} else if (process.env.NODE_ENV === 'production') {
-	baseUrl = 'https://next.tsg-irlich.de';
-}
+import { getBaseUrl } from '@/utils/url';
 
 export const sendContactForm = actionClient
 	.inputSchema(contactFormSchema)
@@ -24,7 +16,7 @@ export const sendContactForm = actionClient
 			bcc: ['it@tsg-irlich.de'],
 			from: 'TSG Irlich - Benachrichtigungen <webseite@notifications.tsg-irlich.de>',
 			react: ContactForwardEmail({
-				baseUrl,
+				baseUrl: getBaseUrl(),
 				contactEmail: email,
 				contactMessage: message,
 				contactName: name,

--- a/apps/web/src/app/(legal)/datenschutz/page.tsx
+++ b/apps/web/src/app/(legal)/datenschutz/page.tsx
@@ -1,5 +1,7 @@
 import { cn } from '@tsgi-web/shared';
+import type { Metadata } from 'next';
 
+import { getOpenGraphImageOptions } from '@/app/news/_shared/utils';
 import { Hero } from '@/components/section/hero';
 import { PortableText, type PortableTextValue } from '@/components/ui/portable-text';
 import { client } from '@/lib/sanity/client';
@@ -7,6 +9,23 @@ import { privacyPageQuery } from '@/lib/sanity/queries/pages/privacy';
 
 import { textClassName } from '../_shared/class-names';
 import heroImage from '../_shared/hero.webp';
+
+export async function generateMetadata(): Promise<Metadata> {
+	const page = await client.fetch(privacyPageQuery);
+
+	if (!page) return {};
+
+	const description = page.meta?.metaDescription ?? '';
+	const image = page.meta?.openGraphImage;
+	const images = image ? getOpenGraphImageOptions(image, page.title) : [];
+	const title = page.meta?.metaTitle ?? page.title ?? '';
+
+	return {
+		description,
+		openGraph: { description, images, title },
+		title,
+	};
+}
 
 export default async function PrivacyPage() {
 	const page = await client.fetch(privacyPageQuery);

--- a/apps/web/src/app/(legal)/impressum/page.tsx
+++ b/apps/web/src/app/(legal)/impressum/page.tsx
@@ -1,6 +1,8 @@
 import { cn } from '@tsgi-web/shared';
+import type { Metadata } from 'next';
 import Link from 'next/link';
 
+import { getOpenGraphImageOptions } from '@/app/news/_shared/utils';
 import { Hero } from '@/components/section/hero';
 import { PortableText, type PortableTextValue } from '@/components/ui/portable-text';
 import { ContactLink } from '@/components/with-logic/contact-link';
@@ -9,6 +11,23 @@ import { imprintPageQuery } from '@/lib/sanity/queries/pages/imprint';
 
 import { textClassName } from '../_shared/class-names';
 import heroImage from '../_shared/hero.webp';
+
+export async function generateMetadata(): Promise<Metadata> {
+	const page = await client.fetch(imprintPageQuery);
+
+	if (!page) return {};
+
+	const description = page.meta?.metaDescription ?? '';
+	const image = page.meta?.openGraphImage;
+	const images = image ? getOpenGraphImageOptions(image, page.title) : [];
+	const title = page.meta?.metaTitle ?? page.title ?? '';
+
+	return {
+		description,
+		openGraph: { description, images, title },
+		title,
+	};
+}
 
 export default async function ImprintPage() {
 	const page = await client.fetch(imprintPageQuery);

--- a/apps/web/src/app/angebot/[group]/page.tsx
+++ b/apps/web/src/app/angebot/[group]/page.tsx
@@ -30,13 +30,13 @@ export async function generateMetadata({
 	const image = getOGImage(groupParameter);
 
 	return {
-		description: page.subtitle ?? '',
+		description: page.meta?.metaDescription ?? '',
 		openGraph: {
-			description: page.subtitle ?? '',
+			description: page.meta?.metaDescription ?? '',
 			images: image ?? [],
-			title: `${currentDepartment?.title ?? ''} — TSG Irlich`,
+			title: `${currentDepartment?.title ?? ''} bei der TSG Irlich`,
 		},
-		title: `${currentDepartment?.title ?? ''} — TSG Irlich`,
+		title: `${currentDepartment?.title ?? ''} bei der TSG Irlich`,
 	};
 }
 

--- a/apps/web/src/app/angebot/page.tsx
+++ b/apps/web/src/app/angebot/page.tsx
@@ -7,8 +7,8 @@ import { Stats } from '@/components/section/stats';
 import heroImage from '@/images/angebot/hero.webp';
 import { client } from '@/lib/sanity/client';
 import { offerPageQuery } from '@/lib/sanity/queries/pages/offer';
-import { getOGImage } from '@/utils/groups';
 
+import { getOpenGraphImageOptions } from '../news/_shared/utils';
 import { Groups } from './_sections/groups';
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -16,17 +16,14 @@ export async function generateMetadata(): Promise<Metadata> {
 
 	if (!page) return {};
 
-	const { intro, title } = page.content.departmentsSection;
-
-	const image = getOGImage('FALLBACK');
+	const description = page.meta?.metaDescription ?? '';
+	const image = page.meta?.openGraphImage;
+	const images = image ? getOpenGraphImageOptions(image, page.title) : [];
+	const title = page.meta?.metaTitle ?? page.title ?? '';
 
 	return {
-		description: intro ?? '',
-		openGraph: {
-			description: intro ?? '',
-			images: image ?? [],
-			title,
-		},
+		description,
+		openGraph: { description, images, title },
 		title,
 	};
 }

--- a/apps/web/src/app/kontakt/page.tsx
+++ b/apps/web/src/app/kontakt/page.tsx
@@ -8,11 +8,24 @@ import contactImage from '@/images/kontakt/hero.webp';
 import { client } from '@/lib/sanity/client';
 import { contactPageQuery } from '@/lib/sanity/queries/pages/contact';
 
-export const metadata: Metadata = {
-	description:
-		'Die TSG Irlich bietet für jedermann, der sich gerne bewegt und mit Menschen zusammen ist, etwas. In 18 verschiedenen Sparten findest du alles, was du benötigst.',
-	title: 'TSG Irlich — deine Turn- und Sportgemeinde in Neuwied / Irlich',
-};
+import { getOpenGraphImageOptions } from '../news/_shared/utils';
+
+export async function generateMetadata(): Promise<Metadata> {
+	const page = await client.fetch(contactPageQuery);
+
+	if (!page) return {};
+
+	const description = page.meta?.metaDescription ?? '';
+	const image = page.meta?.openGraphImage;
+	const images = image ? getOpenGraphImageOptions(image, page.title) : [];
+	const title = page.meta?.metaTitle ?? page.title ?? '';
+
+	return {
+		description,
+		openGraph: { description, images, title },
+		title,
+	};
+}
 
 export default async function ContactPage() {
 	const page = await client.fetch(contactPageQuery);

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,5 +1,3 @@
-import process from 'node:process';
-
 import { cn } from '@tsgi-web/shared';
 import { Analytics } from '@vercel/analytics/next';
 import type { Metadata } from 'next';
@@ -9,6 +7,7 @@ import Footer from '@/components/layout/footer';
 import { Navigation } from '@/components/with-logic/navigation';
 import { client } from '@/lib/sanity/client';
 import { mainNavigationQuery } from '@/lib/sanity/queries/main-navigation';
+import { getBaseUrl } from '@/utils/url';
 
 import './globals.css';
 
@@ -35,16 +34,9 @@ const inter = Inter({
 
 const NAVIGATION_REVALIDATE_SECONDS = 60 * 60 * 12; /* 12 hours */
 
-let baseUrl = 'http://localhost:3000';
-if (process.env.VERCEL_PROJECT_PRODUCTION_URL) {
-	baseUrl = `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`;
-} else if (process.env.NODE_ENV === 'production') {
-	baseUrl = 'https://next.tsg-irlich.de';
-}
-
 export const metadata: Metadata = {
 	/* eslint-disable perfectionist/sort-objects */
-	metadataBase: new URL(baseUrl),
+	metadataBase: new URL(getBaseUrl()),
 	title: 'TSG Irlich — deine Turn- und Sportgemeinde in Neuwied / Irlich',
 	description:
 		'Die TSG Irlich bietet für jedermann, der sich gerne bewegt und mit Menschen zusammen ist, etwas. In 18 verschiedenen Sparten findest du alles, was du benötigst.',

--- a/apps/web/src/app/mitgliedschaft/page.tsx
+++ b/apps/web/src/app/mitgliedschaft/page.tsx
@@ -8,14 +8,26 @@ import heroImage from '@/images/mitgliedschaft/hero.webp';
 import { client } from '@/lib/sanity/client';
 import { membershipPageQuery } from '@/lib/sanity/queries/pages/membership';
 
+import { getOpenGraphImageOptions } from '../news/_shared/utils';
 import { Downloads } from './_sections/downloads';
 import { Intro } from './_sections/intro';
 
-export const metadata: Metadata = {
-	description:
-		'Die TSG Irlich bietet für jedermann, der sich gerne bewegt und mit Menschen zusammen ist, etwas. In 18 verschiedenen Sparten findest du alles, was du benötigst.',
-	title: 'TSG Irlich — deine Turn- und Sportgemeinde in Neuwied / Irlich',
-};
+export async function generateMetadata(): Promise<Metadata> {
+	const page = await client.fetch(membershipPageQuery);
+
+	if (!page.membership) return {};
+
+	const description = page.membership.meta?.metaDescription ?? '';
+	const image = page.membership.meta?.openGraphImage;
+	const images = image ? getOpenGraphImageOptions(image, page.membership.title) : [];
+	const title = page.membership.meta?.metaTitle ?? page.membership.title ?? '';
+
+	return {
+		description,
+		openGraph: { description, images, title },
+		title,
+	};
+}
 
 export default async function ContactPage() {
 	const page = await client.fetch(membershipPageQuery);

--- a/apps/web/src/app/news/[category]/[slug]/page.tsx
+++ b/apps/web/src/app/news/[category]/[slug]/page.tsx
@@ -14,6 +14,7 @@ import { socialMediaQuery } from '@/lib/sanity/queries/shared/social-media';
 import { sponsorsQuery } from '@/lib/sanity/queries/shared/sponsors';
 import { urlForImage } from '@/lib/sanity/utils';
 
+import { getOpenGraphImageOptions } from '../../_shared/utils';
 import { Author } from './_sections/author';
 import { Categories } from './_sections/categories';
 import { SocialMedia } from './_sections/social-media';
@@ -28,23 +29,15 @@ export async function generateMetadata({
 
 	if (!article) return {};
 
+	const description = article.meta?.metaDescription ?? article.excerpt ?? '';
+	const image = article.meta?.openGraphImage ?? article.featuredImage;
+	const images = image ? getOpenGraphImageOptions(image, article.title) : [];
+	const title = article.meta?.metaTitle ?? article.title ?? '';
+
 	return {
-		description: article.excerpt ?? '',
-		openGraph: {
-			description: article.excerpt ?? '',
-			images: article.featuredImage
-				? [
-						{
-							alt: article.featuredImage.alt ?? article.title,
-							height: 630,
-							url: urlForImage(article.featuredImage, 630, 1200) ?? '',
-							width: 1200,
-						},
-					]
-				: [],
-			title: article.title ?? '',
-		},
-		title: article.title ?? '',
+		description,
+		openGraph: { description, images, title },
+		title,
 	};
 }
 

--- a/apps/web/src/app/news/_shared/utils.ts
+++ b/apps/web/src/app/news/_shared/utils.ts
@@ -1,0 +1,18 @@
+import type { Metadata } from 'next';
+
+import { urlForImage } from '@/lib/sanity/utils';
+import type { AnyImage } from '@/types/image.types';
+
+type OpenGraph = Metadata['openGraph'];
+type OGImage = NonNullable<OpenGraph>['images'];
+
+export function getOpenGraphImageOptions(image?: AnyImage, title?: string): OGImage {
+	if (!image) return;
+
+	return {
+		alt: image.alt ?? title ?? '',
+		height: 630,
+		url: urlForImage(image, 630, 1200) ?? '',
+		width: 1200,
+	};
+}

--- a/apps/web/src/app/news/page.tsx
+++ b/apps/web/src/app/news/page.tsx
@@ -1,3 +1,5 @@
+import type { Metadata } from 'next';
+
 import { ContactPersons } from '@/components/section/contact-persons';
 import { Hero } from '@/components/section/hero';
 import { Newsletter } from '@/components/section/newsletter';
@@ -13,9 +15,27 @@ import {
 import newsOverviewImage from './_assets/news-overview.webp';
 import { LatestNews } from './_sections/latest-news';
 import { LatestNewsPagination } from './_sections/latest-news-pagination';
+import { getOpenGraphImageOptions } from './_shared/utils';
 
 const START_INDEX = 3;
 const ITEMS_PER_PAGE = 6;
+
+export async function generateMetadata(): Promise<Metadata> {
+	const page = await client.fetch(newsOverviewPageQuery);
+
+	if (!page) return {};
+
+	const description = page.meta?.metaDescription ?? '';
+	const image = page.meta?.openGraphImage;
+	const images = image ? getOpenGraphImageOptions(image, page.title) : [];
+	const title = page.meta?.metaTitle ?? page.title ?? '';
+
+	return {
+		description,
+		openGraph: { description, images, title },
+		title,
+	};
+}
 
 export default async function NewsOverviewPage({ searchParams }: Readonly<PageProps<'/news'>>) {
 	const { seite } = await searchParams;

--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -1,11 +1,13 @@
-import Link from 'next/link';
-
 export default function NotFound() {
 	return (
-		<div>
-			<h2>Not Found</h2>
-			<p>Could not find requested resource</p>
-			<Link href="/">Return Home</Link>
+		<div className="flex h-screen flex-col items-center justify-center">
+			<h2 className="text-2xl font-bold md:text-5xl">Falscher Link? Falsche Adresse?</h2>
+			<p className="pt-4 text-lg md:pt-8 md:text-2xl">
+				Die angeforderte Seite konnte nicht gefunden werden.
+			</p>
+			<p className="pt-2 text-lg md:text-2xl">
+				Nutze die Navigation oben, um zur gewünschten Seite zu gelangen.
+			</p>
 		</div>
 	);
 }

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -19,14 +19,26 @@ import { Hero } from './_home/hero';
 import { News } from './_home/news';
 import { Sponsors } from './_home/sponsors';
 import { Testimonials } from './_home/testimonials';
+import { getOpenGraphImageOptions } from './news/_shared/utils';
 
 const TESTIMONIALS_REVALIDATE_SECONDS = 60 * 60 * 12; /* 12 hours */
 
-export const metadata: Metadata = {
-	description:
-		'Die TSG Irlich bietet für jedermann, der sich gerne bewegt und mit Menschen zusammen ist, etwas. In 18 verschiedenen Sparten findest du alles, was du benötigst.',
-	title: 'TSG Irlich — deine Turn- und Sportgemeinde in Neuwied / Irlich',
-};
+export async function generateMetadata(): Promise<Metadata> {
+	const page = await client.fetch(homePageQuery);
+
+	if (!page) return {};
+
+	const description = page.meta?.metaDescription ?? '';
+	const image = page.meta?.openGraphImage;
+	const images = image ? getOpenGraphImageOptions(image, page.title) : [];
+	const title = page.meta?.metaTitle ?? page.title ?? '';
+
+	return {
+		description,
+		openGraph: { description, images, title },
+		title,
+	};
+}
 
 export default async function HomePage() {
 	const [page, testimonials, newsArticles, socialMedia, sponsors] = await Promise.all([

--- a/apps/web/src/app/verein/page.tsx
+++ b/apps/web/src/app/verein/page.tsx
@@ -9,14 +9,26 @@ import heroImage from '@/images/verein/hero.webp';
 import { client } from '@/lib/sanity/client';
 import { aboutUsPageQuery } from '@/lib/sanity/queries/pages/about-us';
 
+import { getOpenGraphImageOptions } from '../news/_shared/utils';
 import { Chronicle } from './_sections/chronicle';
 import { Intro } from './_sections/intro';
 
-export const metadata: Metadata = {
-	description:
-		'Die TSG Irlich bietet für jedermann, der sich gerne bewegt und mit Menschen zusammen ist, etwas. In 18 verschiedenen Sparten findest du alles, was du benötigst.',
-	title: 'Über uns — TSG Irlich',
-};
+export async function generateMetadata(): Promise<Metadata> {
+	const page = await client.fetch(aboutUsPageQuery);
+
+	if (!page) return {};
+
+	const description = page.meta?.metaDescription ?? '';
+	const image = page.meta?.openGraphImage;
+	const images = image ? getOpenGraphImageOptions(image, page.title) : [];
+	const title = page.meta?.metaTitle ?? page.title ?? '';
+
+	return {
+		description,
+		openGraph: { description, images, title },
+		title,
+	};
+}
 
 export default async function VereinPage() {
 	const page = await client.fetch(aboutUsPageQuery);

--- a/apps/web/src/components/layout/footer.tsx
+++ b/apps/web/src/components/layout/footer.tsx
@@ -41,7 +41,7 @@ export default async function Footer() {
 			<div className="container pt-16 pb-4 md:pt-40">
 				<div className="md:flex md:justify-between">
 					<section className="flex flex-col items-center gap-5">
-						<Link href="/">
+						<Link href="/" title="Zur Startseite wechseln">
 							<TSGLogo className="h-32 w-auto" />
 						</Link>
 

--- a/apps/web/src/lib/sanity/queries/index.ts
+++ b/apps/web/src/lib/sanity/queries/index.ts
@@ -9,4 +9,6 @@ export const contactPersons = /* groq */ `
   "taskDescription": affiliations[0].taskDescription,
 `;
 
+export const meta = /* groq */ `meta { metaTitle, metaDescription, openGraphImage}`;
+
 export const featuredImage = /* groq */ `featuredImage`;

--- a/apps/web/src/lib/sanity/queries/pages/news-article.ts
+++ b/apps/web/src/lib/sanity/queries/pages/news-article.ts
@@ -1,6 +1,6 @@
 import { defineQuery } from 'next-sanity';
 
-import { featuredImage } from '@/lib/sanity/queries';
+import { featuredImage, meta } from '@/lib/sanity/queries';
 
 /**
  * Query to get the news article hero
@@ -36,6 +36,7 @@ export const newsArticleContentQuery = defineQuery(`
 		},
 		excerpt,
 		${featuredImage},
+		${meta},
 		publishedAt,
 		"slug": slug.current,
 		title,

--- a/apps/web/src/lib/sanity/queries/pages/offer-groups-group.ts
+++ b/apps/web/src/lib/sanity/queries/pages/offer-groups-group.ts
@@ -1,6 +1,6 @@
 import { defineQuery } from 'next-sanity';
 
-import { featuredImage } from '@/lib/sanity/queries';
+import { featuredImage, meta } from '@/lib/sanity/queries';
 
 /**
  * Query to get the groups page
@@ -21,6 +21,7 @@ export const offerGroupsGroupPageGroupsQuery = defineQuery(`
 		description,
 		${featuredImage},
 		images,
+		${meta},
 		title,
 		training {
 			trainingDescription,

--- a/apps/web/src/lib/sanity/queries/shared/news.ts
+++ b/apps/web/src/lib/sanity/queries/shared/news.ts
@@ -1,6 +1,6 @@
 import { defineQuery } from 'next-sanity';
 
-import { featuredImage } from '@/lib/sanity/queries';
+import { featuredImage, meta } from '@/lib/sanity/queries';
 
 export const newsArticle = /* groq */ `
 	_id,
@@ -8,6 +8,7 @@ export const newsArticle = /* groq */ `
 	author->{ firstName, lastName, image },
 	categories[]->{ title, "slug": slug.current },
 	excerpt,
+	meta { metaTitle, metaDescription, openGraphImage},
 	${featuredImage},
 	"slug": slug.current,
 	title,
@@ -32,6 +33,7 @@ export const newsArticlesTotalQuery = defineQuery(`count(*[_type == "news.articl
 export const newsCategoryQuery = defineQuery(`
 	*[_type == 'news.category' && slug.current == $slug][0] {
 		"slug": slug.current,
-		title
+		title,
+		${meta}
 	}
 `);

--- a/apps/web/src/types/image.types.ts
+++ b/apps/web/src/types/image.types.ts
@@ -1,0 +1,37 @@
+import type {
+	internalGroqTypeReferenceTo,
+	SanityImageAssetReference,
+	SanityImageCrop,
+	SanityImageHotspot,
+} from './sanity.types.generated';
+
+export interface SanityImage {
+	_type: 'image';
+	alt?: string;
+	asset?: SanityImageAssetReference;
+	crop?: SanityImageCrop;
+	hotspot?: SanityImageHotspot;
+	media?: unknown;
+}
+
+export interface SanityImageReference {
+	asset?: {
+		_ref: string;
+		_type: 'reference';
+		_weak?: boolean;
+		[internalGroqTypeReferenceTo]?: 'sanity.imageAsset';
+	};
+	alt: string;
+	crop?: SanityImageCrop;
+	hotspot?: SanityImageHotspot;
+}
+
+export interface ExtendedImage extends SanityImageReference {
+	_type: 'extendedImage';
+}
+
+export interface MainImage extends SanityImageReference {
+	_type: 'mainImage';
+}
+
+export type AnyImage = ExtendedImage | MainImage | SanityImage;

--- a/apps/web/src/types/sanity.types.generated.ts
+++ b/apps/web/src/types/sanity.types.generated.ts
@@ -60,7 +60,6 @@ export type NewsOverviewCategory = {
 	_rev: string;
 	title: string;
 	subtitle: string;
-	meta?: MetaFields;
 	content: {
 		contactPersonsSection: ContactPersonsSection;
 	};
@@ -607,8 +606,8 @@ export type Sponsors = {
 	_updatedAt: string;
 	_rev: string;
 	name: string;
-	website?: string;
-	logo?: {
+	website: string;
+	logo: {
 		asset?: SanityImageAssetReference;
 		media?: unknown;
 		hotspot?: SanityImageHotspot;
@@ -690,6 +689,7 @@ export type NewsCategory = {
 	_rev: string;
 	title: string;
 	slug: Slug;
+	meta?: MetaFields;
 };
 
 export type NewsCategoryReference = {
@@ -848,6 +848,7 @@ export type GroupTaekwondo = {
 	title: string;
 	slug: Slug;
 	email: string;
+	meta?: MetaFields;
 	overviewTitle?: string;
 	sortOrder: number;
 	description: SimpleBlockContent;
@@ -895,6 +896,7 @@ export type GroupSoccer = {
 	title: string;
 	slug: Slug;
 	email: string;
+	meta?: MetaFields;
 	overviewTitle?: string;
 	sortOrder: number;
 	description: SimpleBlockContent;
@@ -942,6 +944,7 @@ export type GroupOtherSports = {
 	title: string;
 	slug: Slug;
 	email: string;
+	meta?: MetaFields;
 	overviewTitle?: string;
 	sortOrder: number;
 	description: SimpleBlockContent;
@@ -989,6 +992,7 @@ export type GroupDance = {
 	title: string;
 	slug: Slug;
 	email: string;
+	meta?: MetaFields;
 	overviewTitle?: string;
 	sortOrder: number;
 	description: SimpleBlockContent;
@@ -1036,6 +1040,7 @@ export type GroupCourses = {
 	title: string;
 	slug: Slug;
 	email: string;
+	meta?: MetaFields;
 	overviewTitle?: string;
 	sortOrder: number;
 	description: SimpleBlockContent;
@@ -1083,6 +1088,7 @@ export type GroupChildrenGymnastics = {
 	title: string;
 	slug: Slug;
 	email: string;
+	meta?: MetaFields;
 	overviewTitle?: string;
 	sortOrder: number;
 	description: SimpleBlockContent;
@@ -1130,6 +1136,7 @@ export type GroupAdmin = {
 	title: string;
 	slug: Slug;
 	email: string;
+	meta?: MetaFields;
 	overviewTitle?: string;
 	sortOrder: number;
 	description: SimpleBlockContent;
@@ -2018,7 +2025,7 @@ export type NewsArticleHeroQueryResult = {
 
 // Source: src/lib/sanity/queries/pages/news-article.ts
 // Variable: newsArticleContentQuery
-// Query: *[_type == 'news.article' && slug.current == $slug][0] {		author -> {			email,			firstName,			image,			lastName,			jobTitle,		},		body[],		categories[] -> {			"slug": slug.current,			title		},		excerpt,		featuredImage,		publishedAt,		"slug": slug.current,		title,	}
+// Query: *[_type == 'news.article' && slug.current == $slug][0] {		author -> {			email,			firstName,			image,			lastName,			jobTitle,		},		body[],		categories[] -> {			"slug": slug.current,			title		},		excerpt,		featuredImage,		meta { metaTitle, metaDescription, openGraphImage},		publishedAt,		"slug": slug.current,		title,	}
 export type NewsArticleContentQueryResult = {
 	author: {
 		email: string;
@@ -2050,6 +2057,18 @@ export type NewsArticleContentQueryResult = {
 	}>;
 	excerpt: string;
 	featuredImage: MainImage;
+	meta: {
+		metaTitle: string | null;
+		metaDescription: string | null;
+		openGraphImage: {
+			asset?: SanityImageAssetReference;
+			media?: unknown;
+			hotspot?: SanityImageHotspot;
+			crop?: SanityImageCrop;
+			alt?: string;
+			_type: 'image';
+		} | null;
+	} | null;
 	publishedAt: string;
 	slug: string;
 	title: string;
@@ -2066,7 +2085,6 @@ export type NewsOverviewCategoryPageQueryResult = {
 	_rev: string;
 	title: string;
 	subtitle: string;
-	meta?: MetaFields;
 	content: {
 		contactPersonsSection: {
 			title: string;
@@ -2088,7 +2106,7 @@ export type NewsOverviewCategoryPageQueryResult = {
 
 // Source: src/lib/sanity/queries/pages/news-overview-category.ts
 // Variable: newsArticlesPaginatedForCategoryQuery
-// Query: *[_type == 'news.article' && $category in categories[]->slug.current]	| order(publishedAt desc) [$start..$end] {			_id,	publishedAt,	author->{ firstName, lastName, image },	categories[]->{ title, "slug": slug.current },	excerpt,	featuredImage,	"slug": slug.current,	title,	}
+// Query: *[_type == 'news.article' && $category in categories[]->slug.current]	| order(publishedAt desc) [$start..$end] {			_id,	publishedAt,	author->{ firstName, lastName, image },	categories[]->{ title, "slug": slug.current },	excerpt,	meta { metaTitle, metaDescription, openGraphImage},	featuredImage,	"slug": slug.current,	title,	}
 export type NewsArticlesPaginatedForCategoryQueryResult = Array<{
 	_id: string;
 	publishedAt: string;
@@ -2102,6 +2120,18 @@ export type NewsArticlesPaginatedForCategoryQueryResult = Array<{
 		slug: string;
 	}>;
 	excerpt: string;
+	meta: {
+		metaTitle: string | null;
+		metaDescription: string | null;
+		openGraphImage: {
+			asset?: SanityImageAssetReference;
+			media?: unknown;
+			hotspot?: SanityImageHotspot;
+			crop?: SanityImageCrop;
+			alt?: string;
+			_type: 'image';
+		} | null;
+	} | null;
 	featuredImage: MainImage;
 	slug: string;
 	title: string;
@@ -2170,7 +2200,7 @@ export type OfferGroupsGroupPageQueryResult = {
 
 // Source: src/lib/sanity/queries/pages/offer-groups-group.ts
 // Variable: offerGroupsGroupPageGroupsQuery
-// Query: *[_type == $groupType && slug.current == $slug][0] {		description,		featuredImage,		images,		title,		training {			trainingDescription,			trainingTimes[] {				...,				venue->			}		}	}
+// Query: *[_type == $groupType && slug.current == $slug][0] {		description,		featuredImage,		images,		meta { metaTitle, metaDescription, openGraphImage},		title,		training {			trainingDescription,			trainingTimes[] {				...,				venue->			}		}	}
 export type OfferGroupsGroupPageGroupsQueryResult =
 	| {
 			description: SimpleBlockContent;
@@ -2180,6 +2210,18 @@ export type OfferGroupsGroupPageGroupsQueryResult =
 					_key: string;
 				} & ExtendedImage
 			> | null;
+			meta: {
+				metaTitle: string | null;
+				metaDescription: string | null;
+				openGraphImage: {
+					asset?: SanityImageAssetReference;
+					media?: unknown;
+					hotspot?: SanityImageHotspot;
+					crop?: SanityImageCrop;
+					alt?: string;
+					_type: 'image';
+				} | null;
+			} | null;
 			title: string;
 			training: {
 				trainingDescription: SimpleBlockContent | null;
@@ -2238,6 +2280,7 @@ export type OfferGroupsGroupPageGroupsQueryResult =
 			description: SimpleBlockContent;
 			featuredImage: null;
 			images: null;
+			meta: null;
 			title: string;
 			training: null;
 	  }
@@ -2245,6 +2288,18 @@ export type OfferGroupsGroupPageGroupsQueryResult =
 			description: null;
 			featuredImage: MainImage;
 			images: null;
+			meta: {
+				metaTitle: string | null;
+				metaDescription: string | null;
+				openGraphImage: {
+					asset?: SanityImageAssetReference;
+					media?: unknown;
+					hotspot?: SanityImageHotspot;
+					crop?: SanityImageCrop;
+					alt?: string;
+					_type: 'image';
+				} | null;
+			} | null;
 			title: string;
 			training: null;
 	  }
@@ -2252,6 +2307,7 @@ export type OfferGroupsGroupPageGroupsQueryResult =
 			description: null;
 			featuredImage: null;
 			images: null;
+			meta: null;
 			title: null;
 			training: null;
 	  }
@@ -2259,6 +2315,7 @@ export type OfferGroupsGroupPageGroupsQueryResult =
 			description: null;
 			featuredImage: null;
 			images: null;
+			meta: null;
 			title: string;
 			training: null;
 	  }
@@ -2266,13 +2323,53 @@ export type OfferGroupsGroupPageGroupsQueryResult =
 			description: null;
 			featuredImage: null;
 			images: null;
+			meta: null;
 			title: string | null;
+			training: null;
+	  }
+	| {
+			description: null;
+			featuredImage: null;
+			images: null;
+			meta: {
+				metaTitle: string | null;
+				metaDescription: string | null;
+				openGraphImage: {
+					asset?: SanityImageAssetReference;
+					media?: unknown;
+					hotspot?: SanityImageHotspot;
+					crop?: SanityImageCrop;
+					alt?: string;
+					_type: 'image';
+				} | null;
+			} | null;
+			title: null;
+			training: null;
+	  }
+	| {
+			description: null;
+			featuredImage: null;
+			images: null;
+			meta: {
+				metaTitle: string | null;
+				metaDescription: string | null;
+				openGraphImage: {
+					asset?: SanityImageAssetReference;
+					media?: unknown;
+					hotspot?: SanityImageHotspot;
+					crop?: SanityImageCrop;
+					alt?: string;
+					_type: 'image';
+				} | null;
+			} | null;
+			title: string;
 			training: null;
 	  }
 	| {
 			description: string | null;
 			featuredImage: null;
 			images: null;
+			meta: null;
 			title: string | null;
 			training: null;
 	  }
@@ -2501,7 +2598,7 @@ export type GroupsQueryResult = Array<{
 
 // Source: src/lib/sanity/queries/shared/news.ts
 // Variable: newsArticlesQuery
-// Query: *[_type == 'news.article'] | order(publishedAt desc) [0..2] {			_id,	publishedAt,	author->{ firstName, lastName, image },	categories[]->{ title, "slug": slug.current },	excerpt,	featuredImage,	"slug": slug.current,	title,	}
+// Query: *[_type == 'news.article'] | order(publishedAt desc) [0..2] {			_id,	publishedAt,	author->{ firstName, lastName, image },	categories[]->{ title, "slug": slug.current },	excerpt,	meta { metaTitle, metaDescription, openGraphImage},	featuredImage,	"slug": slug.current,	title,	}
 export type NewsArticlesQueryResult = Array<{
 	_id: string;
 	publishedAt: string;
@@ -2515,6 +2612,18 @@ export type NewsArticlesQueryResult = Array<{
 		slug: string;
 	}>;
 	excerpt: string;
+	meta: {
+		metaTitle: string | null;
+		metaDescription: string | null;
+		openGraphImage: {
+			asset?: SanityImageAssetReference;
+			media?: unknown;
+			hotspot?: SanityImageHotspot;
+			crop?: SanityImageCrop;
+			alt?: string;
+			_type: 'image';
+		} | null;
+	} | null;
 	featuredImage: MainImage;
 	slug: string;
 	title: string;
@@ -2522,7 +2631,7 @@ export type NewsArticlesQueryResult = Array<{
 
 // Source: src/lib/sanity/queries/shared/news.ts
 // Variable: newsArticlesPaginatedQuery
-// Query: *[_type == 'news.article'] | order(publishedAt desc) [$start..$end] { // $start = 3, $end = 8			_id,	publishedAt,	author->{ firstName, lastName, image },	categories[]->{ title, "slug": slug.current },	excerpt,	featuredImage,	"slug": slug.current,	title,	}
+// Query: *[_type == 'news.article'] | order(publishedAt desc) [$start..$end] { // $start = 3, $end = 8			_id,	publishedAt,	author->{ firstName, lastName, image },	categories[]->{ title, "slug": slug.current },	excerpt,	meta { metaTitle, metaDescription, openGraphImage},	featuredImage,	"slug": slug.current,	title,	}
 export type NewsArticlesPaginatedQueryResult = Array<{
 	_id: string;
 	publishedAt: string;
@@ -2536,6 +2645,18 @@ export type NewsArticlesPaginatedQueryResult = Array<{
 		slug: string;
 	}>;
 	excerpt: string;
+	meta: {
+		metaTitle: string | null;
+		metaDescription: string | null;
+		openGraphImage: {
+			asset?: SanityImageAssetReference;
+			media?: unknown;
+			hotspot?: SanityImageHotspot;
+			crop?: SanityImageCrop;
+			alt?: string;
+			_type: 'image';
+		} | null;
+	} | null;
 	featuredImage: MainImage;
 	slug: string;
 	title: string;
@@ -2548,10 +2669,22 @@ export type NewsArticlesTotalQueryResult = number;
 
 // Source: src/lib/sanity/queries/shared/news.ts
 // Variable: newsCategoryQuery
-// Query: *[_type == 'news.category' && slug.current == $slug][0] {		"slug": slug.current,		title	}
+// Query: *[_type == 'news.category' && slug.current == $slug][0] {		"slug": slug.current,		title,		meta { metaTitle, metaDescription, openGraphImage}	}
 export type NewsCategoryQueryResult = {
 	slug: string;
 	title: string;
+	meta: {
+		metaTitle: string | null;
+		metaDescription: string | null;
+		openGraphImage: {
+			asset?: SanityImageAssetReference;
+			media?: unknown;
+			hotspot?: SanityImageHotspot;
+			crop?: SanityImageCrop;
+			alt?: string;
+			_type: 'image';
+		} | null;
+	} | null;
 } | null;
 
 // Source: src/lib/sanity/queries/shared/social-media.ts
@@ -2561,7 +2694,7 @@ export type SocialMediaQueryResult = SocialFields | null;
 
 // Source: src/lib/sanity/queries/shared/sponsors.ts
 // Variable: sponsorsQuery
-// Query: *[_type== 'sponsors'][] {		_id,		name,		logo,	} | order(name asc)
+// Query: *[_type == 'sponsors'] {		_id,		name,		logo,	} | order(name asc)
 export type SponsorsQueryResult = Array<{
 	_id: string;
 	name: string;
@@ -2571,7 +2704,7 @@ export type SponsorsQueryResult = Array<{
 		hotspot?: SanityImageHotspot;
 		crop?: SanityImageCrop;
 		_type: 'image';
-	} | null;
+	};
 }>;
 
 // Query TypeMap
@@ -2586,13 +2719,13 @@ declare module '@sanity/client' {
 		'\n\t*[_type == \'imprint\'][0] {\n\t\t...,\n\t\t"contactForm": contactForm {\n\t\t\ttitle,\n\t\t\t"slug": link->slug.current\n\t\t}\n\t}\n': ImprintPageQueryResult;
 		'\n\t{\n\t\t"membership": *[_type == \'membership\'][0] {\n\t\t\t...,\n\t\t\tdownloadsSection {\n\t\t\t\t...,\n\t\t\t\tdownloads[] {\n\t\t\t\t\t...,\n\t\t\t\t\tdocument {\n\t\t\t\t\t\t...,\n\t\t\t\t\t\tasset->\n\t\t\t\t\t}\n\t\t\t\t}\n\t\t\t},\n\t\t\tcontactPersonsSection {\n\t\t\t\t...,\n\t\t\t\tcontactPersons[]-> {\n\t\t\t\t\t\n  firstName,\n  lastName,\n  phone,\n  image,\n  contactAs,\n  "email": affiliations[0].role->email,\n  "role": affiliations[0].role->title,\n  "taskDescription": affiliations[0].taskDescription,\n\n\t\t\t\t}\n\t\t\t}\n\t\t},\n\t\t"pricingSection": *[_type == \'home\'][0].content.pricingSection\n\t}\n': MembershipPageQueryResult;
 		"\n\t*[_type == 'news-article-page'][0] {\n\t\ttitle,\n\t\tsubtitle,\n\t}\n": NewsArticleHeroQueryResult;
-		'\n\t*[_type == \'news.article\' && slug.current == $slug][0] {\n\t\tauthor -> {\n\t\t\temail,\n\t\t\tfirstName,\n\t\t\timage,\n\t\t\tlastName,\n\t\t\tjobTitle,\n\t\t},\n\t\tbody[],\n\t\tcategories[] -> {\n\t\t\t"slug": slug.current,\n\t\t\ttitle\n\t\t},\n\t\texcerpt,\n\t\tfeaturedImage,\n\t\tpublishedAt,\n\t\t"slug": slug.current,\n\t\ttitle,\n\t}\n': NewsArticleContentQueryResult;
+		'\n\t*[_type == \'news.article\' && slug.current == $slug][0] {\n\t\tauthor -> {\n\t\t\temail,\n\t\t\tfirstName,\n\t\t\timage,\n\t\t\tlastName,\n\t\t\tjobTitle,\n\t\t},\n\t\tbody[],\n\t\tcategories[] -> {\n\t\t\t"slug": slug.current,\n\t\t\ttitle\n\t\t},\n\t\texcerpt,\n\t\tfeaturedImage,\n\t\tmeta { metaTitle, metaDescription, openGraphImage},\n\t\tpublishedAt,\n\t\t"slug": slug.current,\n\t\ttitle,\n\t}\n': NewsArticleContentQueryResult;
 		'\n\t*[_type == \'newsOverviewCategory\'][0] {\n\t\t...,\n\t\tcontent {\n\t\t\tcontactPersonsSection {\n\t\t\t\t...,\n\t\t\t\tcontactPersons[]-> {\n\t\t\t\t\t\n  firstName,\n  lastName,\n  phone,\n  image,\n  contactAs,\n  "email": affiliations[0].role->email,\n  "role": affiliations[0].role->title,\n  "taskDescription": affiliations[0].taskDescription,\n\n\t\t\t\t}\n\t\t\t}\n\t\t}\n\t}\n': NewsOverviewCategoryPageQueryResult;
-		'\n\t*[_type == \'news.article\' && $category in categories[]->slug.current]\n\t| order(publishedAt desc) [$start..$end] {\n\t\t\n\t_id,\n\tpublishedAt,\n\tauthor->{ firstName, lastName, image },\n\tcategories[]->{ title, "slug": slug.current },\n\texcerpt,\n\tfeaturedImage,\n\t"slug": slug.current,\n\ttitle,\n\n\t}\n': NewsArticlesPaginatedForCategoryQueryResult;
+		'\n\t*[_type == \'news.article\' && $category in categories[]->slug.current]\n\t| order(publishedAt desc) [$start..$end] {\n\t\t\n\t_id,\n\tpublishedAt,\n\tauthor->{ firstName, lastName, image },\n\tcategories[]->{ title, "slug": slug.current },\n\texcerpt,\n\tmeta { metaTitle, metaDescription, openGraphImage},\n\tfeaturedImage,\n\t"slug": slug.current,\n\ttitle,\n\n\t}\n': NewsArticlesPaginatedForCategoryQueryResult;
 		'\n\tcount(*[_type == "news.article" && $category in categories[]->slug.current])\n': NewsArticlesTotalForCategoryQueryResult;
 		'\n\t*[_type == \'newsOverview\'][0] {\n\t\t...,\n\t\tcontent {\n\t\t\tcontactPersonsSection {\n\t\t\t\t...,\n\t\t\t\tcontactPersons[]-> {\n\t\t\t\t\t\n  firstName,\n  lastName,\n  phone,\n  image,\n  contactAs,\n  "email": affiliations[0].role->email,\n  "role": affiliations[0].role->title,\n  "taskDescription": affiliations[0].taskDescription,\n\n\t\t\t\t}\n\t\t\t}\n\t\t}\n\t}\n': NewsOverviewPageQueryResult;
 		"*[_type == 'singleGroupPage'][0]": OfferGroupsGroupPageQueryResult;
-		'\n\t*[_type == $groupType && slug.current == $slug][0] {\n\t\tdescription,\n\t\tfeaturedImage,\n\t\timages,\n\t\ttitle,\n\t\ttraining {\n\t\t\ttrainingDescription,\n\t\t\ttrainingTimes[] {\n\t\t\t\t...,\n\t\t\t\tvenue->\n\t\t\t}\n\t\t}\n\t}\n': OfferGroupsGroupPageGroupsQueryResult;
+		'\n\t*[_type == $groupType && slug.current == $slug][0] {\n\t\tdescription,\n\t\tfeaturedImage,\n\t\timages,\n\t\tmeta { metaTitle, metaDescription, openGraphImage},\n\t\ttitle,\n\t\ttraining {\n\t\t\ttrainingDescription,\n\t\t\ttrainingTimes[] {\n\t\t\t\t...,\n\t\t\t\tvenue->\n\t\t\t}\n\t\t}\n\t}\n': OfferGroupsGroupPageGroupsQueryResult;
 		'\n\t*[\n\t\t_type == \'person\' &&\n\t\tdefined(affiliations[team->slug.current == $slug][0])\n\t]|order(lastName asc) {\n\t\t_id,\n\t\tfirstName,\n\t\tlastName,\n\t\tphone,\n\t\timage,\n\t\tcontactAs,\n\t\t"email": affiliations[team->slug.current == $slug][0].team->email,\n\t\t"role":  affiliations[team->slug.current == $slug][0].role->title,\n\t\t"team":  affiliations[team->slug.current == $slug][0].team->title,\n\t\t"taskDescription": affiliations[team->slug.current == $slug][0].taskDescription,\n\t}\n': OfferGroupsGroupPageContactPersonsQueryResult;
 		"*[_type == 'groupsPage'][0]": OfferGroupsPageQueryResult;
 		"\n\t*[_type == $groupType][] | order(sortOrder asc) {\n\t\ticon,\n\t\tfeaturedImage,\n\t\toverviewTitle,\n\t\t'slug': slug.current,\n\t\ttitle,\n\t}\n": OfferGroupsPageGroupsQueryResult;
@@ -2600,11 +2733,11 @@ declare module '@sanity/client' {
 		'\n*[_type == \'departmentsPage\'][0] {\n\t...,\n\tcontent {\n\t\t...,\n\t\tcontactPersonsSection {\n\t\t\t...,\n\t\t\tcontactPersons[]-> {\n\t\t\t\t\n  firstName,\n  lastName,\n  phone,\n  image,\n  contactAs,\n  "email": affiliations[0].role->email,\n  "role": affiliations[0].role->title,\n  "taskDescription": affiliations[0].taskDescription,\n\n\t\t\t}\n\t\t}\n\t}\n}\n': OfferPageQueryResult;
 		"*[_type == 'privacy'][0]": PrivacyPageQueryResult;
 		"\n\t*[_type in [\n\t\t'group.soccer',\n\t\t'group.children-gymnastics',\n\t\t'group.courses',\n\t\t'group.taekwondo',\n\t\t'group.dance',\n\t\t'group.other-sports',\n\t]] {\n\t\t_id,\n\t\ttitle,\n\t\ticon,\n\t}\n": GroupsQueryResult;
-		'\n\t*[_type == \'news.article\'] | order(publishedAt desc) [0..2] {\n\t\t\n\t_id,\n\tpublishedAt,\n\tauthor->{ firstName, lastName, image },\n\tcategories[]->{ title, "slug": slug.current },\n\texcerpt,\n\tfeaturedImage,\n\t"slug": slug.current,\n\ttitle,\n\n\t}\n': NewsArticlesQueryResult;
-		'\n\t*[_type == \'news.article\'] | order(publishedAt desc) [$start..$end] { // $start = 3, $end = 8\n\t\t\n\t_id,\n\tpublishedAt,\n\tauthor->{ firstName, lastName, image },\n\tcategories[]->{ title, "slug": slug.current },\n\texcerpt,\n\tfeaturedImage,\n\t"slug": slug.current,\n\ttitle,\n\n\t}\n': NewsArticlesPaginatedQueryResult;
+		'\n\t*[_type == \'news.article\'] | order(publishedAt desc) [0..2] {\n\t\t\n\t_id,\n\tpublishedAt,\n\tauthor->{ firstName, lastName, image },\n\tcategories[]->{ title, "slug": slug.current },\n\texcerpt,\n\tmeta { metaTitle, metaDescription, openGraphImage},\n\tfeaturedImage,\n\t"slug": slug.current,\n\ttitle,\n\n\t}\n': NewsArticlesQueryResult;
+		'\n\t*[_type == \'news.article\'] | order(publishedAt desc) [$start..$end] { // $start = 3, $end = 8\n\t\t\n\t_id,\n\tpublishedAt,\n\tauthor->{ firstName, lastName, image },\n\tcategories[]->{ title, "slug": slug.current },\n\texcerpt,\n\tmeta { metaTitle, metaDescription, openGraphImage},\n\tfeaturedImage,\n\t"slug": slug.current,\n\ttitle,\n\n\t}\n': NewsArticlesPaginatedQueryResult;
 		'count(*[_type == "news.article"])': NewsArticlesTotalQueryResult;
-		'\n\t*[_type == \'news.category\' && slug.current == $slug][0] {\n\t\t"slug": slug.current,\n\t\ttitle\n\t}\n': NewsCategoryQueryResult;
+		'\n\t*[_type == \'news.category\' && slug.current == $slug][0] {\n\t\t"slug": slug.current,\n\t\ttitle,\n\t\tmeta { metaTitle, metaDescription, openGraphImage}\n\t}\n': NewsCategoryQueryResult;
 		"*[_type == 'site-settings'][0].socialFields": SocialMediaQueryResult;
-		"\n\t*[_type== 'sponsors'][] {\n\t\t_id,\n\t\tname,\n\t\tlogo,\n\t} | order(name asc)\n": SponsorsQueryResult;
+		"\n\t*[_type == 'sponsors'] {\n\t\t_id,\n\t\tname,\n\t\tlogo,\n\t} | order(name asc)\n": SponsorsQueryResult;
 	}
 }

--- a/apps/web/src/types/sanity.types.ts
+++ b/apps/web/src/types/sanity.types.ts
@@ -1,15 +1,14 @@
-import type {
-	GroupDance,
-	HomePageQueryResult,
-	internalGroqTypeReferenceTo,
-	SanityImageAssetReference,
-	SanityImageCrop,
-	SanityImageHotspot,
-	Stats,
-} from './sanity.types.generated';
+import type { GroupDance, HomePageQueryResult, Stats } from './sanity.types.generated';
 
+export type {
+	AnyImage,
+	ExtendedImage,
+	MainImage,
+	SanityImage,
+	SanityImageReference,
+} from './image.types';
 export * from './sanity.types.generated';
-export * from './training-time';
+export type { TrainingTimeSection } from './training-time';
 
 export type ContactPerson =
 	NonNullable<HomePageQueryResult>['content']['contactPersonsSection']['contactPersons'][0];
@@ -20,32 +19,4 @@ export interface Groups {
 
 export interface StatsSection {
 	stats: Array<Stats & { _key: string }>;
-}
-
-export interface SanityImage {
-	_type: 'image';
-	asset?: SanityImageAssetReference;
-	crop?: SanityImageCrop;
-	hotspot?: SanityImageHotspot;
-	media?: unknown;
-}
-
-export interface SanityImageReference {
-	asset?: {
-		_ref: string;
-		_type: 'reference';
-		_weak?: boolean;
-		[internalGroqTypeReferenceTo]?: 'sanity.imageAsset';
-	};
-	alt: string;
-	crop?: SanityImageCrop;
-	hotspot?: SanityImageHotspot;
-}
-
-export interface ExtendedImage extends SanityImageReference {
-	_type: 'extendedImage';
-}
-
-export interface MainImage extends SanityImageReference {
-	_type: 'mainImage';
 }

--- a/apps/web/src/utils/groups.ts
+++ b/apps/web/src/utils/groups.ts
@@ -11,6 +11,8 @@ import danceImage from '@/images/angebot/groups/tanzen.webp';
 import otherSportsImage from '@/images/angebot/groups/weitere-sportarten.webp';
 import fallbackImageFile from '@/images/angebot/hero.webp';
 
+import { getBaseUrl } from './url';
+
 interface OfferGroupImage {
 	alt: ImageProps['alt'];
 	src: ImageProps['src'];
@@ -99,7 +101,7 @@ export function getOGImage(group: string): OpenGraph['images'] {
 	return {
 		alt: groupSection?.image?.alt ?? fallbackImage.alt,
 		height: 630,
-		url: imageURL,
+		url: `${getBaseUrl()}${imageURL}`,
 		width: 1200,
 	};
 }

--- a/apps/web/src/utils/url.ts
+++ b/apps/web/src/utils/url.ts
@@ -1,5 +1,29 @@
+import process from 'node:process';
+
 import { GOOGLE_MAPS_URL } from '@/constants/urls';
 import type { TrainingTimeSection } from '@/types/sanity.types';
+
+/**
+ * Returns the canonical base URL for the application depending on the runtime environment.
+ *
+ * - Uses the VERCEL_PROJECT_PRODUCTION_URL (from Vercel environment) if present.
+ * - Falls back to 'https://next.tsg-irlich.de' when in production mode.
+ * - Defaults to 'http://localhost:3000' for development.
+ *
+ * @returns The base URL (protocol and domain) for the current deployment environment.
+ *
+ * @example
+ * const baseUrl = getBaseUrl(); // e.g., "https://mein-projekt.vercel.app"
+ */
+export function getBaseUrl(): string {
+	let baseUrl = 'http://localhost:3000';
+	if (process.env.VERCEL_PROJECT_PRODUCTION_URL) {
+		baseUrl = `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`;
+	} else if (process.env.NODE_ENV === 'production') {
+		baseUrl = 'https://next.tsg-irlich.de';
+	}
+	return baseUrl;
+}
 
 /**
  * Generates a Google Maps search URL for a given venue location.


### PR DESCRIPTION
## Summary

Add comprehensive metadata and OpenGraph image support across all pages, enabling CMS-driven SEO configuration through Sanity.

## Changes

- Add meta fields (metaTitle, metaDescription, openGraphImage) to Sanity schemas for news categories and groups
- Implement generateMetadata functions for all pages to use CMS-driven metadata
- Create shared getOpenGraphImageOptions utility for consistent OG image handling
- Extract base URL logic into reusable getBaseUrl utility function
- Update GROQ queries to include meta fields
- Add image type definitions for better type safety
- Improve 404 page with German content
- Make sponsors logo and website fields required

## Motivation

This change enables content editors to manage SEO metadata directly from Sanity CMS, improving workflow efficiency and ensuring consistent OpenGraph image handling across all pages. The centralized utilities reduce code duplication and improve maintainability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dynamic metadata generation across pages for improved SEO and social media sharing
  * Implemented Open Graph image support for enhanced content previews when pages are shared

* **Improvements**
  * Updated 404 error page with localized messaging
  * Enhanced footer home link accessibility

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->