### PR TITLE
fix(web): keep screenshot previews visible after upload

### DIFF
--- a/apps/web/src/components/with-logic/feedback/form.tsx
+++ b/apps/web/src/components/with-logic/feedback/form.tsx
@@ -2,7 +2,7 @@
 
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useState } from 'react';
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 
 import { createLinearIssue } from '@/actions/create-linear-issue';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -46,7 +46,9 @@ export function FeedbackForm() {
 		resolver: zodResolver(feedbackFormSchema),
 	});
 
-	const selectedType = form.watch('type');
+	// `useWatch` instead of `form.watch()` — the latter returns a function the React Compiler
+	// cannot memoize safely.
+	const selectedType = useWatch({ control: form.control, name: 'type' });
 
 	async function onSubmit(values: FeedbackFormValues) {
 		setIsSubmitting(true);

--- a/apps/web/src/components/with-logic/feedback/screenshot-upload.tsx
+++ b/apps/web/src/components/with-logic/feedback/screenshot-upload.tsx
@@ -3,7 +3,7 @@
 import { AlertCircle, ImagePlus, Loader2, X } from 'lucide-react';
 import Image from 'next/image';
 import type { ChangeEvent, DragEvent } from 'react';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { cn } from '@tsgi-web/shared';
 
@@ -36,6 +36,10 @@ export function ScreenshotUpload({
 }: Readonly<ScreenshotUploadProps>) {
 	const [isDragging, setIsDragging] = useState(false);
 	const [uploadingFiles, setUploadingFiles] = useState<UploadingFile[]>([]);
+	// Linear asset URLs require an API key, so the optimizer cannot fetch them (401).
+	// Keep the local object URL of each upload around and show that as the preview instead.
+	const [previews, setPreviews] = useState<Record<string, string>>({});
+	const objectUrlsRef = useRef<Set<string>>(new Set());
 
 	const canAddMore = value.length + uploadingFiles.length < maxFiles;
 
@@ -58,6 +62,7 @@ export function ScreenshotUpload({
 
 			const id = crypto.randomUUID();
 			const preview = URL.createObjectURL(file);
+			objectUrlsRef.current.add(preview);
 
 			// Add to uploading state
 			setUploadingFiles((previous) => [
@@ -69,9 +74,11 @@ export function ScreenshotUpload({
 				const result = await uploadToLinear({ file });
 
 				if (result?.data?.assetUrl) {
-					// Remove from uploading, add to value
+					// Remove from uploading, add to value — the object URL stays alive as preview
+					const { assetUrl } = result.data;
 					setUploadingFiles((previous) => previous.filter((f) => f.id !== id));
-					onChange([...value, result.data.assetUrl]);
+					setPreviews((previous) => ({ ...previous, [assetUrl]: preview }));
+					onChange([...value, assetUrl]);
 				} else {
 					// Mark as error
 					setUploadingFiles((previous) =>
@@ -133,16 +140,15 @@ export function ScreenshotUpload({
 		[maxFiles, processFile, value.length],
 	);
 
-	useEffect(
-		() => () => {
-			for (const file of uploadingFiles) {
-				if (file.preview) {
-					URL.revokeObjectURL(file.preview);
-				}
+	useEffect(() => {
+		const objectUrls = objectUrlsRef.current;
+		return () => {
+			for (const url of objectUrls) {
+				URL.revokeObjectURL(url);
 			}
-		},
-		[uploadingFiles],
-	);
+			objectUrls.clear();
+		};
+	}, []);
 
 	// Handle paste from clipboard
 	useEffect(() => {
@@ -174,6 +180,14 @@ export function ScreenshotUpload({
 	}, [disabled, canAddMore, processFile]);
 
 	const removeUrl = (urlToRemove: string) => {
+		const preview = previews[urlToRemove];
+		if (preview) {
+			URL.revokeObjectURL(preview);
+			objectUrlsRef.current.delete(preview);
+		}
+		setPreviews((previous) =>
+			Object.fromEntries(Object.entries(previous).filter(([key]) => key !== urlToRemove)),
+		);
 		onChange(value.filter((url) => url !== urlToRemove));
 	};
 
@@ -182,6 +196,7 @@ export function ScreenshotUpload({
 			const file = previous.find((f) => f.id === id);
 			if (file?.preview) {
 				URL.revokeObjectURL(file.preview);
+				objectUrlsRef.current.delete(file.preview);
 			}
 			return previous.filter((f) => f.id !== id);
 		});
@@ -234,8 +249,9 @@ export function ScreenshotUpload({
 						>
 							<Image
 								alt={`Screenshot ${index + 1}`}
-								className="absolute inset-0 size-full object-cover"
-								src={url}
+								className="object-cover"
+								src={previews[url] ?? url}
+								fill
 							/>
 							<button
 								aria-label={`Remove screenshot ${index + 1}`}


### PR DESCRIPTION
## Problem

Uploading a screenshot in the feedback form worked, but the preview tile stayed empty. Two separate defects:

1. The `<Image>` for already-uploaded screenshots had neither `width`/`height` nor `fill` — only CSS (`absolute inset-0 size-full`). Next.js threw:
   `Image with src "https://uploads.linear.app/..." is missing required "width" property`
2. Once that was fixed, the optimizer failed with a 401:
   `upstream image response failed for https://uploads.linear.app/... 401`
   Linear asset URLs are only readable with an API key, and `/_next/image` fetches them unauthenticated. Having the host in `next.config.ts` `remotePatterns` does not help.

## Change

- The object URL created for the upload is now kept alive and stored in a `previews` map (asset URL → blob URL). The tile renders `previews[url] ?? url`, so no request to `uploads.linear.app` is made. `next/image` treats `blob:` sources as unoptimized automatically.
- Added the missing `fill` prop; the parent already provides `relative aspect-video overflow-hidden`, so the layout is unchanged.
- Fixed a related bug in the cleanup effect: it had `[uploadingFiles]` as its dependency, so every change to the list revoked the object URLs of uploads still in flight. Object URLs are now tracked in a ref and revoked on unmount, plus explicitly in `removeUrl` / `removeUploading`.

The value submitted to Linear is unchanged — still the asset URL.

## Known limitation

The preview is bound to the browser session. After a page reload before submitting, the tile is empty while the URL stays in state. A persistent preview would need a server route that proxies the asset with `LINEAR_API_KEY`; deliberately out of scope here.

## Verification

- `bun run typecheck` — passes
- `bun run build` — passes
- `bun run lint` — the 4 remaining errors (`arrow-button.tsx`, `form.tsx`) are pre-existing on `next` and untouched by this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved screenshot uploads so image previews remain visible after uploads complete.
  - Preserved local previews when remote asset links are unavailable.
  - Added cleanup when images are removed or the upload view is closed to prevent stale previews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->