### PR TITLE
fix(studio): prevent internal URLs in external links

### DIFF
--- a/apps/studio/schemas/objects/external-link.ts
+++ b/apps/studio/schemas/objects/external-link.ts
@@ -12,7 +12,17 @@ const externalLink = defineField({
 			name: 'href',
 			type: 'url',
 			description: 'Externen Link hinzufügen',
-			validation: Rule => Rule.required().error('Die URL ist erforderlich'),
+			validation: Rule =>
+				Rule.required()
+					.custom((url: string) => {
+						if (!url) return true;
+						const internalPattern = /tsg-irlich\.de/i;
+						if (internalPattern.test(url)) {
+							return 'Interne URLs sollten stattdessen den Internen Link-Annotation verwenden';
+						}
+						return true;
+					})
+					.error('Die URL ist erforderlich'),
 		},
 	],
 });


### PR DESCRIPTION
## Summary

This PR adds validation to the external link schema in Sanity Studio to prevent internal URLs (tsg-irlich.de) from being used in external links. Content editors will now receive a clear error message directing them to use the Internal Link annotation instead.

## Changes

- **External Link Schema Validation**:
  - Added custom validation rule to detect internal URLs containing `tsg-irlich.de`
  - Provides clear error message: "Internal URLs should use the Internal Link annotation instead"
  - Maintains existing required field validation

## Motivation

This change ensures proper separation between internal and external links in the CMS. By preventing internal URLs from being used in external link fields, we:

- Guide content editors to use the correct link type (Internal Link annotation)
- Maintain consistency in link handling across the application
- Prevent potential routing issues that could arise from mixing link types
- Improve content editor experience with clear, actionable error messages



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation for external link URLs to detect and prevent internal site URLs (tsg-irlich.de). Users are now guided with a helpful message to use the Internal Link annotation for internal links instead.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->