### PR TITLE
docs: update commands to use `nr` runner

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,29 +16,27 @@ containing:
 
 ### Root Commands (use these for most tasks)
 
+Use `nr` (from @antfu/ni) as the preferred command runner:
+
 ```bash
 # Development
-bun run dev                    # Start all apps in development mode
-turbo dev                   # Alternative using turbo directly
+nr dev                         # Start all apps in development mode
+nr dev:email                   # Start React Email preview server
 
 # Building
-bun run build                  # Build all apps
-bun run build:affected         # Build only affected packages
-turbo build --affected      # Alternative using turbo directly
+nr build                       # Build all apps
+nr build:affected              # Build only affected packages
 
 # Linting & Code Quality
-bun run lint                   # Lint all apps
-bun run lint:affected          # Lint only affected packages
-bun run lint:root              # Lint root directory files
-bun run lint:cspell            # Run spell check
+nr lint                        # Lint all apps
+nr lint:affected               # Lint only affected packages
+nr lint:root                   # Lint root directory files
+nr lint:cspell                 # Run spell check
 
 # Type Checking & Generation
-bun run typecheck              # Type check all apps
-bun run typegen:sanity         # Generate Sanity types for web app
-bun run typegen:routes         # Generate Next.js route types
-
-# Email Development
-bun run dev:email              # Start React Email preview server
+nr typecheck                   # Type check all apps
+nr typegen:sanity              # Generate Sanity types for web app
+nr typegen:routes              # Generate Next.js route types
 ```
 
 ### Individual App Commands
@@ -46,27 +44,27 @@ bun run dev:email              # Start React Email preview server
 ```bash
 # Web app (apps/web)
 cd apps/web
-bun run dev                    # Next.js dev server
-bun run build                  # Production build
-bun run start                  # Start production server
-bun run lint                   # ESLint with auto-fix
-bun run typecheck              # Type check with TypeScript
-bun run typegen:sanity         # Generate Sanity types
-bun run typegen:routes         # Generate Next.js route types
+nr dev                         # Next.js dev server
+nr build                       # Production build
+nr start                       # Start production server
+nr lint                        # ESLint with auto-fix
+nr typecheck                   # Type check with TypeScript
+nr typegen:sanity              # Generate Sanity types
+nr typegen:routes              # Generate Next.js route types
 
 # Studio app (apps/studio)
 cd apps/studio
-bun run dev                    # Sanity Studio development
-bun run build                  # Build Sanity Studio
-bun run deploy                 # Deploy studio to Sanity
-bun run extract-types          # Extract schema types for typegen
-bun run typecheck              # Type check with TypeScript
+nr dev                         # Sanity Studio development
+nr build                       # Build Sanity Studio
+nr deploy                      # Deploy studio to Sanity
+nr extract-types               # Extract schema types for typegen
+nr typecheck                   # Type check with TypeScript
 
 # Email package (packages/email)
 cd packages/email
-bun run dev:email              # React Email preview server (port 3001)
-bun run build                  # Build email templates
-bun run export                 # Export email templates
+nr dev:email                   # React Email preview server (port 3001)
+nr build                       # Build email templates
+nr export                      # Export email templates
 ```
 
 ## Architecture & Code Organization
@@ -137,12 +135,8 @@ bun run export                 # Export email templates
 ### Type Generation Workflow
 
 ```bash
-# After schema changes, always run:
-cd apps/studio && bun run extract-types   # Extract from studio
-cd apps/web && bun run typegen:sanity     # Generate types for web
-
-# Or from root:
-turbo extract-types && turbo typegen:sanity
+# After schema changes, always run from root:
+nr extract-types && nr typegen:sanity
 ```
 
 ## Environment & Configuration

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -188,11 +188,8 @@ export const myDataQuery = defineQuery(groq`
 After making any changes to Sanity schemas, always run:
 
 ```bash
-cd apps/studio && bun run extract-types   # Extract from studio
-cd apps/web && bun run typegen:sanity     # Generate types for web
-
-# Or from root:
-turbo extract-types && turbo typegen:sanity
+# From root:
+nr extract-types && nr typegen:sanity
 ```
 
 ## Commit Guidelines
@@ -348,7 +345,7 @@ bun run test
 2. Use `defineType()` and `defineField()`
 3. Add German titles/descriptions
 4. Include appropriate icon
-5. Run type generation: `turbo extract-types && turbo typegen:sanity`
+5. Run type generation: `nr extract-types && nr typegen:sanity`
 
 ### Updating Dependencies
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,9 @@ tsg-web/
 
 - **Multi-language support** (German)
 - **Responsive design** for all devices
-- **SEO optimized** with Next.js metadata
+- **SEO optimized** with dynamic sitemap, robots.txt, and metadata
+- **PWA support** with web app manifest and icons
+- **RSS feed** for news articles
 - **Performance optimized** with image optimization
 - **About us** description of the club
 - **Contact forms** with validation
@@ -99,6 +101,7 @@ tsg-web/
 - **Sports groups** and departments showcase
 - **Member testimonials**
 - **Training schedules**
+- **Accessibility page** with accessibility statement
 
 ### CMS Features
 


### PR DESCRIPTION
## Summary

Updates all documentation files to use `nr` (from @antfu/ni) as the preferred command runner instead of `bun run` or `turbo` directly.

## Changes

- **CLAUDE.md**: Replace all `bun run` and `turbo` commands with `nr`, add note about preferred command runner
- **CONTRIBUTING.md**: Update type generation workflow to use `nr`
- **README.md**: Add new features (SEO, PWA, RSS, Accessibility) to the features list

## Motivation

Ensures consistency across documentation and aligns with the project's actual workflow where `nr` is used as the standard command runner.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced SEO capabilities with dynamic sitemap, robots.txt, and metadata
  * PWA support with web app manifest and icons
  * RSS feed for news articles
  * Accessibility page with accessibility statement

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->