### PR TITLE
fix(web): make mobile navigation hover state readable

### DIFF
--- a/apps/web/src/components/with-logic/navigation.tsx
+++ b/apps/web/src/components/with-logic/navigation.tsx
@@ -120,7 +120,7 @@ export function Navigation({ navItems }: Readonly<NavigationProps>) {
 					<div className="flex items-center gap-2 lg:hidden">
 						<button
 							aria-label="Toggle menu"
-							className="my-2 inline-flex items-center justify-center rounded-md p-2 text-foreground transition-colors hover:bg-gray-100"
+							className="my-2 inline-flex items-center justify-center rounded-md p-2 text-foreground transition-colors hover:bg-muted/40"
 							// oxlint-disable-next-line react_perf/jsx-no-new-function-as-prop
 							onClick={() => {
 								setIsMobileOpen(!isMobileOpen);
@@ -145,7 +145,7 @@ export function Navigation({ navItems }: Readonly<NavigationProps>) {
 					{navItemsWithActive.map((item) => (
 						<Link
 							className={cn(
-								'block rounded-md px-3 py-2 text-base font-medium text-foreground transition-colors hover:bg-gray-100 dark:hover:bg-gray-900',
+								'block rounded-md px-3 py-2 text-base font-medium text-foreground transition-colors hover:bg-muted/40',
 								{ 'bg-secondary/40': item.isActive },
 							)}
 							href={item.slug}


### PR DESCRIPTION
## Summary

The hover state of the mobile navigation rendered a near-black background behind near-black text, making the hovered entry unreadable. Both hover states in the mobile navigation now use the app's own palette token instead of hardcoded Tailwind gray shades.

## Changes

- `apps/web/src/components/with-logic/navigation.tsx`
  - Mobile nav links: `hover:bg-gray-100 dark:hover:bg-gray-900` → `hover:bg-muted/40`.
  - Mobile menu toggle button: `hover:bg-gray-100` → `hover:bg-muted/40`.

## Motivation

The app ships a single light palette — `globals.css` defines no dark theme and no `dark` variant strategy. Tailwind v4's default `dark:` variant therefore resolves to `prefers-color-scheme: dark`, so any visitor whose OS is in dark mode triggered `dark:hover:bg-gray-900` while `text-foreground` stayed at its light-theme near-black value. Result: dark text on a dark background.

`bg-muted/40` keeps sufficient contrast against `text-foreground` and stays visually distinct from the active entry's `bg-secondary/40`. The toggle button had no `dark:` variant and so was not broken, but it hardcoded the same gray shade; switching it keeps the mobile header on one palette.

## Testing

- `pnpm exec oxfmt` and `pnpm exec oxlint` on the changed file: clean.
- `pnpm run typecheck`: 3/3 tasks pass.
- `pnpm exec cve-lite .` (pre-push hook): no known vulnerabilities.
- No automated visual regression coverage exists for the navigation, so the contrast itself was verified by reasoning about the resolved token values rather than by a test.

## Breaking Changes

None. Visual-only change, scoped to the mobile navigation hover state.