### PR TITLE
feat(web): use oswald as heading font

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -60,9 +60,9 @@
 		Inter, ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
 		'Segoe UI Symbol', 'Noto Color Emoji';
 	--font-sans-serif:
-		Anton, ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
+		Oswald, ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
 		'Segoe UI Symbol', 'Noto Color Emoji';
-	--font-serif: Bebas Neue, ui-serif, Georgia, Cambria, 'Times New Roman', Times, serif;
+	--font-serif: 'Bebas Neue', ui-serif, Georgia, Cambria, 'Times New Roman', Times, serif;
 
 	--breakpoint-3xl: 120rem;
 
@@ -357,9 +357,8 @@
 	h6,
 	.title,
 	.sub-title {
-		font-family:
-			Anton, ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
-			'Segoe UI Symbol', 'Noto Color Emoji';
+		font-family: var(--font-sans-serif);
+		font-weight: bold;
 		text-wrap: balance;
 	}
 

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import { Analytics } from '@vercel/analytics/next';
 import type { Metadata } from 'next';
 import { VisualEditing } from 'next-sanity/visual-editing';
-import { Anton, Bebas_Neue, Inter } from 'next/font/google';
+import { Bebas_Neue, Inter, Oswald } from 'next/font/google';
 import { draftMode } from 'next/headers';
 
 import { EMPTY_ARRAY, cn } from '@tsgi-web/shared';
@@ -18,11 +18,11 @@ import { getBaseUrl } from '@/utils/url';
 // oxlint-disable-next-line import/no-unassigned-import
 import './globals.css';
 
-const anton = Anton({
+const oswald = Oswald({
 	display: 'swap',
 	subsets: ['latin'],
 	variable: '--font-sans-serif',
-	weight: ['400'],
+	weight: ['400', '700'],
 });
 
 const bebasNeue = Bebas_Neue({
@@ -75,7 +75,7 @@ export default async function RootLayout({
 		<html lang="de" data-scroll-behavior="smooth">
 			<body
 				className={cn(
-					`${anton.variable} ${bebasNeue.variable} ${inter.variable} antialiased`,
+					`${oswald.variable} ${bebasNeue.variable} ${inter.variable} antialiased`,
 					'flex h-screen flex-col',
 				)}
 			>


### PR DESCRIPTION
## What changed

- Swapped the Anton Google font for Oswald in `apps/web/src/app/layout.tsx`, loading the `400` and `700` weights.
- Headings (`h4`–`h6`, `.title`, `.sub-title`) now reference `var(--font-sans-serif)` instead of hardcoding the font family. The hardcoded stack named the raw Google family, which never matched the hashed family that `next/font` generates, so headings silently fell back to a system font. They now use the font that is actually loaded.
- Added `font-weight: bolder` to those headings, which resolves to the newly loaded `700` weight.
- Quoted `'Bebas Neue'` in the `--font-serif` stack, since multi-word family names need quoting.

## Verification

- `pnpm exec oxfmt` and `pnpm exec oxlint` on the changed files: clean.
- `pnpm run typecheck`: all four packages pass.
- `pnpm exec cve-lite .` (pre-push hook): no known vulnerabilities.

## Note

`Oswald` is a variable font, so passing an explicit `weight` array pins it to static instances instead of the full variable range. Dropping `weight` entirely would load the variable font — worth considering as a follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the application’s typography to use the Oswald font.
  * Improved heading styling with a bolder, more consistent appearance.
  * Corrected font naming for improved rendering consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->