### PR TITLE
test: set up vitest across the monorepo (WEB-296)

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
   push:
 
+permissions:
+  contents: read
+
 jobs:
   check:
     name: Check
@@ -34,6 +37,12 @@ jobs:
 
       - name: Lint files
         run: pnpm run lint:affected:github
+
+      - name: Run tests
+        run: pnpm run test:affected
+        env:
+          NEXT_PUBLIC_SANITY_DATASET: ${{ secrets.SANITY_DATASET }}
+          NEXT_PUBLIC_SANITY_PROJECT_ID: ${{ secrets.SANITY_PROJECT_ID }}
 
       - name: Build files
         run: pnpm run build:affected

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -39,7 +39,7 @@ jobs:
         run: pnpm run lint:affected:github
 
       - name: Run tests
-        run: pnpm run test:affected
+        run: pnpm run test
         env:
           NEXT_PUBLIC_SANITY_DATASET: ${{ secrets.SANITY_DATASET }}
           NEXT_PUBLIC_SANITY_PROJECT_ID: ${{ secrets.SANITY_PROJECT_ID }}

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+permissions:
+  contents: read
+
 jobs:
   sonarqube:
     name: SonarQube
@@ -15,6 +18,24 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          cache: pnpm
+          node-version-file: .nvmrc
+
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Collect Coverage
+        run: pnpm run test:coverage
+        env:
+          NEXT_PUBLIC_SANITY_DATASET: ${{ secrets.SANITY_DATASET }}
+          NEXT_PUBLIC_SANITY_PROJECT_ID: ${{ secrets.SANITY_PROJECT_ID }}
 
       - name: SonarQube Scan
         uses: SonarSource/sonarqube-scan-action@a31c9398be7ace6bbfaf30c0bd5d415f843d45e9 # v7

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,7 +161,7 @@ A new variable also has to be registered in the root `turbo.json` (`globalEnv` o
 - `apps/web` splits into a `node` and a `dom` (jsdom) project; component and hook tests land in `dom` — see `apps/web/AGENTS.md`
 - oxlint's vitest plugin warns (`pnpm run lint` still exits 0) when a `describe` title isn't lowercase or repeats an imported identifier, or a hook sits outside a `describe` block — the convention is kept repo-wide regardless
 - Test files, `test-utils/**` and `vitest.config.ts` are exempt from `sort-keys`, `no-magic-numbers`, `max-lines`, `max-lines-per-function` and `typescript/no-unsafe-type-assertion` in `oxlint.config.ts` — widen a single rule inline, never the override itself
-- External services are mocked at the `fetch` boundary, not the module boundary; Resend is the one SDK mock
+- Mock external services at the `fetch` boundary, not the module boundary; Resend is planned as the one exception, mocked at the SDK level
 - `pnpm run test:coverage` writes `coverage/lcov.info` per workspace for CI/SonarQube; no minimum coverage threshold yet
 
 ### Performance & Best Practices

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,9 +35,9 @@ pnpm run lint:root                   # Lint root directory files
 pnpm run format                      # Format with oxfmt (format:check to only verify)
 
 # Testing
-pnpm run test                         # Run every unit test suite
-pnpm run test:affected                # Only the affected packages
-pnpm run test:coverage                # Run with coverage (lcov per workspace)
+pnpm run test                        # Run every unit test suite
+pnpm run test:affected               # Only the affected packages
+pnpm run test:coverage               # Run with coverage (lcov per workspace)
 
 # Type Checking & Generation
 pnpm run typecheck                   # Type check all apps
@@ -159,7 +159,7 @@ A new variable also has to be registered in the root `turbo.json` (`globalEnv` o
 - **Vitest** for unit tests, one `vitest.config.ts` per workspace (`apps/web`, `apps/studio`, `packages/shared`, `packages/email`); tests live next to their source (`foo.ts` → `foo.test.ts`)
 - Import `describe`/`it`/`expect`/`vi` explicitly from `vitest` — `globals` stays off
 - `apps/web` splits into a `node` and a `dom` (jsdom) project; component and hook tests land in `dom` — see `apps/web/AGENTS.md`
-- oxlint's vitest plugin requires a lowercase `describe` title that never repeats an imported identifier, and `beforeEach`/`afterEach`/`beforeAll`/`afterAll` inside a `describe` block
+- oxlint's vitest plugin warns (`pnpm run lint` still exits 0) when a `describe` title isn't lowercase or repeats an imported identifier, or a hook sits outside a `describe` block — the convention is kept repo-wide regardless
 - Test files, `test-utils/**` and `vitest.config.ts` are exempt from `sort-keys`, `no-magic-numbers`, `max-lines`, `max-lines-per-function` and `typescript/no-unsafe-type-assertion` in `oxlint.config.ts` — widen a single rule inline, never the override itself
 - External services are mocked at the `fetch` boundary, not the module boundary; Resend is the one SDK mock
 - `pnpm run test:coverage` writes `coverage/lcov.info` per workspace for CI/SonarQube; no minimum coverage threshold yet

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,11 @@ pnpm run lint:affected               # Lint only affected packages
 pnpm run lint:root                   # Lint root directory files
 pnpm run format                      # Format with oxfmt (format:check to only verify)
 
+# Testing
+pnpm run test                         # Run every unit test suite
+pnpm run test:affected                # Only the affected packages
+pnpm run test:coverage                # Run with coverage (lcov per workspace)
+
 # Type Checking & Generation
 pnpm run typecheck                   # Type check all apps
 pnpm run extract-types               # Extract the Sanity schema from the studio
@@ -151,6 +156,13 @@ A new variable also has to be registered in the root `turbo.json` (`globalEnv` o
 - **oxfmt** with @mheob/oxfmt-config
 - **Lefthook** for pre-commit hooks
 - **Commitizen** with czg for conventional commits
+- **Vitest** for unit tests, one `vitest.config.ts` per workspace (`apps/web`, `apps/studio`, `packages/shared`, `packages/email`); tests live next to their source (`foo.ts` → `foo.test.ts`)
+- Import `describe`/`it`/`expect`/`vi` explicitly from `vitest` — `globals` stays off
+- `apps/web` splits into a `node` and a `dom` (jsdom) project; component and hook tests land in `dom` — see `apps/web/AGENTS.md`
+- oxlint's vitest plugin requires a lowercase `describe` title that never repeats an imported identifier, and `beforeEach`/`afterEach`/`beforeAll`/`afterAll` inside a `describe` block
+- Test files, `test-utils/**` and `vitest.config.ts` are exempt from `sort-keys`, `no-magic-numbers`, `max-lines`, `max-lines-per-function` and `typescript/no-unsafe-type-assertion` in `oxlint.config.ts` — widen a single rule inline, never the override itself
+- External services are mocked at the `fetch` boundary, not the module boundary; Resend is the one SDK mock
+- `pnpm run test:coverage` writes `coverage/lcov.info` per workspace for CI/SonarQube; no minimum coverage threshold yet
 
 ### Performance & Best Practices
 

--- a/apps/studio/AGENTS.md
+++ b/apps/studio/AGENTS.md
@@ -62,6 +62,10 @@ The web app's `src/types/sanity.types.generated.ts` is generated from that extra
 
 The order of the plugins in `plugins/index.ts` is the order of the studio's top navigation (Structure, Media, Presentation, Vision in development, then the built-in Releases).
 
+## Testing
+
+A single `vitest.config.ts` (jsdom, `**/*.test.{ts,tsx}`) covers the whole app — no project split like `apps/web`. The current suite only tests a plain utility (`utils/time.test.ts`); no schema yet has a dedicated test. When adding one, call `preview.prepare` or a field's `validation` function directly on the exported definition object — schema definitions are plain objects, so no Sanity runtime is needed.
+
 ## Environment variables
 
 `env.ts` reads the `SANITY_STUDIO_*` variables and fails fast when a required one is missing; `sanity.cli.ts` reads the `SANITY_API_*` variables. Add new studio variables to `env.ts`, to the `studio#build` task in the root `turbo.json`, and to the list in the root `AGENTS.md`.

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -14,6 +14,9 @@
 		"lint:fix": "oxlint --fix",
 		"lint:github": "oxlint --format=github",
 		"start": "sanity start",
+		"test": "vitest run",
+		"test:coverage": "vitest run --coverage",
+		"test:watch": "vitest",
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
@@ -36,8 +39,13 @@
 	"devDependencies": {
 		"@types/react": "^19.2.18",
 		"@types/react-dom": "^19.2.4",
+		"@vitejs/plugin-react": "^6.1.0",
+		"@vitest/coverage-v8": "^4.1.11",
+		"jsdom": "^30.0.1",
 		"oxlint": "^1.79.0",
 		"oxlint-tsgolint": "^7.0.2001",
-		"typescript": "^7.0.2"
+		"typescript": "^7.0.2",
+		"vite-tsconfig-paths": "^6.1.1",
+		"vitest": "^4.1.11"
 	}
 }

--- a/apps/studio/utils/time.test.ts
+++ b/apps/studio/utils/time.test.ts
@@ -1,15 +1,10 @@
-import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import { formatDate } from './time';
 
 describe('date formatting', () => {
-	beforeAll(() => {
-		vi.stubEnv('TZ', 'UTC');
-	});
-
-	afterAll(() => {
-		vi.unstubAllEnvs();
-	});
+	// `formatDate` calls `toISOString()`, which always renders UTC by specification, so it is
+	// timezone-independent — no TZ stubbing is needed for these fixtures.
 
 	it('formats a Date as a two digit year date', () => {
 		expect(formatDate(new Date('2026-08-25T10:00:00.000Z'))).toBe('26-08-25');

--- a/apps/studio/utils/time.test.ts
+++ b/apps/studio/utils/time.test.ts
@@ -1,0 +1,29 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { formatDate } from './time';
+
+describe('date formatting', () => {
+	beforeAll(() => {
+		vi.stubEnv('TZ', 'UTC');
+	});
+
+	afterAll(() => {
+		vi.unstubAllEnvs();
+	});
+
+	it('formats a Date as a two digit year date', () => {
+		expect(formatDate(new Date('2026-08-25T10:00:00.000Z'))).toBe('26-08-25');
+	});
+
+	it('formats an ISO string', () => {
+		expect(formatDate('2026-01-01T00:00:00.000Z')).toBe('26-01-01');
+	});
+
+	it('formats a plain date string', () => {
+		expect(formatDate('2026-12-31')).toBe('26-12-31');
+	});
+
+	it('uses UTC, so a UTC timestamp keeps its calendar day', () => {
+		expect(formatDate('2026-08-25T23:30:00.000Z')).toBe('26-08-25');
+	});
+});

--- a/apps/studio/vitest.config.ts
+++ b/apps/studio/vitest.config.ts
@@ -6,7 +6,10 @@ export default defineConfig({
 	plugins: [react(), tsconfigPaths()],
 	test: {
 		coverage: {
+			exclude: ['**/*.test.{ts,tsx}', '**/test-utils/**', '**/*.config.ts', '**/*.generated.ts'],
+			provider: 'v8',
 			reporter: ['text', 'html', 'lcov'],
+			reportsDirectory: './coverage',
 		},
 		environment: 'jsdom',
 		exclude: ['dist/**', 'node_modules/**', '.sanity/**'],

--- a/apps/studio/vitest.config.ts
+++ b/apps/studio/vitest.config.ts
@@ -1,0 +1,16 @@
+import react from '@vitejs/plugin-react';
+import tsconfigPaths from 'vite-tsconfig-paths';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	plugins: [react(), tsconfigPaths()],
+	test: {
+		coverage: {
+			reporter: ['text', 'html', 'lcov'],
+		},
+		environment: 'jsdom',
+		exclude: ['dist/**', 'node_modules/**', '.sanity/**'],
+		include: ['**/*.test.{ts,tsx}'],
+		name: 'studio',
+	},
+});

--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -77,7 +77,7 @@ Forms use react-hook-form with a Zod schema from `src/lib/validations`. The matc
 
 ## Testing
 
-Vitest splits this app into two projects, defined in `vitest.config.ts`: `node` (the default — everything under `src/**` except `src/components/**` and `src/hooks/**`) and `dom` (jsdom, exactly `src/{components,hooks}/**`). Component and hook tests belong in `dom`.
+Vitest splits this app into two projects, defined in `vitest.config.ts`, by file extension: `.test.tsx` anywhere under `src/` runs in the `dom` project (jsdom); `.test.ts` runs in `node`, except under `src/components/**` and `src/hooks/**`, which also run in `dom`.
 
 Static image imports (`.webp` and friends) are resolved by the `assetStub` Vite plugin in `vitest.config.ts` — without it, any module that imports an image fails to load in a test run.
 

--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -75,6 +75,18 @@ Read them through `env('KEY')` from `@/lib/env` — never `process.env` directly
 
 Forms use react-hook-form with a Zod schema from `src/lib/validations`. The matching server action lives in `src/actions`, is built with `actionClient` from `@/lib/actions/safe-action` (next-safe-action) and validates the same schema via `.inputSchema()`.
 
+## Testing
+
+Vitest splits this app into two projects, defined in `vitest.config.ts`: `node` (the default — everything under `src/**` except `src/components/**` and `src/hooks/**`) and `dom` (jsdom, exactly `src/{components,hooks}/**`). Component and hook tests belong in `dom`.
+
+Static image imports (`.webp` and friends) are resolved by the `assetStub` Vite plugin in `vitest.config.ts` — without it, any module that imports an image fails to load in a test run.
+
+Three helpers live in `test-utils/`:
+
+- `setup-dom.ts` — stubs `matchMedia`, `ResizeObserver` and `IntersectionObserver`; wired as the `dom` project's `setupFiles`.
+- `env.ts` — `loadWithEnv` resets the module registry and stubs environment variables before importing the module under test. `src/lib/env.ts` caches every validated value in a module-level `Map`, so a test must not hold a value import of that module or the reset is defeated.
+- `fetch-mock.ts` — `createFetchMock` replaces `fetch` with a queue of canned responses and records every call. Recorded headers are normalized through `Headers`, same as the real `fetch`, so they come back lowercased — assert against lowercase header names.
+
 ## Gotchas
 
 - No `try`/`catch`/`finally` in components or hooks — the React Compiler bails out on `finally`. Await with `settle()` from `@tsgi-web/shared` and branch on `outcome.ok`.

--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -84,7 +84,7 @@ Static image imports (`.webp` and friends) are resolved by the `assetStub` Vite 
 Three helpers live in `test-utils/`:
 
 - `setup-dom.ts` — stubs `matchMedia`, `ResizeObserver` and `IntersectionObserver`; wired as the `dom` project's `setupFiles`.
-- `env.ts` — `loadWithEnv` resets the module registry and stubs environment variables before importing the module under test. `src/lib/env.ts` caches every validated value in a module-level `Map`, so a test must not hold a value import of that module or the reset is defeated.
+- `env.ts` — `loadWithEnv` resets the module registry and stubs the environment, because `src/lib/env.ts` caches validated values in a module-level `Map`. A test using it must import the module under test only as `import type` and get its runtime binding from `loadWithEnv`'s return value — see `src/utils/url.test.ts`.
 - `fetch-mock.ts` — `createFetchMock` replaces `fetch` with a queue of canned responses and records every call. Recorded headers are normalized through `Headers`, same as the real `fetch`, so they come back lowercased — assert against lowercase header names.
 
 ## Gotchas

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -55,10 +55,14 @@
 		"zod": "^4.4.3"
 	},
 	"devDependencies": {
+		"@testing-library/react": "^16.3.2",
+		"@testing-library/user-event": "^14.6.6",
 		"@types/node": "^24.13.3",
 		"@types/react": "19.2.18",
 		"@types/react-dom": "19.2.4",
+		"@vitejs/plugin-react": "^6.1.0",
 		"@vitest/coverage-v8": "^4.1.11",
+		"jsdom": "^30.0.1",
 		"oxlint": "^1.79.0",
 		"oxlint-tsgolint": "^7.0.2001",
 		"postcss": "^8.5.26",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,6 +10,9 @@
 		"lint:fix": "oxlint --fix",
 		"lint:github": "oxlint --format=github",
 		"start": "next start",
+		"test": "vitest run",
+		"test:coverage": "vitest run --coverage",
+		"test:watch": "vitest",
 		"typecheck": "tsc --noEmit",
 		"typegen:routes": "next typegen && tsc --noEmit",
 		"typegen:sanity": "sanity typegen generate"
@@ -55,10 +58,13 @@
 		"@types/node": "^24.13.3",
 		"@types/react": "19.2.18",
 		"@types/react-dom": "19.2.4",
+		"@vitest/coverage-v8": "^4.1.11",
 		"oxlint": "^1.79.0",
 		"oxlint-tsgolint": "^7.0.2001",
 		"postcss": "^8.5.26",
 		"postcss-load-config": "^6.0.1",
-		"typescript": "^7.0.2"
+		"typescript": "^7.0.2",
+		"vite-tsconfig-paths": "^6.1.1",
+		"vitest": "^4.1.11"
 	}
 }

--- a/apps/web/src/actions/subscribe-to-newsletter.ts
+++ b/apps/web/src/actions/subscribe-to-newsletter.ts
@@ -79,7 +79,7 @@ export async function subscribeToNewsletter(
 	if ('error' in validated) {
 		return {
 			error: validated.error,
-			message: 'Bitte überprüfen Deine Eingaben.',
+			message: 'Bitte überprüfe Deine Eingaben.',
 			success: false,
 			title: 'Fehler',
 		};

--- a/apps/web/src/hooks/use-media-query.test.ts
+++ b/apps/web/src/hooks/use-media-query.test.ts
@@ -38,11 +38,22 @@ describe('media query hook', () => {
 	it('removes its listener on unmount', () => {
 		const { unmount } = renderHook(() => useMediaQuery(QUERY));
 		const list = window.matchMedia(QUERY);
-		// oxlint-disable-next-line typescript/no-unsafe-type-assertion
 		const { listeners } = list as unknown as { listeners: Set<unknown> };
 
 		unmount();
 
 		expect(listeners.size).toBe(0);
+	});
+
+	it('keeps the media query list in sync with the dispatched change', () => {
+		const { result } = renderHook(() => useMediaQuery(QUERY));
+		const list = window.matchMedia(QUERY);
+
+		act(() => {
+			dispatchMediaQueryChange(list, true);
+		});
+
+		expect(result.current).toBe(true);
+		expect(list.matches).toBe(true);
 	});
 });

--- a/apps/web/src/hooks/use-media-query.test.ts
+++ b/apps/web/src/hooks/use-media-query.test.ts
@@ -1,0 +1,48 @@
+/* eslint-disable unicorn/prefer-global-this */
+
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createMatchMediaStub, dispatchMediaQueryChange } from '../../test-utils/setup-dom';
+import { useMediaQuery } from './use-media-query';
+
+const QUERY = '(max-width: 48rem)';
+
+describe('media query hook', () => {
+	afterEach(() => {
+		vi.stubGlobal('matchMedia', createMatchMediaStub(false));
+	});
+
+	it('returns false when the query does not match', () => {
+		const { result } = renderHook(() => useMediaQuery(QUERY));
+		expect(result.current).toBe(false);
+	});
+
+	it('returns true when the query matches on mount', () => {
+		vi.stubGlobal('matchMedia', createMatchMediaStub(true));
+		const { result } = renderHook(() => useMediaQuery(QUERY));
+		expect(result.current).toBe(true);
+	});
+
+	it('updates when the media query changes', () => {
+		const { result } = renderHook(() => useMediaQuery(QUERY));
+		const list = window.matchMedia(QUERY);
+
+		act(() => {
+			dispatchMediaQueryChange(list, true);
+		});
+
+		expect(result.current).toBe(true);
+	});
+
+	it('removes its listener on unmount', () => {
+		const { unmount } = renderHook(() => useMediaQuery(QUERY));
+		const list = window.matchMedia(QUERY);
+		// oxlint-disable-next-line typescript/no-unsafe-type-assertion
+		const { listeners } = list as unknown as { listeners: Set<unknown> };
+
+		unmount();
+
+		expect(listeners.size).toBe(0);
+	});
+});

--- a/apps/web/src/utils/typography.test.ts
+++ b/apps/web/src/utils/typography.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import { capitalizeString, capitalizeWords } from './typography';
+
+describe('capitalize a string', () => {
+	it('capitalizes the first letter', () => {
+		expect(capitalizeString('fußball')).toBe('Fußball');
+	});
+
+	it('leaves an already capitalized string alone', () => {
+		expect(capitalizeString('Fußball')).toBe('Fußball');
+	});
+
+	it('returns an empty string for an empty input', () => {
+		expect(capitalizeString('')).toBe('');
+	});
+
+	it('handles a single character', () => {
+		expect(capitalizeString('a')).toBe('A');
+	});
+
+	it('keeps the rest of the string untouched', () => {
+		expect(capitalizeString('kinderTURNEN')).toBe('KinderTURNEN');
+	});
+});
+
+describe('capitalize words', () => {
+	it('capitalizes every hyphen separated word', () => {
+		expect(capitalizeWords('weitere-sportarten')).toBe('Weitere Sportarten');
+	});
+
+	it('lowercases the remainder of each word', () => {
+		expect(capitalizeWords('WEITERE-SPORTARTEN')).toBe('Weitere Sportarten');
+	});
+
+	it('accepts a custom separator', () => {
+		expect(capitalizeWords('weitere sportarten', ' ')).toBe('Weitere Sportarten');
+	});
+
+	it('returns an empty string for an empty input', () => {
+		expect(capitalizeWords('')).toBe('');
+	});
+
+	it('handles a single word', () => {
+		expect(capitalizeWords('taekwondo')).toBe('Taekwondo');
+	});
+});

--- a/apps/web/src/utils/url.test.ts
+++ b/apps/web/src/utils/url.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+
+import { GOOGLE_MAPS_URL } from '@/constants/urls';
+import type * as urlModule from '@/utils/url';
+
+import { loadWithEnv } from '../../test-utils/env';
+
+type UrlModule = typeof urlModule;
+
+const VENUE = {
+	city: 'Neuwied',
+	houseNumber: '12',
+	name: 'Sporthalle Irlich',
+	street: 'Pappelweg',
+	zipCode: '56567',
+};
+
+describe('base url', () => {
+	it('prefers the Vercel production URL', async () => {
+		const { getBaseUrl } = await loadWithEnv<UrlModule>('@/utils/url', {
+			NODE_ENV: 'production',
+			VERCEL_PROJECT_PRODUCTION_URL: 'tsg-irlich.vercel.app',
+		});
+
+		expect(getBaseUrl()).toBe('https://tsg-irlich.vercel.app');
+	});
+
+	it('falls back to the live domain in production', async () => {
+		const { getBaseUrl } = await loadWithEnv<UrlModule>('@/utils/url', {
+			NODE_ENV: 'production',
+			VERCEL_PROJECT_PRODUCTION_URL: undefined,
+		});
+
+		expect(getBaseUrl()).toBe('https://www.tsg-irlich.de');
+	});
+
+	it('falls back to localhost outside production', async () => {
+		const { getBaseUrl } = await loadWithEnv<UrlModule>('@/utils/url', {
+			NODE_ENV: 'development',
+			VERCEL_PROJECT_PRODUCTION_URL: undefined,
+		});
+
+		expect(getBaseUrl()).toBe('http://localhost:3000');
+	});
+});
+
+describe('google maps link', () => {
+	it('builds a search URL from the full address', async () => {
+		const { printGoogleMapsLink } = await loadWithEnv<UrlModule>('@/utils/url', {});
+
+		expect(printGoogleMapsLink(VENUE)).toBe(
+			`${GOOGLE_MAPS_URL}${encodeURIComponent('Sporthalle Irlich, Pappelweg 12, 56567 Neuwied')}`,
+		);
+	});
+
+	it('skips an empty venue name', async () => {
+		const { printGoogleMapsLink } = await loadWithEnv<UrlModule>('@/utils/url', {});
+
+		expect(printGoogleMapsLink({ ...VENUE, name: '' })).toBe(
+			`${GOOGLE_MAPS_URL}${encodeURIComponent('Pappelweg 12, 56567 Neuwied')}`,
+		);
+	});
+
+	it('skips an empty zip code', async () => {
+		const { printGoogleMapsLink } = await loadWithEnv<UrlModule>('@/utils/url', {});
+
+		expect(printGoogleMapsLink({ ...VENUE, zipCode: '' })).toBe(
+			`${GOOGLE_MAPS_URL}${encodeURIComponent('Sporthalle Irlich, Pappelweg 12, Neuwied')}`,
+		);
+	});
+});

--- a/apps/web/src/utils/url.test.ts
+++ b/apps/web/src/utils/url.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
-import { GOOGLE_MAPS_URL } from '@/constants/urls';
 import type * as urlModule from '@/utils/url';
 
 import { loadWithEnv } from '../../test-utils/env';
 
 type UrlModule = typeof urlModule;
+
+const GOOGLE_MAPS_PREFIX = 'https://www.google.com/maps/search/?api=1&query=';
 
 const VENUE = {
 	city: 'Neuwied',
@@ -49,7 +50,7 @@ describe('google maps link', () => {
 		const { printGoogleMapsLink } = await loadWithEnv<UrlModule>('@/utils/url', {});
 
 		expect(printGoogleMapsLink(VENUE)).toBe(
-			`${GOOGLE_MAPS_URL}${encodeURIComponent('Sporthalle Irlich, Pappelweg 12, 56567 Neuwied')}`,
+			`${GOOGLE_MAPS_PREFIX}${encodeURIComponent('Sporthalle Irlich, Pappelweg 12, 56567 Neuwied')}`,
 		);
 	});
 
@@ -57,7 +58,7 @@ describe('google maps link', () => {
 		const { printGoogleMapsLink } = await loadWithEnv<UrlModule>('@/utils/url', {});
 
 		expect(printGoogleMapsLink({ ...VENUE, name: '' })).toBe(
-			`${GOOGLE_MAPS_URL}${encodeURIComponent('Pappelweg 12, 56567 Neuwied')}`,
+			`${GOOGLE_MAPS_PREFIX}${encodeURIComponent('Pappelweg 12, 56567 Neuwied')}`,
 		);
 	});
 
@@ -65,7 +66,7 @@ describe('google maps link', () => {
 		const { printGoogleMapsLink } = await loadWithEnv<UrlModule>('@/utils/url', {});
 
 		expect(printGoogleMapsLink({ ...VENUE, zipCode: '' })).toBe(
-			`${GOOGLE_MAPS_URL}${encodeURIComponent('Sporthalle Irlich, Pappelweg 12, Neuwied')}`,
+			`${GOOGLE_MAPS_PREFIX}${encodeURIComponent('Sporthalle Irlich, Pappelweg 12, Neuwied')}`,
 		);
 	});
 });

--- a/apps/web/test-utils/env.ts
+++ b/apps/web/test-utils/env.ts
@@ -6,6 +6,10 @@ import { vi } from 'vitest';
  * `src/lib/env.ts` caches every validated value in a module level `Map`, so a test that needs a
  * different value has to reset the registry before importing the consumer.
  *
+ * The caller must import the module under test as `import type` only — a value import binds a
+ * live reference that survives `vi.resetModules()` and silently defeats this helper. See
+ * `src/utils/url.test.ts` for the pattern.
+ *
  * @param specifier - The module specifier to import, resolved the same way a static `import`
  * would resolve it (a `@/`-aliased path works, a path relative to this file does not).
  * @param vars - The environment variables to stub before importing, keyed by name.

--- a/apps/web/test-utils/env.ts
+++ b/apps/web/test-utils/env.ts
@@ -1,0 +1,31 @@
+import { vi } from 'vitest';
+
+/**
+ * Imports a module with a fresh module registry and the given environment variables in place.
+ *
+ * `src/lib/env.ts` caches every validated value in a module level `Map`, so a test that needs a
+ * different value has to reset the registry before importing the consumer.
+ *
+ * @param specifier - The module specifier to import, resolved the same way a static `import`
+ * would resolve it (a `@/`-aliased path works, a path relative to this file does not).
+ * @param vars - The environment variables to stub before importing, keyed by name.
+ * @returns The freshly imported module.
+ */
+async function loadWithEnv<T>(
+	specifier: string,
+	vars: Record<string, string | undefined>,
+): Promise<T> {
+	vi.resetModules();
+	vi.unstubAllEnvs();
+
+	for (const [key, value] of Object.entries(vars)) {
+		vi.stubEnv(key, value);
+	}
+
+	// A dynamic `import()` of a string specifier resolves to `any`; the caller supplies `T` to
+	// name the module's real shape.
+	// oxlint-disable-next-line typescript/no-unsafe-type-assertion
+	return (await import(specifier)) as T;
+}
+
+export { loadWithEnv };

--- a/apps/web/test-utils/fetch-mock.ts
+++ b/apps/web/test-utils/fetch-mock.ts
@@ -40,30 +40,42 @@ function resolveUrl(input: RequestInfo | URL): string {
  * does, which lowercases every header name — assert against lowercase keys (`authorization`,
  * `content-type`), not the casing the code under test sent them with.
  *
- * @returns The recorded calls plus controls to enqueue responses and restore the real `fetch`.
+ * A request made once the queue is empty still throws, so a missing `enqueue` fails fast when
+ * nothing under test swallows the error. It is also recorded on `unqueued` before the throw, so a
+ * test whose subject catches its own errors (for example a `try`/`catch` that returns an error
+ * result) can tell a short queue apart from a genuine failure by asserting
+ * `expect(mock.unqueued).toEqual([])`.
+ *
+ * @returns The recorded calls, the calls that ran out of queued responses, plus controls to
+ * enqueue responses and restore the real `fetch`.
  */
 function createFetchMock(): {
 	calls: FetchCall[];
 	enqueue: (response: MockResponse) => void;
 	enqueueJson: (body: unknown, init?: { status?: number }) => void;
 	restore: () => void;
+	unqueued: FetchCall[];
 } {
 	const calls: FetchCall[] = [];
+	const unqueued: FetchCall[] = [];
 	const queue: MockResponse[] = [];
 
 	const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
 		const url = resolveUrl(input);
 
-		calls.push({
+		const call = {
 			body: typeof init?.body === 'string' ? init.body : undefined,
 			headers: Object.fromEntries(new Headers(init?.headers).entries()),
 			method: init?.method ?? 'GET',
 			url,
-		});
+		};
+
+		calls.push(call);
 
 		const next = queue.shift();
 
 		if (!next) {
+			unqueued.push(call);
 			throw new Error(`No mock response queued for ${url}`);
 		}
 
@@ -85,6 +97,7 @@ function createFetchMock(): {
 		restore: () => {
 			vi.unstubAllGlobals();
 		},
+		unqueued,
 	};
 }
 

--- a/apps/web/test-utils/fetch-mock.ts
+++ b/apps/web/test-utils/fetch-mock.ts
@@ -1,0 +1,87 @@
+import { vi } from 'vitest';
+
+interface FetchCall {
+	body: string | undefined;
+	headers: Record<string, string>;
+	method: string;
+	url: string;
+}
+
+interface MockResponse {
+	body: string;
+	status: number;
+}
+
+/**
+ * Resolves the URL a `fetch` call targets, regardless of which `RequestInfo` shape it was called
+ * with. `String(input)` is not safe for this: a `Request` has no custom `toString`, so it would
+ * stringify to `[object Request]`.
+ *
+ * @param input - The first argument a `fetch` call was made with.
+ * @returns The URL the call targets, as a string.
+ */
+function resolveUrl(input: RequestInfo | URL): string {
+	if (typeof input === 'string') {
+		return input;
+	}
+	if (input instanceof URL) {
+		return input.toString();
+	}
+	return input.url;
+}
+
+/**
+ * Replaces the global `fetch` with a queue of canned responses and records every request.
+ *
+ * Responses are handed out in the order they were enqueued, which keeps the tests of the multi
+ * request flows (token, then receiver, then DOI mail) readable.
+ *
+ * @returns The recorded calls plus controls to enqueue responses and restore the real `fetch`.
+ */
+function createFetchMock(): {
+	calls: FetchCall[];
+	enqueue: (response: MockResponse) => void;
+	enqueueJson: (body: unknown, init?: { status?: number }) => void;
+	restore: () => void;
+} {
+	const calls: FetchCall[] = [];
+	const queue: MockResponse[] = [];
+
+	const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+		const url = resolveUrl(input);
+
+		calls.push({
+			body: typeof init?.body === 'string' ? init.body : undefined,
+			headers: Object.fromEntries(new Headers(init?.headers).entries()),
+			method: init?.method ?? 'GET',
+			url,
+		});
+
+		const next = queue.shift();
+
+		if (!next) {
+			throw new Error(`No mock response queued for ${url}`);
+		}
+
+		// Mirrors the real `fetch`, which hands back the response on a later microtask.
+		await Promise.resolve();
+		return new Response(next.body, { status: next.status });
+	});
+
+	vi.stubGlobal('fetch', fetchMock);
+
+	return {
+		calls,
+		enqueue: (response: MockResponse) => {
+			queue.push(response);
+		},
+		enqueueJson: (body: unknown, init?: { status?: number }) => {
+			queue.push({ body: JSON.stringify(body), status: init?.status ?? 200 });
+		},
+		restore: () => {
+			vi.unstubAllGlobals();
+		},
+	};
+}
+
+export { createFetchMock, type FetchCall, type MockResponse };

--- a/apps/web/test-utils/fetch-mock.ts
+++ b/apps/web/test-utils/fetch-mock.ts
@@ -36,6 +36,10 @@ function resolveUrl(input: RequestInfo | URL): string {
  * Responses are handed out in the order they were enqueued, which keeps the tests of the multi
  * request flows (token, then receiver, then DOI mail) readable.
  *
+ * Recorded `headers` are normalized through the `Headers` constructor, same as the real `fetch`
+ * does, which lowercases every header name — assert against lowercase keys (`authorization`,
+ * `content-type`), not the casing the code under test sent them with.
+ *
  * @returns The recorded calls plus controls to enqueue responses and restore the real `fetch`.
  */
 function createFetchMock(): {

--- a/apps/web/test-utils/setup-dom.ts
+++ b/apps/web/test-utils/setup-dom.ts
@@ -1,0 +1,80 @@
+import { vi } from 'vitest';
+
+type MediaQueryListener = (event: MediaQueryListEvent) => void;
+
+/**
+ * Builds a `matchMedia` implementation whose `matches` value is fixed and whose listeners can be
+ * triggered from a test through `dispatchMediaQueryChange`.
+ *
+ * Returns the same `MediaQueryList` instance for a given query string, so a hook that creates its
+ * own list via `window.matchMedia(query)` and a test that fetches a list for the same query share
+ * one listener set.
+ *
+ * @param matches - The fixed `matches` value every list produced by the stub reports.
+ * @returns A `matchMedia` implementation to install with `vi.stubGlobal`.
+ */
+function createMatchMediaStub(matches: boolean): (query: string) => MediaQueryList {
+	const lists = new Map<string, MediaQueryList>();
+
+	return (query: string) => {
+		const existing = lists.get(query);
+		if (existing) {
+			return existing;
+		}
+
+		const listeners = new Set<MediaQueryListener>();
+
+		// oxlint-disable-next-line typescript/no-unsafe-type-assertion
+		const list = {
+			addEventListener: (_type: string, listener: MediaQueryListener) => {
+				listeners.add(listener);
+			},
+			dispatchEvent: () => true,
+			listeners,
+			matches,
+			media: query,
+			onchange: null,
+			removeEventListener: (_type: string, listener: MediaQueryListener) => {
+				listeners.delete(listener);
+			},
+		} as unknown as MediaQueryList;
+
+		lists.set(query, list);
+		return list;
+	};
+}
+
+/**
+ * Fires a `change` event on every listener registered for the given media query list.
+ *
+ * @param list - The `MediaQueryList` (created by {@link createMatchMediaStub}) to dispatch on.
+ * @param matches - The `matches` value to report on the dispatched event.
+ */
+function dispatchMediaQueryChange(list: MediaQueryList, matches: boolean): void {
+	// oxlint-disable-next-line typescript/no-unsafe-type-assertion
+	const { listeners } = list as unknown as { listeners: Set<MediaQueryListener> };
+	for (const listener of listeners) {
+		// oxlint-disable-next-line typescript/no-unsafe-type-assertion
+		listener({ matches } as MediaQueryListEvent);
+	}
+}
+
+class ObserverStub {
+	public disconnect(): void {
+		// no-op
+	}
+
+	public observe(): void {
+		// no-op
+	}
+
+	public unobserve(): void {
+		// no-op
+	}
+}
+
+vi.stubGlobal('matchMedia', createMatchMediaStub(false));
+vi.stubGlobal('ResizeObserver', ObserverStub);
+vi.stubGlobal('IntersectionObserver', ObserverStub);
+
+export { createMatchMediaStub, dispatchMediaQueryChange };

--- a/apps/web/test-utils/setup-dom.ts
+++ b/apps/web/test-utils/setup-dom.ts
@@ -82,4 +82,18 @@ vi.stubGlobal('matchMedia', createMatchMediaStub(false));
 vi.stubGlobal('ResizeObserver', ObserverStub);
 vi.stubGlobal('IntersectionObserver', ObserverStub);
 
+// jsdom implements neither the pointer-capture API nor `scrollIntoView`, both of which Radix's
+// primitives (Select, Dialog, the vaul drawer) touch on mount — stub them so a test fails on the
+// component under test, not on an unrelated jsdom gap.
+Element.prototype.hasPointerCapture = () => false;
+Element.prototype.setPointerCapture = () => {
+	// no-op
+};
+Element.prototype.releasePointerCapture = () => {
+	// no-op
+};
+Element.prototype.scrollIntoView = () => {
+	// no-op
+};
+
 export { createMatchMediaStub, dispatchMediaQueryChange };

--- a/apps/web/test-utils/setup-dom.ts
+++ b/apps/web/test-utils/setup-dom.ts
@@ -2,6 +2,11 @@ import { vi } from 'vitest';
 
 type MediaQueryListener = (event: MediaQueryListEvent) => void;
 
+interface MutableMediaQueryList {
+	listeners: Set<MediaQueryListener>;
+	matches: boolean;
+}
+
 /**
  * Builds a `matchMedia` implementation whose `matches` value is fixed and whose listeners can be
  * triggered from a test through `dispatchMediaQueryChange`.
@@ -10,7 +15,7 @@ type MediaQueryListener = (event: MediaQueryListEvent) => void;
  * own list via `window.matchMedia(query)` and a test that fetches a list for the same query share
  * one listener set.
  *
- * @param matches - The fixed `matches` value every list produced by the stub reports.
+ * @param matches - The initial `matches` value the list reports before any dispatched change.
  * @returns A `matchMedia` implementation to install with `vi.stubGlobal`.
  */
 function createMatchMediaStub(matches: boolean): (query: string) => MediaQueryList {
@@ -24,7 +29,6 @@ function createMatchMediaStub(matches: boolean): (query: string) => MediaQueryLi
 
 		const listeners = new Set<MediaQueryListener>();
 
-		// oxlint-disable-next-line typescript/no-unsafe-type-assertion
 		const list = {
 			addEventListener: (_type: string, listener: MediaQueryListener) => {
 				listeners.add(listener);
@@ -45,16 +49,17 @@ function createMatchMediaStub(matches: boolean): (query: string) => MediaQueryLi
 }
 
 /**
- * Fires a `change` event on every listener registered for the given media query list.
+ * Fires a `change` event on every listener registered for the given media query list, after
+ * updating the list's own `matches` property so the stub and the dispatched event agree.
  *
  * @param list - The `MediaQueryList` (created by {@link createMatchMediaStub}) to dispatch on.
- * @param matches - The `matches` value to report on the dispatched event.
+ * @param matches - The `matches` value to set on the list and to report on the dispatched event.
  */
 function dispatchMediaQueryChange(list: MediaQueryList, matches: boolean): void {
-	// oxlint-disable-next-line typescript/no-unsafe-type-assertion
-	const { listeners } = list as unknown as { listeners: Set<MediaQueryListener> };
-	for (const listener of listeners) {
-		// oxlint-disable-next-line typescript/no-unsafe-type-assertion
+	const mutableList = list as unknown as MutableMediaQueryList;
+	mutableList.matches = matches;
+
+	for (const listener of mutableList.listeners) {
 		listener({ matches } as MediaQueryListEvent);
 	}
 }

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -40,8 +40,8 @@ export default defineConfig({
 				extends: true,
 				test: {
 					environment: 'node',
-					exclude: ['src/components/**', 'src/hooks/**', 'node_modules/**'],
-					include: ['src/**/*.test.{ts,tsx}'],
+					exclude: ['src/{components,hooks}/**', 'node_modules/**'],
+					include: ['src/**/*.test.ts'],
 					name: { color: 'green', label: 'node' },
 				},
 			},
@@ -50,7 +50,7 @@ export default defineConfig({
 				plugins: [react()],
 				test: {
 					environment: 'jsdom',
-					include: ['src/{components,hooks}/**/*.test.{ts,tsx}'],
+					include: ['src/**/*.test.tsx', 'src/{components,hooks}/**/*.test.ts'],
 					name: { color: 'magenta', label: 'dom' },
 					setupFiles: ['./test-utils/setup-dom.ts'],
 				},

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,3 +1,4 @@
+import react from '@vitejs/plugin-react';
 import tsconfigPaths from 'vite-tsconfig-paths';
 import { defineConfig, type Plugin } from 'vitest/config';
 
@@ -39,6 +40,16 @@ export default defineConfig({
 					exclude: ['src/components/**', 'src/hooks/**', 'node_modules/**'],
 					include: ['src/**/*.test.{ts,tsx}'],
 					name: { color: 'green', label: 'node' },
+				},
+			},
+			{
+				extends: true,
+				plugins: [react()],
+				test: {
+					environment: 'jsdom',
+					include: ['src/{components,hooks}/**/*.test.{ts,tsx}'],
+					name: { color: 'magenta', label: 'dom' },
+					setupFiles: ['./test-utils/setup-dom.ts'],
 				},
 			},
 		],

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,0 +1,46 @@
+import tsconfigPaths from 'vite-tsconfig-paths';
+import { defineConfig, type Plugin } from 'vitest/config';
+
+const ASSET_PATTERN = /\.(?:avif|gif|jpe?g|png|svg|webp)$/u;
+
+/**
+ * Resolves static image imports to the object Next.js injects for them, so modules that import
+ * an image (for example `src/utils/groups.ts`) can be loaded in a test run.
+ *
+ * @returns The Vite plugin that stubs static image imports.
+ */
+function assetStub(): Plugin {
+	return {
+		enforce: 'pre',
+		load(id) {
+			if (!ASSET_PATTERN.test(id)) {
+				return null;
+			}
+			return `export default { blurDataURL: '', blurWidth: 0, height: 1, src: '${id}', width: 1 };`;
+		},
+		name: 'tsgi:asset-stub',
+		resolveId(source) {
+			return ASSET_PATTERN.test(source) ? source : null;
+		},
+	};
+}
+
+export default defineConfig({
+	plugins: [assetStub(), tsconfigPaths()],
+	test: {
+		coverage: {
+			reporter: ['text', 'html', 'lcov'],
+		},
+		projects: [
+			{
+				extends: true,
+				test: {
+					environment: 'node',
+					exclude: ['src/components/**', 'src/hooks/**', 'node_modules/**'],
+					include: ['src/**/*.test.{ts,tsx}'],
+					name: { color: 'green', label: 'node' },
+				},
+			},
+		],
+	},
+});

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -30,7 +30,10 @@ export default defineConfig({
 	plugins: [assetStub(), tsconfigPaths()],
 	test: {
 		coverage: {
+			exclude: ['**/*.test.{ts,tsx}', '**/test-utils/**', '**/*.config.ts', '**/*.generated.ts'],
+			provider: 'v8',
 			reporter: ['text', 'html', 'lcov'],
+			reportsDirectory: './coverage',
 		},
 		projects: [
 			{

--- a/docs/superpowers/plans/2026-08-25-web-296-unit-tests-pr1-infra.md
+++ b/docs/superpowers/plans/2026-08-25-web-296-unit-tests-pr1-infra.md
@@ -1,0 +1,1385 @@
+# WEB-296 Unit Tests — PR 1 (Infrastructure) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the monorepo a working Vitest setup in all four workspaces, wired into Turbo, CI and SonarQube coverage, plus the two bugfixes the spec pins with tests.
+
+**Architecture:** One `vitest.config.ts` per workspace, each resolving `@/*` through `vite-tsconfig-paths`. `apps/web` splits into two inline Vitest projects (`node` default, `dom` for jsdom) because Vitest 4 removed `environmentMatchGlobs`. Shared test helpers live in `apps/web/test-utils/`. Turbo gets `test` and `test:coverage` tasks; `check.yml` runs the tests, `sonar.yml` produces and uploads coverage.
+
+**Tech Stack:** Vitest 4, `@vitest/coverage-v8`, jsdom 30, Testing Library (React 16.3 / user-event 14.6), `@vitejs/plugin-react` 6, `vite-tsconfig-paths` 6, `@react-email/render` 2, Turbo 2, pnpm 11, GitButler CLI (`but`) for commits.
+
+**Spec:** `docs/superpowers/specs/2026-08-25-web-296-unit-tests-design.md`
+
+## Global Constraints
+
+- Node `^24.19.0`, pnpm `11.22.0` — do not change `.nvmrc` or `packageManager`.
+- Test files live next to their source: `foo.ts` → `foo.test.ts`.
+- No `globals: true`. Every test file imports `describe`, `expect`, `it`, `vi` from `vitest` explicitly.
+- Exact dependency floors: `vitest@^4.1.11`, `@vitest/coverage-v8@^4.1.11`, `jsdom@^30.0.1`, `@testing-library/react@^16.3.2`, `@testing-library/user-event@^14.6.6`, `@vitejs/plugin-react@^6.1.0`, `vite-tsconfig-paths@^6.1.1`, `@react-email/render@^2.1.0`.
+- `packages/email/.react-email/**` is generated and gitignored — it must never be picked up by a test run.
+- Object literals must be written with alphabetically sorted keys; the repo's `oxlint` config has `sort-keys` active.
+- Commits go through the GitButler CLI (`but commit`), never `git commit`. Branch name: `test/web-296-unit-tests`.
+- Conventional Commits, no `Co-Authored-By` and no generator trailer in any commit message.
+- After every task: `pnpm run lint` and `pnpm run format:check` must stay clean.
+
+## Deviations from the spec (deliberate, agreed at plan time)
+
+1. **`packages/shared` gets only its `node` project in this PR.** The spec also lists a jsdom project for the icon/logo components. An inline Vitest project whose `include` matches no file fails the run, and no icon test exists until PR 5 — so the jsdom project is added by the PR that adds the first icon test.
+2. **Three test files land earlier than their spec PR**, because each is the cheapest honest proof that a piece of infrastructure works: `apps/web/src/utils/typography.test.ts` (node project, PR 2 in the spec), `apps/web/src/hooks/use-media-query.test.ts` (dom project + `matchMedia` stub, PR 4), `apps/web/src/utils/url.test.ts` (env helper, PR 2) and `apps/studio/utils/time.test.ts` + `packages/email/lib/cleverreach-markers.test.ts` (PR 5). The later PRs drop those files from their scope; everything else in them stays as specced.
+3. **The `überprüfe` grammar fix ships without a test in this PR** (its guard is the action test in PR 3). It is a one-word copy fix and blocking it on PR 3's mock setup would leave two spellings in `main` for no gain.
+
+---
+
+### Task 1: Branch and land the spec
+
+**Files:**
+- Commit (already written): `docs/superpowers/specs/2026-08-25-web-296-unit-tests-design.md`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: branch `test/web-296-unit-tests` holding every later commit of this plan.
+
+- [ ] **Step 1: Check the workspace state**
+
+Run: `but status`
+Expected: the spec file and this plan file show as uncommitted changes.
+
+- [ ] **Step 2: Commit spec and plan onto a new branch**
+
+```bash
+but commit -b test/web-296-unit-tests \
+  -m "docs(web): add the unit test design and infra plan for WEB-296" \
+  docs/superpowers/specs/2026-08-25-web-296-unit-tests-design.md \
+  docs/superpowers/plans/2026-08-25-web-296-unit-tests-pr1-infra.md
+```
+
+- [ ] **Step 3: Verify the branch exists and holds one commit**
+
+Run: `but branch show test/web-296-unit-tests`
+Expected: one commit, the two docs files.
+
+---
+
+### Task 2: Vitest in `packages/shared` and the `date.ts` fix
+
+The smallest workspace goes first: it proves the runner, the coverage provider and the lint override before any framework glue is involved. The `date.ts` bug is fixed here because its test is the regression guard.
+
+**Files:**
+- Modify: `package.json` (root devDependencies)
+- Modify: `oxlint.config.ts` (test-file override)
+- Create: `packages/shared/vitest.config.ts`
+- Modify: `packages/shared/package.json` (scripts)
+- Create: `packages/shared/src/utils/date.test.ts`
+- Modify: `packages/shared/src/utils/date.ts:6-7`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: the pattern every other workspace config copies — `defineConfig` from `vitest/config`, `tsconfigPaths()` plugin, `include: ['**/*.test.{ts,tsx}']`, workspace scripts `test`, `test:watch`, `test:coverage`.
+
+- [ ] **Step 1: Install the runner at the root**
+
+```bash
+pnpm add -Dw vitest@^4.1.11 @vitest/coverage-v8@^4.1.11
+```
+
+- [ ] **Step 2: Add the test-file lint override**
+
+In `oxlint.config.ts`, add this object as the **first** entry of the existing `overrides` array (before the `**/*.tsx` entry):
+
+```ts
+		{
+			files: ['**/*.test.ts', '**/*.test.tsx', '**/test-utils/**', '**/vitest.config.ts'],
+			rules: {
+				'max-lines': 'off',
+				'max-lines-per-function': 'off',
+				'no-magic-numbers': 'off',
+				'sort-keys': 'off',
+			},
+		},
+```
+
+Rationale: test suites are long by nature, are full of literal numbers, and `describe` bodies are one big function. Without this every test file would need a disable comment header.
+
+- [ ] **Step 3: Create the shared workspace config**
+
+Create `packages/shared/vitest.config.ts`:
+
+```ts
+import tsconfigPaths from 'vite-tsconfig-paths';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	plugins: [tsconfigPaths()],
+	test: {
+		environment: 'node',
+		include: ['src/**/*.test.{ts,tsx}'],
+		name: 'shared',
+	},
+});
+```
+
+- [ ] **Step 4: Add the workspace dependency and scripts**
+
+```bash
+pnpm --filter @tsgi-web/shared add -D vite-tsconfig-paths@^6.1.1
+```
+
+Then add to `packages/shared/package.json` `scripts` (keep the keys alphabetically sorted with the existing ones):
+
+```json
+		"test": "vitest run",
+		"test:coverage": "vitest run --coverage",
+		"test:watch": "vitest"
+```
+
+- [ ] **Step 5: Write the failing test**
+
+Create `packages/shared/src/utils/date.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+
+import { MS_PER_SECOND, TIME_SPAN_IN_SECONDS, timeSpanInMilliSeconds } from './date';
+
+const SECONDS_PER_MINUTE = 60;
+const MINUTES_PER_HOUR = 60;
+const HOURS_PER_DAY = 24;
+const DAYS_PER_WEEK = 7;
+const DAYS_PER_MONTH = 30;
+const DAYS_PER_YEAR = 365;
+
+describe('TIME_SPAN_IN_SECONDS', () => {
+	it('holds one second', () => {
+		expect(TIME_SPAN_IN_SECONDS.second).toBe(1);
+	});
+
+	it('holds a minute in seconds', () => {
+		expect(TIME_SPAN_IN_SECONDS.minute).toBe(SECONDS_PER_MINUTE);
+	});
+
+	it('holds an hour in seconds', () => {
+		expect(TIME_SPAN_IN_SECONDS.hour).toBe(SECONDS_PER_MINUTE * MINUTES_PER_HOUR);
+	});
+
+	it('holds a day in seconds', () => {
+		expect(TIME_SPAN_IN_SECONDS.day).toBe(SECONDS_PER_MINUTE * MINUTES_PER_HOUR * HOURS_PER_DAY);
+	});
+
+	it('holds a week as seven days', () => {
+		expect(TIME_SPAN_IN_SECONDS.week).toBe(TIME_SPAN_IN_SECONDS.day * DAYS_PER_WEEK);
+	});
+
+	it('holds a month as thirty days', () => {
+		expect(TIME_SPAN_IN_SECONDS.month).toBe(TIME_SPAN_IN_SECONDS.day * DAYS_PER_MONTH);
+	});
+
+	it('holds a year as 365 days', () => {
+		expect(TIME_SPAN_IN_SECONDS.year).toBe(TIME_SPAN_IN_SECONDS.day * DAYS_PER_YEAR);
+	});
+});
+
+describe('timeSpanInMilliSeconds', () => {
+	it('converts a span to milliseconds', () => {
+		expect(timeSpanInMilliSeconds('minute')).toBe(SECONDS_PER_MINUTE * MS_PER_SECOND);
+	});
+
+	it('converts the smallest span', () => {
+		expect(timeSpanInMilliSeconds('second')).toBe(MS_PER_SECOND);
+	});
+});
+```
+
+- [ ] **Step 6: Run it and watch the two wrong constants fail**
+
+Run: `pnpm --filter @tsgi-web/shared test`
+Expected: FAIL — `hour` expected `3600` received `360`, `day` expected `86400` received `8640`, plus the `week`/`month`/`year` cases that are derived from `day`. Every other case passes.
+
+- [ ] **Step 7: Fix the constants**
+
+In `packages/shared/src/utils/date.ts`, change the two wrong values:
+
+```ts
+	hour: 3600,
+	day: 86_400,
+```
+
+Leave `week: 604_800`, `month: 2_592_000` and `year: 31_536_000` untouched — they are already the 7-, 30- and 365-day values.
+
+- [ ] **Step 8: Run the test again**
+
+Run: `pnpm --filter @tsgi-web/shared test`
+Expected: PASS, 9 tests.
+
+- [ ] **Step 9: Verify coverage works**
+
+Run: `pnpm --filter @tsgi-web/shared test:coverage`
+Expected: PASS plus a coverage table, and `packages/shared/coverage/lcov.info` exists.
+
+- [ ] **Step 10: Verify nothing else broke**
+
+Run: `pnpm run lint && pnpm run format:check && pnpm run typecheck`
+Expected: all clean. `date.ts` is consumed only by `number-ticker.tsx` (`second`) and `cleverreach.ts` (`minute`), so the corrected values change no behavior.
+
+- [ ] **Step 11: Commit**
+
+```bash
+but commit -b test/web-296-unit-tests \
+  -m "test(shared): set up vitest and cover the time span constants" \
+  -m "The hour and day spans were off by a factor of ten. Only second and minute are used today, so the correction is behavior neutral."
+```
+
+---
+
+### Task 3: The `node` project in `apps/web`
+
+**Files:**
+- Create: `apps/web/vitest.config.ts`
+- Modify: `apps/web/package.json` (devDependencies, scripts)
+- Create: `apps/web/src/utils/typography.test.ts`
+
+**Interfaces:**
+- Consumes: the config pattern from Task 2.
+- Produces: `apps/web/vitest.config.ts` with an `assetStub` plugin and a `node` project; Task 4 adds the `dom` project to the same file.
+
+- [ ] **Step 1: Add the web devDependencies**
+
+```bash
+pnpm --filter web add -D vite-tsconfig-paths@^6.1.1
+```
+
+- [ ] **Step 2: Create the web config with the asset stub**
+
+Create `apps/web/vitest.config.ts`. The `assetStub` plugin exists because `src/utils/groups.ts` imports `.webp` files, which Vite cannot resolve into a module on its own; the stub mirrors the object Next.js injects for a static image import.
+
+```ts
+import type { Plugin } from 'vite';
+import tsconfigPaths from 'vite-tsconfig-paths';
+import { defineConfig } from 'vitest/config';
+
+const ASSET_PATTERN = /\.(?:avif|gif|jpe?g|png|svg|webp)$/u;
+
+/**
+ * Resolves static image imports to the object Next.js injects for them, so modules that import
+ * an image (for example `src/utils/groups.ts`) can be loaded in a test run.
+ */
+function assetStub(): Plugin {
+	return {
+		enforce: 'pre',
+		load(id) {
+			if (!ASSET_PATTERN.test(id)) {
+				return null;
+			}
+			return `export default { blurDataURL: '', blurWidth: 0, height: 1, src: '${id}', width: 1 };`;
+		},
+		name: 'tsgi:asset-stub',
+		resolveId(source) {
+			return ASSET_PATTERN.test(source) ? source : null;
+		},
+	};
+}
+
+export default defineConfig({
+	plugins: [assetStub(), tsconfigPaths()],
+	test: {
+		projects: [
+			{
+				extends: true,
+				test: {
+					environment: 'node',
+					exclude: ['src/components/**', 'src/hooks/**', 'node_modules/**'],
+					include: ['src/**/*.test.{ts,tsx}'],
+					name: { color: 'green', label: 'node' },
+				},
+			},
+		],
+	},
+});
+```
+
+- [ ] **Step 3: Add the web scripts**
+
+Add to `apps/web/package.json` `scripts`, keeping alphabetical order with the existing keys:
+
+```json
+		"test": "vitest run",
+		"test:coverage": "vitest run --coverage",
+		"test:watch": "vitest"
+```
+
+- [ ] **Step 4: Write the failing test**
+
+Create `apps/web/src/utils/typography.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+
+import { capitalizeString, capitalizeWords } from './typography';
+
+describe('capitalizeString', () => {
+	it('capitalizes the first letter', () => {
+		expect(capitalizeString('fußball')).toBe('Fußball');
+	});
+
+	it('leaves an already capitalized string alone', () => {
+		expect(capitalizeString('Fußball')).toBe('Fußball');
+	});
+
+	it('returns an empty string for an empty input', () => {
+		expect(capitalizeString('')).toBe('');
+	});
+
+	it('handles a single character', () => {
+		expect(capitalizeString('a')).toBe('A');
+	});
+
+	it('keeps the rest of the string untouched', () => {
+		expect(capitalizeString('kinderTURNEN')).toBe('KinderTURNEN');
+	});
+});
+
+describe('capitalizeWords', () => {
+	it('capitalizes every hyphen separated word', () => {
+		expect(capitalizeWords('weitere-sportarten')).toBe('Weitere Sportarten');
+	});
+
+	it('lowercases the remainder of each word', () => {
+		expect(capitalizeWords('WEITERE-SPORTARTEN')).toBe('Weitere Sportarten');
+	});
+
+	it('accepts a custom separator', () => {
+		expect(capitalizeWords('weitere sportarten', ' ')).toBe('Weitere Sportarten');
+	});
+
+	it('returns an empty string for an empty input', () => {
+		expect(capitalizeWords('')).toBe('');
+	});
+
+	it('handles a single word', () => {
+		expect(capitalizeWords('taekwondo')).toBe('Taekwondo');
+	});
+});
+```
+
+- [ ] **Step 5: Run it**
+
+Run: `pnpm --filter web test`
+Expected: PASS, 10 tests, reported under the `node` project label. If it fails to resolve `./typography`, the `tsconfigPaths()` plugin is missing from the config.
+
+- [ ] **Step 6: Prove the asset stub works**
+
+Run: `pnpm --filter web exec vitest run --project node src/utils/typography.test.ts`
+Expected: PASS. Then, as a throwaway check that image imports load, run:
+
+```bash
+pnpm --filter web exec vitest run --project node --reporter=dot \
+  --testNamePattern='nothing' src/utils
+```
+
+Expected: no test matches, but **no import error** — which is the point: `groups.ts` and its `.webp` imports were collected without failing. If you see `Failed to load url ... hero.webp`, the `assetStub` plugin is not being applied.
+
+- [ ] **Step 7: Lint, format, typecheck**
+
+Run: `pnpm run lint && pnpm run format:check && pnpm run typecheck`
+Expected: clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+but commit -b test/web-296-unit-tests \
+  -m "test(web): add the vitest node project and cover typography"
+```
+
+---
+
+### Task 4: The `dom` project in `apps/web`
+
+**Files:**
+- Modify: `apps/web/vitest.config.ts` (second project)
+- Create: `apps/web/test-utils/setup-dom.ts`
+- Modify: `apps/web/package.json` (devDependencies)
+- Create: `apps/web/src/hooks/use-media-query.test.ts`
+
+**Interfaces:**
+- Consumes: `apps/web/vitest.config.ts` from Task 3.
+- Produces: `apps/web/test-utils/setup-dom.ts`, which exports `createMatchMediaStub(matches: boolean): (query: string) => MediaQueryList` and registers `window.matchMedia`, `ResizeObserver` and `IntersectionObserver`. PR 4's component tests rely on both.
+
+- [ ] **Step 1: Add the DOM dependencies**
+
+```bash
+pnpm --filter web add -D jsdom@^30.0.1 @testing-library/react@^16.3.2 \
+  @testing-library/user-event@^14.6.6 @vitejs/plugin-react@^6.1.0
+```
+
+- [ ] **Step 2: Write the DOM setup file**
+
+Create `apps/web/test-utils/setup-dom.ts`:
+
+```ts
+import { vi } from 'vitest';
+
+type MediaQueryListener = (event: MediaQueryListEvent) => void;
+
+/**
+ * Builds a `matchMedia` implementation whose `matches` value is fixed and whose listeners can be
+ * triggered from a test through `dispatchMediaQueryChange`.
+ */
+function createMatchMediaStub(matches: boolean): (query: string) => MediaQueryList {
+	return (query: string) => {
+		const listeners = new Set<MediaQueryListener>();
+
+		const list = {
+			addEventListener: (_type: string, listener: MediaQueryListener) => {
+				listeners.add(listener);
+			},
+			dispatchEvent: () => true,
+			listeners,
+			matches,
+			media: query,
+			onchange: null,
+			removeEventListener: (_type: string, listener: MediaQueryListener) => {
+				listeners.delete(listener);
+			},
+		};
+
+		return list as unknown as MediaQueryList;
+	};
+}
+
+/** Fires a `change` event on every listener registered for the given media query list. */
+function dispatchMediaQueryChange(list: MediaQueryList, matches: boolean): void {
+	const { listeners } = list as unknown as { listeners: Set<MediaQueryListener> };
+	for (const listener of listeners) {
+		listener({ matches } as MediaQueryListEvent);
+	}
+}
+
+class ObserverStub {
+	disconnect(): void {
+		// no-op
+	}
+
+	observe(): void {
+		// no-op
+	}
+
+	unobserve(): void {
+		// no-op
+	}
+}
+
+vi.stubGlobal('matchMedia', createMatchMediaStub(false));
+vi.stubGlobal('ResizeObserver', ObserverStub);
+vi.stubGlobal('IntersectionObserver', ObserverStub);
+
+export { createMatchMediaStub, dispatchMediaQueryChange };
+```
+
+- [ ] **Step 3: Add the `dom` project to the web config**
+
+In `apps/web/vitest.config.ts`, import the React plugin and append the second project after the `node` one:
+
+```ts
+import react from '@vitejs/plugin-react';
+```
+
+```ts
+			{
+				extends: true,
+				plugins: [react()],
+				test: {
+					environment: 'jsdom',
+					include: ['src/{components,hooks}/**/*.test.{ts,tsx}'],
+					name: { color: 'magenta', label: 'dom' },
+					setupFiles: ['./test-utils/setup-dom.ts'],
+				},
+			},
+```
+
+- [ ] **Step 4: Write the failing test**
+
+Create `apps/web/src/hooks/use-media-query.test.ts`:
+
+```ts
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createMatchMediaStub, dispatchMediaQueryChange } from '../../test-utils/setup-dom';
+import { useMediaQuery } from './use-media-query';
+
+const QUERY = '(max-width: 48rem)';
+
+afterEach(() => {
+	vi.stubGlobal('matchMedia', createMatchMediaStub(false));
+});
+
+describe('useMediaQuery', () => {
+	it('returns false when the query does not match', () => {
+		const { result } = renderHook(() => useMediaQuery(QUERY));
+		expect(result.current).toBe(false);
+	});
+
+	it('returns true when the query matches on mount', () => {
+		vi.stubGlobal('matchMedia', createMatchMediaStub(true));
+		const { result } = renderHook(() => useMediaQuery(QUERY));
+		expect(result.current).toBe(true);
+	});
+
+	it('updates when the media query changes', () => {
+		const { result } = renderHook(() => useMediaQuery(QUERY));
+		const list = window.matchMedia(QUERY);
+
+		act(() => {
+			dispatchMediaQueryChange(list, true);
+		});
+
+		expect(result.current).toBe(true);
+	});
+
+	it('removes its listener on unmount', () => {
+		const { unmount } = renderHook(() => useMediaQuery(QUERY));
+		const list = window.matchMedia(QUERY);
+		const { listeners } = list as unknown as { listeners: Set<unknown> };
+
+		unmount();
+
+		expect(listeners.size).toBe(0);
+	});
+});
+```
+
+Note on the third and fourth case: the hook registers its listener on the `MediaQueryList` it created itself, so the test asks `window.matchMedia` for a list and drives that one. The stub returns a fresh list per call but shares the listener set per call — if the assertion fails because the sets differ, make `createMatchMediaStub` cache one list per query string in a `Map` and return the cached instance.
+
+- [ ] **Step 5: Run it**
+
+Run: `pnpm --filter web test`
+Expected: 10 node tests plus 4 dom tests PASS. `matchMedia is not a function` means `setupFiles` is not wired; `document is not defined` means the file was matched by the `node` project instead — check the `exclude` in Task 3 Step 2.
+
+- [ ] **Step 6: Lint, format, typecheck**
+
+Run: `pnpm run lint && pnpm run format:check && pnpm run typecheck`
+Expected: clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+but commit -b test/web-296-unit-tests \
+  -m "test(web): add the jsdom project and cover the media query hook"
+```
+
+---
+
+### Task 5: Test helpers for env and fetch
+
+**Files:**
+- Create: `apps/web/test-utils/env.ts`
+- Create: `apps/web/test-utils/fetch-mock.ts`
+- Create: `apps/web/src/utils/url.test.ts`
+
+**Interfaces:**
+- Consumes: the `node` project from Task 3.
+- Produces:
+  - `loadWithEnv<T>(specifier: string, vars: Record<string, string | undefined>): Promise<T>` — resets the module registry, stubs the given variables, then imports the module fresh. Needed because `src/lib/env.ts` caches validated values in a module-level `Map`.
+  - `createFetchMock(): { calls: FetchCall[]; enqueue(response: MockResponse): void; enqueueJson(body: unknown, init?: { status?: number }): void; restore(): void }` where `FetchCall = { body: string | undefined; headers: Record<string, string>; method: string; url: string }`. PR 3 builds all action and CleverReach tests on this.
+
+- [ ] **Step 1: Write the env helper**
+
+Create `apps/web/test-utils/env.ts`:
+
+```ts
+import { vi } from 'vitest';
+
+/**
+ * Imports a module with a fresh module registry and the given environment variables in place.
+ *
+ * `src/lib/env.ts` caches every validated value in a module level `Map`, so a test that needs a
+ * different value has to reset the registry before importing the consumer.
+ */
+async function loadWithEnv<T>(
+	specifier: string,
+	vars: Record<string, string | undefined>,
+): Promise<T> {
+	vi.resetModules();
+	vi.unstubAllEnvs();
+
+	for (const [key, value] of Object.entries(vars)) {
+		vi.stubEnv(key, value);
+	}
+
+	return (await import(specifier)) as T;
+}
+
+export { loadWithEnv };
+```
+
+- [ ] **Step 2: Write the fetch helper**
+
+Create `apps/web/test-utils/fetch-mock.ts`:
+
+```ts
+import { vi } from 'vitest';
+
+interface FetchCall {
+	body: string | undefined;
+	headers: Record<string, string>;
+	method: string;
+	url: string;
+}
+
+interface MockResponse {
+	body: string;
+	status: number;
+}
+
+/**
+ * Replaces the global `fetch` with a queue of canned responses and records every request.
+ *
+ * Responses are handed out in the order they were enqueued, which keeps the tests of the multi
+ * request flows (token, then receiver, then DOI mail) readable.
+ */
+function createFetchMock(): {
+	calls: FetchCall[];
+	enqueue: (response: MockResponse) => void;
+	enqueueJson: (body: unknown, init?: { status?: number }) => void;
+	restore: () => void;
+} {
+	const calls: FetchCall[] = [];
+	const queue: MockResponse[] = [];
+
+	const fetchMock = vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+		calls.push({
+			body: typeof init?.body === 'string' ? init.body : undefined,
+			headers: { ...(init?.headers as Record<string, string> | undefined) },
+			method: init?.method ?? 'GET',
+			url: String(input),
+		});
+
+		const next = queue.shift();
+
+		if (!next) {
+			throw new Error(`No mock response queued for ${String(input)}`);
+		}
+
+		return Promise.resolve(new Response(next.body, { status: next.status }));
+	});
+
+	vi.stubGlobal('fetch', fetchMock);
+
+	return {
+		calls,
+		enqueue: (response: MockResponse) => {
+			queue.push(response);
+		},
+		enqueueJson: (body: unknown, init?: { status?: number }) => {
+			queue.push({ body: JSON.stringify(body), status: init?.status ?? 200 });
+		},
+		restore: () => {
+			vi.unstubAllGlobals();
+		},
+	};
+}
+
+export { createFetchMock, type FetchCall, type MockResponse };
+```
+
+- [ ] **Step 3: Write the failing test that exercises the env helper**
+
+Create `apps/web/src/utils/url.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+
+import { loadWithEnv } from '../../test-utils/env';
+
+type UrlModule = typeof import('./url');
+
+const GOOGLE_MAPS_PREFIX = 'https://www.google.com/maps/search/?api=1&query=';
+
+const VENUE = {
+	city: 'Neuwied',
+	houseNumber: '12',
+	name: 'Sporthalle Irlich',
+	street: 'Pappelweg',
+	zipCode: '56567',
+};
+
+describe('getBaseUrl', () => {
+	it('prefers the Vercel production URL', async () => {
+		const { getBaseUrl } = await loadWithEnv<UrlModule>('./url', {
+			NODE_ENV: 'production',
+			VERCEL_PROJECT_PRODUCTION_URL: 'tsg-irlich.vercel.app',
+		});
+
+		expect(getBaseUrl()).toBe('https://tsg-irlich.vercel.app');
+	});
+
+	it('falls back to the live domain in production', async () => {
+		const { getBaseUrl } = await loadWithEnv<UrlModule>('./url', {
+			NODE_ENV: 'production',
+			VERCEL_PROJECT_PRODUCTION_URL: undefined,
+		});
+
+		expect(getBaseUrl()).toBe('https://www.tsg-irlich.de');
+	});
+
+	it('falls back to localhost outside production', async () => {
+		const { getBaseUrl } = await loadWithEnv<UrlModule>('./url', {
+			NODE_ENV: 'development',
+			VERCEL_PROJECT_PRODUCTION_URL: undefined,
+		});
+
+		expect(getBaseUrl()).toBe('http://localhost:3000');
+	});
+});
+
+describe('printGoogleMapsLink', () => {
+	it('builds a search URL from the full address', async () => {
+		const { printGoogleMapsLink } = await loadWithEnv<UrlModule>('./url', {});
+
+		expect(printGoogleMapsLink(VENUE)).toBe(
+			`${GOOGLE_MAPS_PREFIX}${encodeURIComponent('Sporthalle Irlich, Pappelweg 12, 56567 Neuwied')}`,
+		);
+	});
+
+	it('skips an empty venue name', async () => {
+		const { printGoogleMapsLink } = await loadWithEnv<UrlModule>('./url', {});
+
+		expect(printGoogleMapsLink({ ...VENUE, name: '' })).toBe(
+			`${GOOGLE_MAPS_PREFIX}${encodeURIComponent('Pappelweg 12, 56567 Neuwied')}`,
+		);
+	});
+
+	it('skips an empty zip code', async () => {
+		const { printGoogleMapsLink } = await loadWithEnv<UrlModule>('./url', {});
+
+		expect(printGoogleMapsLink({ ...VENUE, zipCode: '' })).toBe(
+			`${GOOGLE_MAPS_PREFIX}${encodeURIComponent('Sporthalle Irlich, Pappelweg 12, Neuwied')}`,
+		);
+	});
+});
+```
+
+Before running, open `apps/web/src/constants/urls.ts` and confirm `GOOGLE_MAPS_URL` equals the `GOOGLE_MAPS_PREFIX` above. If it differs, import the constant instead of duplicating it.
+
+- [ ] **Step 4: Run it**
+
+Run: `pnpm --filter web test src/utils/url.test.ts`
+Expected: PASS, 6 tests. A thrown `Invalid environment variable …` means `loadWithEnv` was called without the variable that branch needs.
+
+- [ ] **Step 5: Prove the fetch helper compiles and behaves**
+
+Run: `pnpm run typecheck`
+Expected: clean — this is the only check the fetch helper gets in this PR; PR 3 is its first consumer.
+
+- [ ] **Step 6: Lint and format**
+
+Run: `pnpm run lint && pnpm run format:check`
+Expected: clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+but commit -b test/web-296-unit-tests \
+  -m "test(web): add env and fetch test helpers and cover the url utils"
+```
+
+---
+
+### Task 6: Vitest in `apps/studio`
+
+**Files:**
+- Create: `apps/studio/vitest.config.ts`
+- Modify: `apps/studio/package.json` (devDependencies, scripts)
+- Create: `apps/studio/utils/time.test.ts`
+
+**Interfaces:**
+- Consumes: the config pattern from Task 2.
+- Produces: a jsdom-based studio project; PR 5 adds schema and plugin tests to it.
+
+- [ ] **Step 1: Add the dependencies**
+
+```bash
+pnpm --filter studio add -D jsdom@^30.0.1 @vitejs/plugin-react@^6.1.0 \
+  vite-tsconfig-paths@^6.1.1
+```
+
+- [ ] **Step 2: Create the config**
+
+Create `apps/studio/vitest.config.ts`. Note the studio's `@/*` alias points at the package root, not `src`, and its `exclude` has to keep `dist` and the Sanity caches out.
+
+```ts
+import react from '@vitejs/plugin-react';
+import tsconfigPaths from 'vite-tsconfig-paths';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	plugins: [react(), tsconfigPaths()],
+	test: {
+		environment: 'jsdom',
+		exclude: ['dist/**', 'node_modules/**', '.sanity/**'],
+		include: ['**/*.test.{ts,tsx}'],
+		name: 'studio',
+	},
+});
+```
+
+- [ ] **Step 3: Add the scripts**
+
+Add to `apps/studio/package.json` `scripts`, alphabetically:
+
+```json
+		"test": "vitest run",
+		"test:coverage": "vitest run --coverage",
+		"test:watch": "vitest"
+```
+
+- [ ] **Step 4: Write the failing test**
+
+Create `apps/studio/utils/time.test.ts`. `formatDate` calls `toISOString`, so the expectations are timezone dependent — the suite pins `TZ` to `UTC` and adds one case that documents the behavior for a late evening local time.
+
+```ts
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { formatDate } from './time';
+
+beforeAll(() => {
+	vi.stubEnv('TZ', 'UTC');
+});
+
+afterAll(() => {
+	vi.unstubAllEnvs();
+});
+
+describe('formatDate', () => {
+	it('formats a Date as a two digit year date', () => {
+		expect(formatDate(new Date('2026-08-25T10:00:00.000Z'))).toBe('26-08-25');
+	});
+
+	it('formats an ISO string', () => {
+		expect(formatDate('2026-01-01T00:00:00.000Z')).toBe('26-01-01');
+	});
+
+	it('formats a plain date string', () => {
+		expect(formatDate('2026-12-31')).toBe('26-12-31');
+	});
+
+	it('uses UTC, so a UTC timestamp keeps its calendar day', () => {
+		expect(formatDate('2026-08-25T23:30:00.000Z')).toBe('26-08-25');
+	});
+});
+```
+
+- [ ] **Step 5: Run it**
+
+Run: `pnpm --filter studio test`
+Expected: PASS, 4 tests. If the last case reports `26-08-26`, the process timezone is not UTC — set it in the config instead (`test.env: { TZ: 'UTC' }`) and drop the `stubEnv` calls, because `vi.stubEnv('TZ', …)` does not re-initialize Node's already-resolved timezone.
+
+- [ ] **Step 6: Lint, format, typecheck**
+
+Run: `pnpm run lint && pnpm run format:check && pnpm run typecheck`
+Expected: clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+but commit -b test/web-296-unit-tests \
+  -m "test(studio): set up vitest and cover the date formatting"
+```
+
+---
+
+### Task 7: Vitest in `packages/email`
+
+**Files:**
+- Create: `packages/email/vitest.config.ts`
+- Modify: `packages/email/package.json` (devDependencies, scripts)
+- Create: `packages/email/lib/cleverreach-markers.test.ts`
+
+**Interfaces:**
+- Consumes: the config pattern from Task 2.
+- Produces: an email project whose `exclude` keeps the generated `.react-email` specs out; PR 5 adds the template tests to it.
+
+- [ ] **Step 1: Add the dependencies**
+
+```bash
+pnpm --filter @tsgi-web/email add -D @react-email/render@^2.1.0 \
+  @vitejs/plugin-react@^6.1.0
+```
+
+- [ ] **Step 2: Create the config**
+
+Create `packages/email/vitest.config.ts`. The `exclude` entry for `.react-email` is mandatory: that generated directory ships its own `*.spec.*` files.
+
+```ts
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	plugins: [react()],
+	test: {
+		environment: 'node',
+		exclude: ['.react-email/**', 'node_modules/**'],
+		include: ['{components,emails,lib,scripts}/**/*.test.{ts,tsx}'],
+		name: 'email',
+	},
+});
+```
+
+- [ ] **Step 3: Add the scripts**
+
+Add to `packages/email/package.json` `scripts`, alphabetically:
+
+```json
+		"test": "vitest run",
+		"test:coverage": "vitest run --coverage",
+		"test:watch": "vitest"
+```
+
+- [ ] **Step 4: Write the failing test**
+
+Create `packages/email/lib/cleverreach-markers.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest';
+
+import { marker, stripCleverReachMarkers, toCleverReachTemplate } from './cleverreach-markers';
+
+describe('marker', () => {
+	it('builds a marker without attributes', () => {
+		expect(marker('html')).toBe('@@CR|html@@');
+	});
+
+	it('appends every attribute', () => {
+		expect(marker('img', { name: 'hero', src: 'logo.png' })).toBe(
+			'@@CR|img|name=hero|src=logo.png@@',
+		);
+	});
+
+	it('drops attributes that are undefined', () => {
+		expect(marker('img', { name: 'hero', src: undefined })).toBe('@@CR|img|name=hero@@');
+	});
+});
+
+describe('toCleverReachTemplate', () => {
+	it('turns a marker into a CleverReach comment', () => {
+		expect(toCleverReachTemplate('<p>@@CR|html@@</p>')).toBe('<p><!--#html#--></p>');
+	});
+
+	it('renders attributes as HTML attributes', () => {
+		expect(toCleverReachTemplate('@@CR|img|name=hero@@')).toBe('<!--#img name="hero"#-->');
+	});
+
+	it('converts every marker in the document', () => {
+		expect(toCleverReachTemplate('@@CR|html@@ and @@CR|loopitem@@')).toBe(
+			'<!--#html#--> and <!--#loopitem#-->',
+		);
+	});
+
+	it('removes the separators React inserts between children', () => {
+		expect(toCleverReachTemplate('a<!-- -->b')).toBe('ab');
+	});
+
+	it('leaves HTML without markers untouched', () => {
+		expect(toCleverReachTemplate('<p>Hallo TSG-Familie!</p>')).toBe('<p>Hallo TSG-Familie!</p>');
+	});
+});
+
+describe('stripCleverReachMarkers', () => {
+	it('removes a marker and keeps the surrounding HTML', () => {
+		expect(stripCleverReachMarkers('<p>@@CR|html@@Text</p>')).toBe('<p>Text</p>');
+	});
+
+	it('removes every marker', () => {
+		expect(stripCleverReachMarkers('@@CR|html@@a@@CR|img|name=hero@@b')).toBe('ab');
+	});
+
+	it('leaves HTML without markers untouched', () => {
+		expect(stripCleverReachMarkers('<p>Text</p>')).toBe('<p>Text</p>');
+	});
+});
+```
+
+- [ ] **Step 5: Run it**
+
+Run: `pnpm --filter @tsgi-web/email test`
+Expected: PASS, 11 tests.
+
+- [ ] **Step 6: Confirm the generated specs stayed out**
+
+Run: `pnpm --filter @tsgi-web/email test --reporter=verbose`
+Expected: only `lib/cleverreach-markers.test.ts` in the file list. Any `.react-email/...spec.ts` entry means the `exclude` is wrong.
+
+- [ ] **Step 7: Lint, format, typecheck**
+
+Run: `pnpm run lint && pnpm run format:check && pnpm run typecheck`
+Expected: clean. `packages/email`'s `build` script is `tsc --noEmit`, so the new test file is type-checked by it too.
+
+- [ ] **Step 8: Commit**
+
+```bash
+but commit -b test/web-296-unit-tests \
+  -m "test(email): set up vitest and cover the cleverreach markers"
+```
+
+---
+
+### Task 8: Fix the newsletter error copy
+
+**Files:**
+- Modify: `apps/web/src/actions/subscribe-to-newsletter.ts:82`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: a single German copy string that PR 3's action test asserts.
+
+- [ ] **Step 1: Find both spellings**
+
+Run: `grep -rn "überprüf" apps/web/src`
+Expected: two hits — `ERROR_MESSAGES.VALIDATION_ERROR` with `'Bitte überprüfe Deine Eingaben.'` and the validation branch of `subscribeToNewsletter` with `'Bitte überprüfen Deine Eingaben.'`.
+
+- [ ] **Step 2: Fix the wrong one**
+
+In the validation branch of `subscribeToNewsletter`, change:
+
+```ts
+			message: 'Bitte überprüfen Deine Eingaben.',
+```
+
+to:
+
+```ts
+			message: 'Bitte überprüfe Deine Eingaben.',
+```
+
+- [ ] **Step 3: Verify only one spelling remains**
+
+Run: `grep -rn "überprüfen Deine" apps/web/src`
+Expected: no output.
+
+- [ ] **Step 4: Lint, format, typecheck**
+
+Run: `pnpm run lint && pnpm run format:check && pnpm run typecheck`
+Expected: clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+but commit -b test/web-296-unit-tests \
+  -m "fix(web): use the informal imperative in the newsletter error message"
+```
+
+---
+
+### Task 9: Turbo tasks, root scripts and coverage output
+
+**Files:**
+- Modify: `turbo.json` (tasks)
+- Modify: `package.json` (root scripts)
+- Modify: `.gitignore`
+- Modify: `packages/shared/vitest.config.ts`, `apps/web/vitest.config.ts`, `apps/studio/vitest.config.ts`, `packages/email/vitest.config.ts` (coverage block)
+
+**Interfaces:**
+- Consumes: the four workspace configs and their `test` scripts.
+- Produces: `pnpm run test`, `pnpm run test:affected`, `pnpm run test:coverage` at the root, and one `coverage/lcov.info` per workspace.
+
+- [ ] **Step 1: Add the coverage block to every config**
+
+Add this to the `test` object of all four `vitest.config.ts` files (for `apps/web`, put it in the outer `test` object, not inside a project, so both projects report into one directory):
+
+```ts
+		coverage: {
+			exclude: ['**/*.test.{ts,tsx}', '**/test-utils/**', '**/*.config.ts', '**/*.generated.ts'],
+			provider: 'v8',
+			reporter: ['text', 'lcov'],
+			reportsDirectory: './coverage',
+		},
+```
+
+- [ ] **Step 2: Add the Turbo tasks**
+
+In `turbo.json`, add to `tasks` (keys stay alphabetically sorted, so `test` and `test:coverage` go after `studio#build` and before `typecheck`):
+
+```json
+		"test": {},
+		"test:coverage": {
+			"outputs": ["coverage/**"]
+		},
+```
+
+No `dependsOn` — unit tests need no build output.
+
+- [ ] **Step 3: Add the root scripts**
+
+In the root `package.json` `scripts`, alphabetically after `prepare`:
+
+```json
+		"test": "turbo test",
+		"test:affected": "turbo test --affected",
+		"test:coverage": "turbo test:coverage",
+```
+
+- [ ] **Step 4: Ignore the coverage output**
+
+Add to `.gitignore`:
+
+```
+# test coverage
+coverage
+```
+
+- [ ] **Step 5: Run the whole suite through Turbo**
+
+Run: `pnpm run test`
+Expected: four successful tasks (`web`, `studio`, `@tsgi-web/shared`, `@tsgi-web/email`), 44 tests total (10 typography + 4 media query + 6 url + 9 date + 4 formatDate + 11 markers). Confirm the number against the actual output and use it in the PR description.
+
+- [ ] **Step 6: Run coverage through Turbo**
+
+Run: `pnpm run test:coverage`
+Expected: four `coverage/lcov.info` files exist:
+
+```bash
+ls apps/web/coverage/lcov.info apps/studio/coverage/lcov.info \
+  packages/shared/coverage/lcov.info packages/email/coverage/lcov.info
+```
+
+- [ ] **Step 7: Confirm caching works**
+
+Run: `pnpm run test` twice in a row.
+Expected: the second run reports `FULL TURBO`.
+
+- [ ] **Step 8: Confirm coverage is not committed**
+
+Run: `but status`
+Expected: no `coverage/` entries.
+
+- [ ] **Step 9: Lint, format**
+
+Run: `pnpm run lint && pnpm run format:check`
+Expected: clean.
+
+- [ ] **Step 10: Commit**
+
+```bash
+but commit -b test/web-296-unit-tests \
+  -m "build: run the test suites through turbo and collect coverage"
+```
+
+---
+
+### Task 10: Run the tests in CI
+
+**Files:**
+- Modify: `.github/workflows/check.yml`
+
+**Interfaces:**
+- Consumes: the root `test` script from Task 9.
+- Produces: a PR-blocking test step.
+
+- [ ] **Step 1: Add the test step**
+
+In `.github/workflows/check.yml`, insert between the `Lint files` and `Build files` steps:
+
+```yaml
+      - name: Run tests
+        run: pnpm run test:affected
+        env:
+          NEXT_PUBLIC_SANITY_DATASET: ${{ secrets.SANITY_DATASET }}
+          NEXT_PUBLIC_SANITY_PROJECT_ID: ${{ secrets.SANITY_PROJECT_ID }}
+```
+
+`test:affected` mirrors the existing `lint:affected` / `build:affected` steps. The two Sanity variables are needed because `src/lib/sanity/client.ts` reads them at module load, and the web tests import modules that pull it in.
+
+- [ ] **Step 2: Verify the file parses**
+
+Run: `pnpm exec oxlint .github/workflows/check.yml --no-error-on-unmatched-pattern; python3 -c "import sys,yaml;yaml.safe_load(open('.github/workflows/check.yml'))" && echo "yaml ok"`
+Expected: `yaml ok`.
+
+- [ ] **Step 3: Reproduce the CI command locally**
+
+Run: `pnpm run test:affected`
+Expected: PASS. If the web tests fail with `Invalid environment variable NEXT_PUBLIC_SANITY_…`, note the failing module in the PR description — the fix belongs here, either by adding the variable to the CI env block or by adding a `test.env` default to `apps/web/vitest.config.ts`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+but commit -b test/web-296-unit-tests \
+  -m "ci: run the unit tests on every pull request"
+```
+
+---
+
+### Task 11: Report coverage to SonarQube
+
+**Files:**
+- Modify: `sonar-project.properties`
+- Modify: `.github/workflows/sonar.yml`
+
+**Interfaces:**
+- Consumes: the four `coverage/lcov.info` files from Task 9.
+- Produces: coverage visible in SonarQube, with no minimum threshold.
+
+- [ ] **Step 1: Rewrite the coverage settings**
+
+In `sonar-project.properties`, replace the `sonar.coverage.exclusions=**/*` line with:
+
+```properties
+# Coverage settings
+sonar.javascript.lcov.reportPaths=apps/web/coverage/lcov.info,apps/studio/coverage/lcov.info,packages/shared/coverage/lcov.info,packages/email/coverage/lcov.info
+sonar.test.inclusions=**/*.test.ts,**/*.test.tsx
+sonar.coverage.exclusions=**/*.config.ts,**/test-utils/**,**/*.generated.ts
+```
+
+Keep the existing `sonar.exclusions=**/sanity.types.generated.ts` line as it is. No `sonar.qualitygate` or coverage threshold — that is a follow-up ticket per the spec.
+
+- [ ] **Step 2: Generate coverage before the scan**
+
+In `.github/workflows/sonar.yml`, insert these steps between the `checkout` step and the `SonarQube Scan` step:
+
+```yaml
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          cache: pnpm
+          node-version-file: .nvmrc
+
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Collect Coverage
+        run: pnpm run test:coverage
+        env:
+          NEXT_PUBLIC_SANITY_DATASET: ${{ secrets.SANITY_DATASET }}
+          NEXT_PUBLIC_SANITY_PROJECT_ID: ${{ secrets.SANITY_PROJECT_ID }}
+```
+
+Reuse the exact pinned action SHAs from `check.yml` (copied above) so both workflows stay on one version.
+
+- [ ] **Step 3: Verify the YAML parses**
+
+Run: `python3 -c "import yaml;yaml.safe_load(open('.github/workflows/sonar.yml'))" && echo "yaml ok"`
+Expected: `yaml ok`.
+
+- [ ] **Step 4: Verify the lcov paths exist**
+
+Run: `pnpm run test:coverage && wc -l apps/web/coverage/lcov.info apps/studio/coverage/lcov.info packages/shared/coverage/lcov.info packages/email/coverage/lcov.info`
+Expected: four non-empty files, matching the paths in `sonar-project.properties` exactly.
+
+- [ ] **Step 5: Commit**
+
+```bash
+but commit -b test/web-296-unit-tests \
+  -m "ci: report unit test coverage to sonarqube"
+```
+
+---
+
+### Task 12: Document the setup
+
+**Files:**
+- Modify: `AGENTS.md` (Development Commands, Code Quality Tools)
+- Modify: `apps/web/AGENTS.md`
+- Modify: `apps/studio/AGENTS.md`
+
+**Interfaces:**
+- Consumes: every script added in this PR.
+- Produces: the conventions later PRs and other agents follow.
+
+- [ ] **Step 1: Read the two app guides first**
+
+Run: `sed -n 1,60p apps/web/AGENTS.md; sed -n 1,60p apps/studio/AGENTS.md`
+Match their existing heading style and tone when adding to them.
+
+- [ ] **Step 2: Add a Testing block to the root guide**
+
+In `AGENTS.md`, inside the fenced command block under **Development Commands**, after the Linting section:
+
+```bash
+# Testing
+pnpm run test                        # Run every unit test suite
+pnpm run test:affected               # Only the affected packages
+pnpm run test:coverage               # Run with coverage (lcov per workspace)
+```
+
+Then add this bullet list under **Code Quality Tools**:
+
+```markdown
+- **Vitest** for unit tests, one `vitest.config.ts` per workspace
+  - Tests live next to their source (`foo.ts` → `foo.test.ts`)
+  - Import `describe`/`it`/`expect`/`vi` explicitly — `globals` is off on purpose
+  - `apps/web` splits into a `node` and a `dom` (jsdom) project; component and hook tests land in `dom`
+  - Shared helpers: `apps/web/test-utils/env.ts` (module cache + env vars), `apps/web/test-utils/fetch-mock.ts` (HTTP), `apps/web/test-utils/setup-dom.ts` (matchMedia and observer stubs)
+  - External services are mocked at the `fetch` boundary, not at the module boundary; Resend is the one SDK mock
+```
+
+- [ ] **Step 3: Add the per-app notes**
+
+In `apps/web/AGENTS.md`, add a `## Testing` section describing the two projects, the asset stub for image imports, and the three helpers. In `apps/studio/AGENTS.md`, add a `## Testing` section noting that schema tests call `preview.prepare` and `validation` functions directly on the exported definition objects, with no Sanity runtime.
+
+- [ ] **Step 4: Verify the documented commands actually run**
+
+Run: `pnpm run test && pnpm run test:affected && pnpm run test:coverage`
+Expected: all three succeed exactly as documented.
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+pnpm run format
+but commit -b test/web-296-unit-tests \
+  -m "docs: document the unit test setup and conventions"
+```
+
+---
+
+### Task 13: Open the pull request
+
+**Files:** none.
+
+**Interfaces:**
+- Consumes: every commit on `test/web-296-unit-tests`.
+- Produces: a PR that closes the infra part of WEB-296.
+
+- [ ] **Step 1: Final full verification**
+
+Run: `pnpm run lint && pnpm run format:check && pnpm run typecheck && pnpm run test && pnpm run build`
+Expected: everything green. Record the real test count from the output.
+
+- [ ] **Step 2: Review the branch**
+
+Run: `but branch show test/web-296-unit-tests`
+Expected: twelve commits (docs, shared, web node, web dom, helpers, studio, email, copy fix, turbo, ci, sonar, docs — count from the actual output).
+
+- [ ] **Step 3: Push and open the PR**
+
+Run: `but push` then open the PR against `next` with a body that lists: the four workspace setups, the two bugfixes with their reasoning, the test count, and a note that PRs 2–5 add the actual test coverage per the spec.
+
+- [ ] **Step 4: Update the Linear ticket**
+
+Add a comment on WEB-296 linking the PR and stating that this is PR 1 of 5.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+| Spec item (PR 1 section) | Task |
+| --- | --- |
+| Dependencies and versions | 2, 4, 6, 7 |
+| Four workspace configs, `vite-tsconfig-paths`, project split | 2, 3, 4, 6, 7 |
+| Asset stub for `.webp` imports | 3 |
+| DOM setup (matchMedia, observers, next/image, next/navigation, motion mocks) | 4 — **partial**: only matchMedia and the observers ship here, because the module mocks have no consumer until PR 4's component tests. PR 4 owns them; noted in its plan. |
+| Env helper | 5 |
+| Fetch helper | 5 |
+| Scripts, Turbo tasks | 9 |
+| CI step | 10 |
+| Coverage + Sonar rewiring | 9, 11 |
+| Bugfix `date.ts` | 2 |
+| Bugfix `überprüfe` | 8 |
+
+Also covered beyond the spec: the `oxlint` test-file override (Task 2) and the AGENTS.md documentation (Task 12) — both required for the repo's own gates to stay green.
+
+**Placeholder scan:** no `TBD`/`TODO`; every code step carries the actual code; the only "figure it out" steps are the two recorded numbers (test count) and two named fallbacks (the `matchMedia` per-query cache in Task 4 Step 4, the `TZ` handling in Task 6 Step 5), each with the concrete alternative spelled out.
+
+**Type consistency:** `loadWithEnv` / `createFetchMock` / `createMatchMediaStub` / `dispatchMediaQueryChange` are used in Tasks 4 and 5 with the exact signatures their Interfaces blocks declare; `FetchCall` and `MockResponse` are exported from the same file that defines them.

--- a/docs/superpowers/plans/2026-08-25-web-296-unit-tests-pr1-infra.md
+++ b/docs/superpowers/plans/2026-08-25-web-296-unit-tests-pr1-infra.md
@@ -33,16 +33,17 @@
 ### Task 1: Branch and land the spec
 
 **Files:**
+
 - Commit (already written): `docs/superpowers/specs/2026-08-25-web-296-unit-tests-design.md`
 
 **Interfaces:**
+
 - Consumes: nothing.
 - Produces: branch `test/web-296-unit-tests` holding every later commit of this plan.
 
 - [ ] **Step 1: Check the workspace state**
 
-Run: `but status`
-Expected: the spec file and this plan file show as uncommitted changes.
+Run: `but status` Expected: the spec file and this plan file show as uncommitted changes.
 
 - [ ] **Step 2: Commit spec and plan onto a new branch**
 
@@ -55,8 +56,7 @@ but commit -b test/web-296-unit-tests \
 
 - [ ] **Step 3: Verify the branch exists and holds one commit**
 
-Run: `but branch show test/web-296-unit-tests`
-Expected: one commit, the two docs files.
+Run: `but branch show test/web-296-unit-tests` Expected: one commit, the two docs files.
 
 ---
 
@@ -65,6 +65,7 @@ Expected: one commit, the two docs files.
 The smallest workspace goes first: it proves the runner, the coverage provider and the lint override before any framework glue is involved. The `date.ts` bug is fixed here because its test is the regression guard.
 
 **Files:**
+
 - Modify: `package.json` (root devDependencies)
 - Modify: `oxlint.config.ts` (test-file override)
 - Create: `packages/shared/vitest.config.ts`
@@ -73,6 +74,7 @@ The smallest workspace goes first: it proves the runner, the coverage provider a
 - Modify: `packages/shared/src/utils/date.ts:6-7`
 
 **Interfaces:**
+
 - Consumes: nothing.
 - Produces: the pattern every other workspace config copies — `defineConfig` from `vitest/config`, `tsconfigPaths()` plugin, `include: ['**/*.test.{ts,tsx}']`, workspace scripts `test`, `test:watch`, `test:coverage`.
 
@@ -191,8 +193,7 @@ describe('timeSpanInMilliSeconds', () => {
 
 - [ ] **Step 6: Run it and watch the two wrong constants fail**
 
-Run: `pnpm --filter @tsgi-web/shared test`
-Expected: FAIL — `hour` expected `3600` received `360`, `day` expected `86400` received `8640`, plus the `week`/`month`/`year` cases that are derived from `day`. Every other case passes.
+Run: `pnpm --filter @tsgi-web/shared test` Expected: FAIL — `hour` expected `3600` received `360`, `day` expected `86400` received `8640`, plus the `week`/`month`/`year` cases that are derived from `day`. Every other case passes.
 
 - [ ] **Step 7: Fix the constants**
 
@@ -207,18 +208,15 @@ Leave `week: 604_800`, `month: 2_592_000` and `year: 31_536_000` untouched — t
 
 - [ ] **Step 8: Run the test again**
 
-Run: `pnpm --filter @tsgi-web/shared test`
-Expected: PASS, 9 tests.
+Run: `pnpm --filter @tsgi-web/shared test` Expected: PASS, 9 tests.
 
 - [ ] **Step 9: Verify coverage works**
 
-Run: `pnpm --filter @tsgi-web/shared test:coverage`
-Expected: PASS plus a coverage table, and `packages/shared/coverage/lcov.info` exists.
+Run: `pnpm --filter @tsgi-web/shared test:coverage` Expected: PASS plus a coverage table, and `packages/shared/coverage/lcov.info` exists.
 
 - [ ] **Step 10: Verify nothing else broke**
 
-Run: `pnpm run lint && pnpm run format:check && pnpm run typecheck`
-Expected: all clean. `date.ts` is consumed only by `number-ticker.tsx` (`second`) and `cleverreach.ts` (`minute`), so the corrected values change no behavior.
+Run: `pnpm run lint && pnpm run format:check && pnpm run typecheck` Expected: all clean. `date.ts` is consumed only by `number-ticker.tsx` (`second`) and `cleverreach.ts` (`minute`), so the corrected values change no behavior.
 
 - [ ] **Step 11: Commit**
 
@@ -233,11 +231,13 @@ but commit -b test/web-296-unit-tests \
 ### Task 3: The `node` project in `apps/web`
 
 **Files:**
+
 - Create: `apps/web/vitest.config.ts`
 - Modify: `apps/web/package.json` (devDependencies, scripts)
 - Create: `apps/web/src/utils/typography.test.ts`
 
 **Interfaces:**
+
 - Consumes: the config pattern from Task 2.
 - Produces: `apps/web/vitest.config.ts` with an `assetStub` plugin and a `node` project; Task 4 adds the `dom` project to the same file.
 
@@ -362,13 +362,11 @@ describe('capitalizeWords', () => {
 
 - [ ] **Step 5: Run it**
 
-Run: `pnpm --filter web test`
-Expected: PASS, 10 tests, reported under the `node` project label. If it fails to resolve `./typography`, the `tsconfigPaths()` plugin is missing from the config.
+Run: `pnpm --filter web test` Expected: PASS, 10 tests, reported under the `node` project label. If it fails to resolve `./typography`, the `tsconfigPaths()` plugin is missing from the config.
 
 - [ ] **Step 6: Prove the asset stub works**
 
-Run: `pnpm --filter web exec vitest run --project node src/utils/typography.test.ts`
-Expected: PASS. Then, as a throwaway check that image imports load, run:
+Run: `pnpm --filter web exec vitest run --project node src/utils/typography.test.ts` Expected: PASS. Then, as a throwaway check that image imports load, run:
 
 ```bash
 pnpm --filter web exec vitest run --project node --reporter=dot \
@@ -379,8 +377,7 @@ Expected: no test matches, but **no import error** — which is the point: `grou
 
 - [ ] **Step 7: Lint, format, typecheck**
 
-Run: `pnpm run lint && pnpm run format:check && pnpm run typecheck`
-Expected: clean.
+Run: `pnpm run lint && pnpm run format:check && pnpm run typecheck` Expected: clean.
 
 - [ ] **Step 8: Commit**
 
@@ -394,12 +391,14 @@ but commit -b test/web-296-unit-tests \
 ### Task 4: The `dom` project in `apps/web`
 
 **Files:**
+
 - Modify: `apps/web/vitest.config.ts` (second project)
 - Create: `apps/web/test-utils/setup-dom.ts`
 - Modify: `apps/web/package.json` (devDependencies)
 - Create: `apps/web/src/hooks/use-media-query.test.ts`
 
 **Interfaces:**
+
 - Consumes: `apps/web/vitest.config.ts` from Task 3.
 - Produces: `apps/web/test-utils/setup-dom.ts`, which exports `createMatchMediaStub(matches: boolean): (query: string) => MediaQueryList` and registers `window.matchMedia`, `ResizeObserver` and `IntersectionObserver`. PR 4's component tests rely on both.
 
@@ -551,13 +550,11 @@ Note on the third and fourth case: the hook registers its listener on the `Media
 
 - [ ] **Step 5: Run it**
 
-Run: `pnpm --filter web test`
-Expected: 10 node tests plus 4 dom tests PASS. `matchMedia is not a function` means `setupFiles` is not wired; `document is not defined` means the file was matched by the `node` project instead — check the `exclude` in Task 3 Step 2.
+Run: `pnpm --filter web test` Expected: 10 node tests plus 4 dom tests PASS. `matchMedia is not a function` means `setupFiles` is not wired; `document is not defined` means the file was matched by the `node` project instead — check the `exclude` in Task 3 Step 2.
 
 - [ ] **Step 6: Lint, format, typecheck**
 
-Run: `pnpm run lint && pnpm run format:check && pnpm run typecheck`
-Expected: clean.
+Run: `pnpm run lint && pnpm run format:check && pnpm run typecheck` Expected: clean.
 
 - [ ] **Step 7: Commit**
 
@@ -571,11 +568,13 @@ but commit -b test/web-296-unit-tests \
 ### Task 5: Test helpers for env and fetch
 
 **Files:**
+
 - Create: `apps/web/test-utils/env.ts`
 - Create: `apps/web/test-utils/fetch-mock.ts`
 - Create: `apps/web/src/utils/url.test.ts`
 
 **Interfaces:**
+
 - Consumes: the `node` project from Task 3.
 - Produces:
   - `loadWithEnv<T>(specifier: string, vars: Record<string, string | undefined>): Promise<T>` — resets the module registry, stubs the given variables, then imports the module fresh. Needed because `src/lib/env.ts` caches validated values in a module-level `Map`.
@@ -762,18 +761,15 @@ Before running, open `apps/web/src/constants/urls.ts` and confirm `GOOGLE_MAPS_U
 
 - [ ] **Step 4: Run it**
 
-Run: `pnpm --filter web test src/utils/url.test.ts`
-Expected: PASS, 6 tests. A thrown `Invalid environment variable …` means `loadWithEnv` was called without the variable that branch needs.
+Run: `pnpm --filter web test src/utils/url.test.ts` Expected: PASS, 6 tests. A thrown `Invalid environment variable …` means `loadWithEnv` was called without the variable that branch needs.
 
 - [ ] **Step 5: Prove the fetch helper compiles and behaves**
 
-Run: `pnpm run typecheck`
-Expected: clean — this is the only check the fetch helper gets in this PR; PR 3 is its first consumer.
+Run: `pnpm run typecheck` Expected: clean — this is the only check the fetch helper gets in this PR; PR 3 is its first consumer.
 
 - [ ] **Step 6: Lint and format**
 
-Run: `pnpm run lint && pnpm run format:check`
-Expected: clean.
+Run: `pnpm run lint && pnpm run format:check` Expected: clean.
 
 - [ ] **Step 7: Commit**
 
@@ -787,11 +783,13 @@ but commit -b test/web-296-unit-tests \
 ### Task 6: Vitest in `apps/studio`
 
 **Files:**
+
 - Create: `apps/studio/vitest.config.ts`
 - Modify: `apps/studio/package.json` (devDependencies, scripts)
 - Create: `apps/studio/utils/time.test.ts`
 
 **Interfaces:**
+
 - Consumes: the config pattern from Task 2.
 - Produces: a jsdom-based studio project; PR 5 adds schema and plugin tests to it.
 
@@ -870,13 +868,11 @@ describe('formatDate', () => {
 
 - [ ] **Step 5: Run it**
 
-Run: `pnpm --filter studio test`
-Expected: PASS, 4 tests. If the last case reports `26-08-26`, the process timezone is not UTC — set it in the config instead (`test.env: { TZ: 'UTC' }`) and drop the `stubEnv` calls, because `vi.stubEnv('TZ', …)` does not re-initialize Node's already-resolved timezone.
+Run: `pnpm --filter studio test` Expected: PASS, 4 tests. If the last case reports `26-08-26`, the process timezone is not UTC — set it in the config instead (`test.env: { TZ: 'UTC' }`) and drop the `stubEnv` calls, because `vi.stubEnv('TZ', …)` does not re-initialize Node's already-resolved timezone.
 
 - [ ] **Step 6: Lint, format, typecheck**
 
-Run: `pnpm run lint && pnpm run format:check && pnpm run typecheck`
-Expected: clean.
+Run: `pnpm run lint && pnpm run format:check && pnpm run typecheck` Expected: clean.
 
 - [ ] **Step 7: Commit**
 
@@ -890,11 +886,13 @@ but commit -b test/web-296-unit-tests \
 ### Task 7: Vitest in `packages/email`
 
 **Files:**
+
 - Create: `packages/email/vitest.config.ts`
 - Modify: `packages/email/package.json` (devDependencies, scripts)
 - Create: `packages/email/lib/cleverreach-markers.test.ts`
 
 **Interfaces:**
+
 - Consumes: the config pattern from Task 2.
 - Produces: an email project whose `exclude` keeps the generated `.react-email` specs out; PR 5 adds the template tests to it.
 
@@ -1000,18 +998,15 @@ describe('stripCleverReachMarkers', () => {
 
 - [ ] **Step 5: Run it**
 
-Run: `pnpm --filter @tsgi-web/email test`
-Expected: PASS, 11 tests.
+Run: `pnpm --filter @tsgi-web/email test` Expected: PASS, 11 tests.
 
 - [ ] **Step 6: Confirm the generated specs stayed out**
 
-Run: `pnpm --filter @tsgi-web/email test --reporter=verbose`
-Expected: only `lib/cleverreach-markers.test.ts` in the file list. Any `.react-email/...spec.ts` entry means the `exclude` is wrong.
+Run: `pnpm --filter @tsgi-web/email test --reporter=verbose` Expected: only `lib/cleverreach-markers.test.ts` in the file list. Any `.react-email/...spec.ts` entry means the `exclude` is wrong.
 
 - [ ] **Step 7: Lint, format, typecheck**
 
-Run: `pnpm run lint && pnpm run format:check && pnpm run typecheck`
-Expected: clean. `packages/email`'s `build` script is `tsc --noEmit`, so the new test file is type-checked by it too.
+Run: `pnpm run lint && pnpm run format:check && pnpm run typecheck` Expected: clean. `packages/email`'s `build` script is `tsc --noEmit`, so the new test file is type-checked by it too.
 
 - [ ] **Step 8: Commit**
 
@@ -1025,16 +1020,17 @@ but commit -b test/web-296-unit-tests \
 ### Task 8: Fix the newsletter error copy
 
 **Files:**
+
 - Modify: `apps/web/src/actions/subscribe-to-newsletter.ts:82`
 
 **Interfaces:**
+
 - Consumes: nothing.
 - Produces: a single German copy string that PR 3's action test asserts.
 
 - [ ] **Step 1: Find both spellings**
 
-Run: `grep -rn "überprüf" apps/web/src`
-Expected: two hits — `ERROR_MESSAGES.VALIDATION_ERROR` with `'Bitte überprüfe Deine Eingaben.'` and the validation branch of `subscribeToNewsletter` with `'Bitte überprüfen Deine Eingaben.'`.
+Run: `grep -rn "überprüf" apps/web/src` Expected: two hits — `ERROR_MESSAGES.VALIDATION_ERROR` with `'Bitte überprüfe Deine Eingaben.'` and the validation branch of `subscribeToNewsletter` with `'Bitte überprüfen Deine Eingaben.'`.
 
 - [ ] **Step 2: Fix the wrong one**
 
@@ -1052,13 +1048,11 @@ to:
 
 - [ ] **Step 3: Verify only one spelling remains**
 
-Run: `grep -rn "überprüfen Deine" apps/web/src`
-Expected: no output.
+Run: `grep -rn "überprüfen Deine" apps/web/src` Expected: no output.
 
 - [ ] **Step 4: Lint, format, typecheck**
 
-Run: `pnpm run lint && pnpm run format:check && pnpm run typecheck`
-Expected: clean.
+Run: `pnpm run lint && pnpm run format:check && pnpm run typecheck` Expected: clean.
 
 - [ ] **Step 5: Commit**
 
@@ -1072,12 +1066,14 @@ but commit -b test/web-296-unit-tests \
 ### Task 9: Turbo tasks, root scripts and coverage output
 
 **Files:**
+
 - Modify: `turbo.json` (tasks)
 - Modify: `package.json` (root scripts)
 - Modify: `.gitignore`
 - Modify: `packages/shared/vitest.config.ts`, `apps/web/vitest.config.ts`, `apps/studio/vitest.config.ts`, `packages/email/vitest.config.ts` (coverage block)
 
 **Interfaces:**
+
 - Consumes: the four workspace configs and their `test` scripts.
 - Produces: `pnpm run test`, `pnpm run test:affected`, `pnpm run test:coverage` at the root, and one `coverage/lcov.info` per workspace.
 
@@ -1128,13 +1124,11 @@ coverage
 
 - [ ] **Step 5: Run the whole suite through Turbo**
 
-Run: `pnpm run test`
-Expected: four successful tasks (`web`, `studio`, `@tsgi-web/shared`, `@tsgi-web/email`), 44 tests total (10 typography + 4 media query + 6 url + 9 date + 4 formatDate + 11 markers). Confirm the number against the actual output and use it in the PR description.
+Run: `pnpm run test` Expected: four successful tasks (`web`, `studio`, `@tsgi-web/shared`, `@tsgi-web/email`), 44 tests total (10 typography + 4 media query + 6 url + 9 date + 4 formatDate + 11 markers). Confirm the number against the actual output and use it in the PR description.
 
 - [ ] **Step 6: Run coverage through Turbo**
 
-Run: `pnpm run test:coverage`
-Expected: four `coverage/lcov.info` files exist:
+Run: `pnpm run test:coverage` Expected: four `coverage/lcov.info` files exist:
 
 ```bash
 ls apps/web/coverage/lcov.info apps/studio/coverage/lcov.info \
@@ -1143,18 +1137,15 @@ ls apps/web/coverage/lcov.info apps/studio/coverage/lcov.info \
 
 - [ ] **Step 7: Confirm caching works**
 
-Run: `pnpm run test` twice in a row.
-Expected: the second run reports `FULL TURBO`.
+Run: `pnpm run test` twice in a row. Expected: the second run reports `FULL TURBO`.
 
 - [ ] **Step 8: Confirm coverage is not committed**
 
-Run: `but status`
-Expected: no `coverage/` entries.
+Run: `but status` Expected: no `coverage/` entries.
 
 - [ ] **Step 9: Lint, format**
 
-Run: `pnpm run lint && pnpm run format:check`
-Expected: clean.
+Run: `pnpm run lint && pnpm run format:check` Expected: clean.
 
 - [ ] **Step 10: Commit**
 
@@ -1168,9 +1159,11 @@ but commit -b test/web-296-unit-tests \
 ### Task 10: Run the tests in CI
 
 **Files:**
+
 - Modify: `.github/workflows/check.yml`
 
 **Interfaces:**
+
 - Consumes: the root `test` script from Task 9.
 - Produces: a PR-blocking test step.
 
@@ -1179,24 +1172,22 @@ but commit -b test/web-296-unit-tests \
 In `.github/workflows/check.yml`, insert between the `Lint files` and `Build files` steps:
 
 ```yaml
-      - name: Run tests
-        run: pnpm run test:affected
-        env:
-          NEXT_PUBLIC_SANITY_DATASET: ${{ secrets.SANITY_DATASET }}
-          NEXT_PUBLIC_SANITY_PROJECT_ID: ${{ secrets.SANITY_PROJECT_ID }}
+- name: Run tests
+  run: pnpm run test:affected
+  env:
+    NEXT_PUBLIC_SANITY_DATASET: ${{ secrets.SANITY_DATASET }}
+    NEXT_PUBLIC_SANITY_PROJECT_ID: ${{ secrets.SANITY_PROJECT_ID }}
 ```
 
 `test:affected` mirrors the existing `lint:affected` / `build:affected` steps. The two Sanity variables are needed because `src/lib/sanity/client.ts` reads them at module load, and the web tests import modules that pull it in.
 
 - [ ] **Step 2: Verify the file parses**
 
-Run: `pnpm exec oxlint .github/workflows/check.yml --no-error-on-unmatched-pattern; python3 -c "import sys,yaml;yaml.safe_load(open('.github/workflows/check.yml'))" && echo "yaml ok"`
-Expected: `yaml ok`.
+Run: `pnpm exec oxlint .github/workflows/check.yml --no-error-on-unmatched-pattern; python3 -c "import sys,yaml;yaml.safe_load(open('.github/workflows/check.yml'))" && echo "yaml ok"` Expected: `yaml ok`.
 
 - [ ] **Step 3: Reproduce the CI command locally**
 
-Run: `pnpm run test:affected`
-Expected: PASS. If the web tests fail with `Invalid environment variable NEXT_PUBLIC_SANITY_…`, note the failing module in the PR description — the fix belongs here, either by adding the variable to the CI env block or by adding a `test.env` default to `apps/web/vitest.config.ts`.
+Run: `pnpm run test:affected` Expected: PASS. If the web tests fail with `Invalid environment variable NEXT_PUBLIC_SANITY_…`, note the failing module in the PR description — the fix belongs here, either by adding the variable to the CI env block or by adding a `test.env` default to `apps/web/vitest.config.ts`.
 
 - [ ] **Step 4: Commit**
 
@@ -1210,10 +1201,12 @@ but commit -b test/web-296-unit-tests \
 ### Task 11: Report coverage to SonarQube
 
 **Files:**
+
 - Modify: `sonar-project.properties`
 - Modify: `.github/workflows/sonar.yml`
 
 **Interfaces:**
+
 - Consumes: the four `coverage/lcov.info` files from Task 9.
 - Produces: coverage visible in SonarQube, with no minimum threshold.
 
@@ -1235,36 +1228,34 @@ Keep the existing `sonar.exclusions=**/sanity.types.generated.ts` line as it is.
 In `.github/workflows/sonar.yml`, insert these steps between the `checkout` step and the `SonarQube Scan` step:
 
 ```yaml
-      - name: Setup pnpm
-        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+- name: Setup pnpm
+  uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 
-      - name: Setup Node
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
-        with:
-          cache: pnpm
-          node-version-file: .nvmrc
+- name: Setup Node
+  uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+  with:
+    cache: pnpm
+    node-version-file: .nvmrc
 
-      - name: Install Dependencies
-        run: pnpm install --frozen-lockfile --ignore-scripts
+- name: Install Dependencies
+  run: pnpm install --frozen-lockfile --ignore-scripts
 
-      - name: Collect Coverage
-        run: pnpm run test:coverage
-        env:
-          NEXT_PUBLIC_SANITY_DATASET: ${{ secrets.SANITY_DATASET }}
-          NEXT_PUBLIC_SANITY_PROJECT_ID: ${{ secrets.SANITY_PROJECT_ID }}
+- name: Collect Coverage
+  run: pnpm run test:coverage
+  env:
+    NEXT_PUBLIC_SANITY_DATASET: ${{ secrets.SANITY_DATASET }}
+    NEXT_PUBLIC_SANITY_PROJECT_ID: ${{ secrets.SANITY_PROJECT_ID }}
 ```
 
 Reuse the exact pinned action SHAs from `check.yml` (copied above) so both workflows stay on one version.
 
 - [ ] **Step 3: Verify the YAML parses**
 
-Run: `python3 -c "import yaml;yaml.safe_load(open('.github/workflows/sonar.yml'))" && echo "yaml ok"`
-Expected: `yaml ok`.
+Run: `python3 -c "import yaml;yaml.safe_load(open('.github/workflows/sonar.yml'))" && echo "yaml ok"` Expected: `yaml ok`.
 
 - [ ] **Step 4: Verify the lcov paths exist**
 
-Run: `pnpm run test:coverage && wc -l apps/web/coverage/lcov.info apps/studio/coverage/lcov.info packages/shared/coverage/lcov.info packages/email/coverage/lcov.info`
-Expected: four non-empty files, matching the paths in `sonar-project.properties` exactly.
+Run: `pnpm run test:coverage && wc -l apps/web/coverage/lcov.info apps/studio/coverage/lcov.info packages/shared/coverage/lcov.info packages/email/coverage/lcov.info` Expected: four non-empty files, matching the paths in `sonar-project.properties` exactly.
 
 - [ ] **Step 5: Commit**
 
@@ -1278,18 +1269,19 @@ but commit -b test/web-296-unit-tests \
 ### Task 12: Document the setup
 
 **Files:**
+
 - Modify: `AGENTS.md` (Development Commands, Code Quality Tools)
 - Modify: `apps/web/AGENTS.md`
 - Modify: `apps/studio/AGENTS.md`
 
 **Interfaces:**
+
 - Consumes: every script added in this PR.
 - Produces: the conventions later PRs and other agents follow.
 
 - [ ] **Step 1: Read the two app guides first**
 
-Run: `sed -n 1,60p apps/web/AGENTS.md; sed -n 1,60p apps/studio/AGENTS.md`
-Match their existing heading style and tone when adding to them.
+Run: `sed -n 1,60p apps/web/AGENTS.md; sed -n 1,60p apps/studio/AGENTS.md` Match their existing heading style and tone when adding to them.
 
 - [ ] **Step 2: Add a Testing block to the root guide**
 
@@ -1319,8 +1311,7 @@ In `apps/web/AGENTS.md`, add a `## Testing` section describing the two projects,
 
 - [ ] **Step 4: Verify the documented commands actually run**
 
-Run: `pnpm run test && pnpm run test:affected && pnpm run test:coverage`
-Expected: all three succeed exactly as documented.
+Run: `pnpm run test && pnpm run test:affected && pnpm run test:coverage` Expected: all three succeed exactly as documented.
 
 - [ ] **Step 5: Format and commit**
 
@@ -1337,18 +1328,17 @@ but commit -b test/web-296-unit-tests \
 **Files:** none.
 
 **Interfaces:**
+
 - Consumes: every commit on `test/web-296-unit-tests`.
 - Produces: a PR that closes the infra part of WEB-296.
 
 - [ ] **Step 1: Final full verification**
 
-Run: `pnpm run lint && pnpm run format:check && pnpm run typecheck && pnpm run test && pnpm run build`
-Expected: everything green. Record the real test count from the output.
+Run: `pnpm run lint && pnpm run format:check && pnpm run typecheck && pnpm run test && pnpm run build` Expected: everything green. Record the real test count from the output.
 
 - [ ] **Step 2: Review the branch**
 
-Run: `but branch show test/web-296-unit-tests`
-Expected: twelve commits (docs, shared, web node, web dom, helpers, studio, email, copy fix, turbo, ci, sonar, docs — count from the actual output).
+Run: `but branch show test/web-296-unit-tests` Expected: twelve commits (docs, shared, web node, web dom, helpers, studio, email, copy fix, turbo, ci, sonar, docs — count from the actual output).
 
 - [ ] **Step 3: Push and open the PR**
 

--- a/docs/superpowers/specs/2026-08-25-web-296-unit-tests-design.md
+++ b/docs/superpowers/specs/2026-08-25-web-296-unit-tests-design.md
@@ -112,7 +112,7 @@ Die Actions sind in `next-safe-action` gewickelt. Die Tests rufen die exportiert
 Getestet werden nur Komponenten mit eigener Logik. Server Actions werden auf Modulpfad-Ebene gemockt, hier läuft kein `fetch`.
 
 - `ui/lightbox.tsx` — Öffnen an einem gegebenen Index, Blättern vor und zurück, Verhalten an beiden Enden, `Escape` schließt, Pfeiltasten blättern, Klick auf das Backdrop schließt, Klick auf den Inhalt nicht, Caption nur wenn vorhanden, Einzelbild-Fall ohne Pager.
-- `ui/gallery.tsx` — ein Tile pro Bild, Klick auf Tile *n* öffnet die Lightbox bei *n*, Flag für die abgerundeten Ecken, nur das erste Bild ist `preload`.
+- `ui/gallery.tsx` — ein Tile pro Bild, Klick auf Tile _n_ öffnet die Lightbox bei _n_, Flag für die abgerundeten Ecken, nur das erste Bild ist `preload`.
 - `with-logic/feedback/screenshot-upload.tsx` — akzeptiert ein Bild, lehnt falschen Typ und zu große Datei mit der jeweiligen Meldung ab, zeigt den Pending-Zustand, Entfernen löscht den Eintrag, Fehler der Upload-Action erscheint und lässt die Dateiliste konsistent.
 - `section/contact-form.tsx` und `with-logic/feedback/form.tsx` — leeres Absenden zeigt die Zod-Meldungen, gültiges Absenden ruft die Action genau einmal mit den geparsten Werten, `serverError` rendert den Fehler-Alert, Erfolg rendert die Bestätigung und setzt das Formular zurück, Submit ist während des Pendings deaktiviert.
 - `with-logic/navigation.tsx` — Mobile- vs. Desktop-Zweig über das gestubbte `matchMedia`, aktiver Eintrag aus `usePathname`, Öffnen und Schließen des Mobile-Menüs.

--- a/docs/superpowers/specs/2026-08-25-web-296-unit-tests-design.md
+++ b/docs/superpowers/specs/2026-08-25-web-296-unit-tests-design.md
@@ -1,0 +1,154 @@
+# Unit-Tests (WEB-296) — Design-Spec
+
+Datum: 2026-08-25 · Status: entschieden, noch nicht umgesetzt · Ticket: [WEB-296](https://linear.app/tsg-irlich/issue/WEB-296/unittests) (Epic: WEB-294 „Automatiertes Testing")
+
+Scope: **Unit-Tests für alle vier Workspaces** (`apps/web`, `apps/studio`, `packages/shared`, `packages/email`) inklusive Test-Infrastruktur, CI-Anbindung und Coverage-Report. E2E-Tests sind ein eigenes Ticket unter demselben Epic und hier ausdrücklich nicht enthalten.
+
+## Ausgangslage
+
+Das Repository hat heute keine Test-Infrastruktur: kein Test-Runner, kein `test`-Script, keine `test`-Task in `turbo.json`, keinen CI-Schritt. Die einzigen `*.spec.*`-Dateien liegen unter `packages/email/.react-email/` — ein generiertes, per `.gitignore` ausgeschlossenes Verzeichnis, das von den Tests nicht erfasst werden darf.
+
+`sonar-project.properties` schaltet Coverage aktuell komplett ab (`sonar.coverage.exclusions=**/*`).
+
+## Entschiedene Optionen
+
+| Frage | Entscheidung |
+| --- | --- |
+| Umfang | Alles: pure Logik, Server Actions, Komponenten, Studio, E-Mail-Templates |
+| Runner | Vitest, eine Config pro Workspace, `test`-Task über Turbo |
+| Enforcement | CI-Schritt in `check.yml` (blockt PRs) + Coverage-Report an Sonar, **keine** Mindest-Quote |
+| Lieferung | Infra-PR zuerst, danach ein PR pro Ebene (5 PRs) |
+| Test-Globals | Explizite Imports aus `vitest`, kein `globals: true` |
+| Dateiablage | Tests liegen neben der Quelldatei (`foo.ts` → `foo.test.ts`) |
+| Mock-Grenze bei externen Diensten | HTTP-Ebene (`fetch`) statt Modul-Mocks; nur Resend wird als SDK gemockt |
+| Auswahlkriterium | Nur Code mit eigener Logik. Keine Tests, die ausschließlich Typen oder Literale wiederholen |
+
+## Lieferung in fünf PRs
+
+Jeder PR ist eigenständig grün. Nach PR 1 ist die CI-Kette vollständig, alle weiteren PRs fügen nur Tests hinzu.
+
+### PR 1 — Infrastruktur
+
+**Dependencies** (Root-devDependencies, damit die Version einheitlich bleibt): `vitest@^4.1.11`, `@vitest/coverage-v8@^4.1.11`. Pro Workspace zusätzlich, wo benötigt: `jsdom@^30`, `@testing-library/react@^16.3`, `@testing-library/user-event@^14.6`, `@vitejs/plugin-react@^6.1`, `vite-tsconfig-paths@^6.1`, `@react-email/render@^2.1` (nur `packages/email`).
+
+**Configs** — je eine `vitest.config.ts` pro Workspace, jeweils mit `vite-tsconfig-paths`, damit `@/*` aus der jeweiligen `tsconfig.json` auflöst (`apps/web` → `./src/*`, `apps/studio` → `./*`, `packages/shared` → `./src/*`):
+
+- `apps/web`: zwei `test.projects` in derselben Config — `node` (Default) und `dom` (jsdom) über das Glob `src/{components,hooks}/**`. Vitest 4 hat `environmentMatchGlobs` entfernt, `projects` ist der Ersatz.
+- `apps/studio`: jsdom, React-Plugin (die Schemas sind reine Objekte, einzelne `components/` rendern aber).
+- `packages/shared`: node, plus jsdom-Project für die beiden Icon-/Logo-Komponenten.
+- `packages/email`: node, React-Plugin, `exclude: ['.react-email/**']`.
+
+**Asset-Stub**: `apps/web/src/utils/groups.ts` importiert `.webp`-Dateien. Die Web-Config erhält ein kleines Inline-Plugin, das `\.(webp|png|jpe?g|svg)$` auf ein Stub-Modul in der Form `{ src, width, height }` auflöst — dieselbe Form, die Next.js injiziert.
+
+**DOM-Setup** (`apps/web/test-utils/setup-dom.ts`, vom `dom`-Project geladen): Stubs für `window.matchMedia`, `ResizeObserver` und `IntersectionObserver`; Modul-Mocks für `next/image` → einfaches `<img>`, `next/navigation` (`usePathname`, `useRouter`) und `motion` → einfache Elemente, damit Animationen die Assertions nicht flaky machen.
+
+**Env-Helper** (`apps/web/test-utils/env.ts`): `lib/env.ts` cached validierte Werte in einer Modul-`Map`, `getBaseUrl()` liest darüber. Der Helper (`loadWithEnv(path, vars)`) kapselt `vi.resetModules()` + `vi.stubEnv()`, statt diese Kombination in jedem Test zu wiederholen.
+
+**Fetch-Helper** (`apps/web/test-utils/fetch-mock.ts`): `vi.stubGlobal('fetch', …)` mit einer kleinen Queue, die Responses pro URL-Muster liefert.
+
+**Scripts**: `test`, `test:watch`, `test:coverage` pro Workspace; im Root `test` und `test:affected` über Turbo. `turbo.json` erhält die Tasks `test` und `test:coverage` (letztere mit `outputs: ["coverage/**"]`). Unit-Tests brauchen keinen Build, deshalb kein `dependsOn: ["^build"]`.
+
+**CI** (`.github/workflows/check.yml`): neuer `test`-Schritt nach dem Lint- und vor dem Build-Schritt. Er läuft nach dem bereits vorhandenen `typegen:routes`-Schritt und braucht dieselben beiden Secrets (`NEXT_PUBLIC_SANITY_DATASET`, `NEXT_PUBLIC_SANITY_PROJECT_ID`).
+
+**Coverage/Sonar**: `sonar.coverage.exclusions=**/*` entfällt, stattdessen `sonar.javascript.lcov.reportPaths` mit den vier `coverage/lcov.info`-Pfaden und `sonar.test.inclusions=**/*.test.*`. `sonar.yml` führt heute nur Checkout und Scan aus und bekommt deshalb pnpm-/Node-Setup, Install und `pnpm run test:coverage` vor dem Scan-Schritt. (Alternative wäre ein Artefakt-Transport aus `check.yml`; verworfen, weil er mehr bewegliche Teile hat.)
+
+**Zwei Bugfixes in diesem PR**, weil beide durch Tests festgeschrieben werden:
+
+1. `packages/shared/src/utils/date.ts`: `hour: 360` → `3600`, `day: 8640` → `86_400`. `week` (`604_800`) und `month` (`2_592_000`, 30 Tage) sind korrekt. Verhaltensneutral, weil im Repository nur `second` (`number-ticker.tsx`) und `minute` (`cleverreach.ts`) verwendet werden. Der neue `date.test.ts` prüft jede Zeitspanne gegen ihre arithmetische Definition.
+2. `apps/web/src/actions/subscribe-to-newsletter.ts`: `'Bitte überprüfen Deine Eingaben.'` → `'Bitte überprüfe Deine Eingaben.'`, damit derselbe Zustand nicht zwei Grammatiken hat (`ERROR_MESSAGES.VALIDATION_ERROR` ist schon korrekt).
+
+### PR 2 — Pure Logik
+
+`packages/shared`
+
+- `array.ts` — `shuffleArray`: Länge und Elemente bleiben erhalten, Eingabe wird nicht mutiert, deterministische Reihenfolge bei gestubbtem `Math.random`.
+- `cn.ts` — bedingte Objekte, spätere Tailwind-Klasse gewinnt bei Konflikt.
+- `date.ts` — jede Zeitspanne gegen ihre arithmetische Definition (Regressionsschutz für den Bugfix).
+- `promise.ts` — `settle` bei Resolve, bei Reject und mit einem Thenable; wirft nie.
+- Ausgelassen: `jsx.ts` (drei leere Konstanten), alle `index.ts`-Barrels.
+
+`apps/web/src/utils`
+
+- `typography.ts` — leerer String, ein Zeichen, eigener Separator, gemischte Groß-/Kleinschreibung in `capitalizeWords`.
+- `links.ts` — Home, News-Artikel mit und ohne Kategorie, News-Kategorie, Gruppe mit Abteilungsseite, Gruppe ohne Abteilungsseite (z. B. Verwaltung → `undefined`), unbekannter Typ fällt auf `/${slug}`, fehlender Typ oder Slug → `undefined`.
+- `groups.ts` — `getCurrentDepartment` Treffer und Fehlschlag, `getGroupImage`-Fallback, `getOGImage` für bekannte Gruppe vs. Fallback-Pfad inklusive 1200×630.
+- `icon.ts` — bekannte Plattform, Meta-Key `_type` wird übersprungen, Plattform ohne URL wird übersprungen, `null` → `[]`.
+- `image.ts` — `getInitials` (beide Namen, einer fehlt, beide leer, Kleinschreibung), `getGalleryImages` mit `undefined`/`[]` und mit Bildern, deren URL-Builder `undefined` liefert (werden verworfen). Die URL-Builder sind hier gemockt und werden in `sanity/utils` echt getestet.
+- `time.ts` — `getLocaleDate` lang und kurz, String- und `Date`-Eingabe, explizites Locale. Die Assertions normalisieren `U+202F` und `U+00A0`, damit ein ICU-Update die Suite nicht bricht.
+- `url.ts` — `getBaseUrl` in allen drei Zweigen über den Env-Helper; `printGoogleMapsLink` mit vollständiger Adresse, ohne Name, ohne PLZ und mit korrektem Percent-Encoding.
+
+`apps/web/src/lib`
+
+- `sanity/utils.ts` — `getDownloadFileUrl` (`#!` bei fehlender URL oder fehlendem Dateinamen), `getFileSize` (`0`/`undefined` → `—`, B, KB, MB, GB, Grenze bei genau 1024, Dezimalstellen pro Einheit), `urlForImage` (ohne `asset._ref` → `undefined`, nur Höhe = quadratischer Crop, Breite und Höhe, ohne Maße `fit=max`, `q=90`), `urlForImageMax` (`w`, `fit=max`, kein Crop).
+- `env.ts` — gültiger Wert, fehlender Pflichtwert wirft mit dem Key in der Meldung, Defaults greifen (`NODE_ENV`, Sanity-API-Version), `''` wird für `SANITY_API_READ_TOKEN` zu `undefined` vorverarbeitet, zweiter Aufruf kommt aus dem Cache (eine Änderung an `process.env` nach dem ersten Lesen bleibt wirkungslos).
+- `validations/contact-form.ts` — gültige Eingabe, ungültige E-Mail, Nachricht unter 32 Zeichen, Name unter 2 Zeichen, `privacy: false` abgelehnt, `receiver` optional im Basis-Schema und Pflicht in `contactFormWithReceiverSchema`, deutsche Meldungen werden geprüft.
+- `validations/feedback.ts` — Min-/Max-Grenzen für Titel und Beschreibung, E-Mail gültig / leerer String erlaubt / ungültig, jedes Enum lehnt einen unbekannten Wert ab, Meldung bei fehlendem `type`.
+- Ausgelassen: `sanity/queries/**` (GROQ-String-Konstanten ohne Logik, deren Form bereits von TypeGen abgesichert wird), `lib/actions/safe-action.ts` (einzeilige Factory), `lib/resend.ts`, `sanity/client.ts`, `sanity/live.ts` (nur SDK-Konstruktion).
+
+### PR 3 — Server Actions und CleverReach
+
+Alle externen Aufrufe dieser Ebene laufen über `fetch` (CleverReach REST, Linear GraphQL, Linear-S3-PUT); nur Resend ist ein SDK. Deshalb wird auf HTTP-Ebene gemockt (`test-utils/fetch-mock.ts`), plus `vi.mock('@/lib/resend')` und `vi.mock('next/headers')` für `subscribe-to-newsletter`. So bleibt das Zod-Parsing der Antworten unter Test, statt weggemockt zu werden — dort liegen die realistischen Fehler.
+
+Die Actions sind in `next-safe-action` gewickelt. Die Tests rufen die exportierte Action auf und prüfen deren `{ data }` / `{ validationErrors }` / `{ serverError }`-Hülle, nicht einen nackten Rückgabewert. Die `'use server'`-Direktive ist unter Vitest wirkungslos.
+
+`lib/cleverreach.ts` (umfangreichste Datei dieser Ebene)
+
+- `getAccessToken` — einmal `fetch`, zweiter Aufruf aus dem Modul-Cache (genau ein `fetch`); Token innerhalb des 5-Minuten-Puffers löst einen neuen Request aus; nicht-ok-Response wirft mit dem Body-Text; fehlerhaftes Payload scheitert am `accessTokenSchema`. Braucht `vi.resetModules()` pro Fall (Modul-State `tokenCache`) und Fake Timers für das Ablauf-Fenster.
+- `addReceiver` — 200 → Erfolg; 409 → `code: 'ALREADY_SUBSCRIBED'`; anderer Fehler mit parsebarem `{ error: { code, message } }` → Code und Meldung werden durchgereicht; nicht-JSON-Fehlerbody → Fallback `'Failed to add subscriber'`.
+- `sendDoiEmail` — Fehlschlag loggt nur und lässt das Abo erfolgreich (`console.error` geprüft, Ergebnis weiterhin erfolgreich).
+- `resolveDoiMetadata` — explizite Metadaten gewinnen; Defaults leiten den Referer aus `VERCEL_PROJECT_PRODUCTION_URL` ab und sind leer, wenn die Variable fehlt.
+- `subscribe` — ungültige E-Mail → `VALIDATION_ERROR` ohne einen einzigen `fetch`; ein geworfener Fehler an beliebiger Stelle → `INTERNAL_ERROR`; Happy Path liefert die Bestätigungsmeldung und hat beide Endpunkte aufgerufen.
+
+`actions/subscribe-to-newsletter.ts` — fehlende/ungültige `email` in der `FormData` → Fehlerzustand; Header-Auswertung (`x-forwarded-for` mit mehreren IPs nimmt die erste und trimmt, fehlende Header fallen auf `0.0.0.0` / `Mozilla/5.0` zurück); jeder `result.code` mappt auf seine deutsche Meldung, unbekannter Code fällt auf den Rohfehler zurück; Erfolgszustand.
+
+`actions/create-linear-issue.ts` — `buildDescription` (Screenshot-Block nur bei vorhandenen URLs, Metadaten-Zeilen überspringen falsy Felder, `privacy: true` wird gerendert, `Source`-Zeile immer am Ende), Titel je Typ in Großbuchstaben, Mutation-Variablen tragen `teamId`/`assigneeId`/`labelIds`; nicht-ok-HTTP → `HTTP error: <status>`; GraphQL-`errors` → `Failed to create issue`; `success: false` oder fehlendes Issue → `Issue creation failed`; Happy Path liefert `issueId` und `issueIdentifier`.
+
+`actions/upload-to-linear.ts` — Schema lehnt einen Nicht-Bild-Typ und eine Datei über 10 MB ab (Meldungen erscheinen als `validationErrors`); `buildUploadHeaders` legt die Linear-Header über den Content-Type; fehlendes `uploadFile` wirft mit Status und Payload; PUT-Fehlschlag wirft mit seinem Status; Happy Path liefert `assetUrl` und hat die Datei-Bytes per PUT gesendet.
+
+`actions/send-contact-form.ts` — Empfänger-Adresse in Produktion, außerhalb erzwungenes `it@tsg-irlich.de`, `bcc`/`replyTo`/Subject aus der Eingabe gebaut, fehlender Empfänger fällt auf `info@tsg-irlich.de` zurück, `{ error }` von Resend wirft `Email could not be sent`.
+
+### PR 4 — Komponenten und Hook
+
+Getestet werden nur Komponenten mit eigener Logik. Server Actions werden auf Modulpfad-Ebene gemockt, hier läuft kein `fetch`.
+
+- `ui/lightbox.tsx` — Öffnen an einem gegebenen Index, Blättern vor und zurück, Verhalten an beiden Enden, `Escape` schließt, Pfeiltasten blättern, Klick auf das Backdrop schließt, Klick auf den Inhalt nicht, Caption nur wenn vorhanden, Einzelbild-Fall ohne Pager.
+- `ui/gallery.tsx` — ein Tile pro Bild, Klick auf Tile *n* öffnet die Lightbox bei *n*, Flag für die abgerundeten Ecken, nur das erste Bild ist `preload`.
+- `with-logic/feedback/screenshot-upload.tsx` — akzeptiert ein Bild, lehnt falschen Typ und zu große Datei mit der jeweiligen Meldung ab, zeigt den Pending-Zustand, Entfernen löscht den Eintrag, Fehler der Upload-Action erscheint und lässt die Dateiliste konsistent.
+- `section/contact-form.tsx` und `with-logic/feedback/form.tsx` — leeres Absenden zeigt die Zod-Meldungen, gültiges Absenden ruft die Action genau einmal mit den geparsten Werten, `serverError` rendert den Fehler-Alert, Erfolg rendert die Bestätigung und setzt das Formular zurück, Submit ist während des Pendings deaktiviert.
+- `with-logic/navigation.tsx` — Mobile- vs. Desktop-Zweig über das gestubbte `matchMedia`, aktiver Eintrag aus `usePathname`, Öffnen und Schließen des Mobile-Menüs.
+- `section/newsletter.tsx` — Erfolgs- und Fehlerzustand aus `useActionState` mit gemockter Action.
+- `ui/portable-text.tsx` — jede Mark und jeder Blocktyp mappt auf sein Element, interne Links laufen über `getInternalHref`, externe Links bekommen `rel`/`target`, unbekannte Typen führen nicht zum Absturz.
+- `with-logic/breadcrumb.tsx` — Segmente aus dem Pfad, aufbereitete Labels, letztes Segment ist kein Link.
+- `with-logic/number-ticker.tsx` — erreicht den Zielwert unter Fake Timers, respektiert das Delay.
+- `with-logic/contact-link.tsx`, `contact-persons.tsx` — `mailto`/`tel`-Aufbau, Initialen-Fallback ohne Bild, leere Liste rendert nichts.
+- `hooks/use-media-query.ts` — initialer Match, Aktualisierung auf ein `change`-Event, Listener wird beim Unmount entfernt, `false` wenn `matchMedia` fehlt.
+
+Ausgelassen: die shadcn-/Radix-Wrapper (`select`, `dialog`, `drawer`, `scroll-area`, `card`, `input`, `textarea`, `toggle`, `toggle-group`, `alert`, `badge`, `button`, Breadcrumb-Primitives) und die rein darstellenden Karten (`training-card`, `group-card`, `pricing-card`, `news-article-preview*`, `hero`, `vision`, `footer`) — sie reichen nur Props und CVA-Klassen weiter. Interaktion auf diesen Flächen gehört in das E2E-Ticket des Epics.
+
+### PR 5 — Studio und E-Mail
+
+`apps/studio` (Tests liegen neben der Quelldatei, dieser Workspace hat kein `src`)
+
+- `utils/strings.ts` — `slugify`: das Beispiel aus dem JSDoc, Umlaut-Transliteration (`für` → `fuer`), Satzzeichen entfallen, Füllwörter (`und`, `der`, `die`, …) entfallen, eine Eingabe aus ausschließlich Füllwörtern → `''`, bereits geslugte Eingabe ist idempotent.
+- `utils/time.ts` — `formatDate` für `Date` und ISO-String sowie das UTC-Verhalten an einer Zeitzonengrenze (`toISOString` macht das zeitzonenabhängig, der Test fixiert `TZ` über `vi.stubEnv`).
+- `utils/fields.ts` — `getFieldWithGroup` liefert eine Kopie mit gesetzter Gruppe und mutiert die Quelle nicht; `getFieldWithoutGroup` entfernt sie.
+- `structure/index.ts` — `getGroup` und `isExcludedDefaultListItem` für eingeschlossene und ausgeschlossene Typen.
+- `plugins/singleton.ts` — `document.actions` entfernt `duplicate` für einen Singleton-Typ und lässt andere Typen unberührt; `newDocumentOptions` filtert Singleton-Templates im `global`-Kontext und behält sie sonst.
+- `preview.prepare`-Funktionen der Schemas, die tatsächlich rechnen (`schemas/sections/gallery.ts`, `objects/training-time.ts`, `objects/extended-image.ts`, `documents/testimonial.ts`, `schemas/sections/grid.ts`, `spacer.ts`): Titel-Fallbacks bei fehlenden Feldern, Zusammensetzung des Untertitels, Durchreichen von `media`. Aufgerufen direkt auf dem exportierten Definitionsobjekt, ohne Sanity-Runtime.
+- Eigene `validation`-Regeln derselben Schemas, als reine Funktionen aufgerufen und auf ihr `true`/Meldungs-Ergebnis geprüft.
+- Ausgelassen: die Feld- und Section-Literale selbst (`shared/fields/*`, `shared/sections/*`, reine `defineField`-Formen) — `extract-types` und TypeGen sichern die schon ab, und ein Test darauf wiederholt nur das Literal. Ebenfalls ausgelassen: `plugins/assist.ts` (270 Zeilen Prompt-Daten) und `plugins/index.ts` (Plugin-Verdrahtung).
+
+`packages/email`
+
+- `lib/cleverreach-markers.ts` — wertvollste Datei des Pakets, reine String-Verarbeitung: `marker()` ohne Attribute, mit mehreren Attributen und mit einem `undefined`-Attribut (wird verworfen); `toCleverReachTemplate` wandelt einen und mehrere Marker, entfernt Reacts `<!-- -->`-Separatoren und lässt unmarkiertes HTML unberührt; `stripCleverReachMarkers` entfernt jeden Marker und nichts sonst; ein Marker mit `|` im Wert verhält sich wie in der dokumentierten Einschränkung beschrieben.
+- `lib/render-newsletter.ts` — `renderNewsletterHtml` liefert HTML ohne Marker und ohne `#html#`-Kommentare; `renderNewsletterTemplate` liefert die CleverReach-Kommentare; beide reichen `isTemplate` korrekt durch.
+- `emails/*` und `components/newsletter/*` — gezielte Assertions auf die logiktragenden Teile: `news-grid` und `upcoming-events` rendern einen Eintrag pro Element und nichts bei leerer Liste, `event-date-badge` rendert Wochentag/Tag/Monat aus einem `NewsletterEvent`, `email-button` Href und Label, `sponsor-card` den Zweig ohne Bild, `contact-forward.tsx` die Empfängerzeile nur mit übergebenem Empfänger. Dazu genau zwei Full-Render-Snapshots (Newsletter als Template und als Mailing) als struktureller Regressionsschutz.
+- Ausgelassen: die rein gestaltenden Wrapper (`section-kicker`, `cta-band`, Markup von `newsletter-header`/`newsletter-footer`) über ihr Vorkommen in den beiden Snapshots hinaus.
+
+## Erwarteter Umfang
+
+Grob 240–300 Testfälle in etwa 45 Testdateien über alle fünf PRs.
+
+## Offene Punkte
+
+Keine. Coverage-Schwelle bleibt bewusst offen und kann in einem Folgeticket gesetzt werden, wenn die Quote nach PR 5 bekannt ist.

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
 				'max-lines-per-function': 'off',
 				'no-magic-numbers': 'off',
 				'sort-keys': 'off',
+				'typescript/no-unsafe-type-assertion': 'off',
 			},
 		},
 		{

--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -6,6 +6,15 @@ export default defineConfig({
 	ignorePatterns: ['**/*.generated.ts', '**/*generated*.ts'],
 	overrides: [
 		{
+			files: ['**/*.test.ts', '**/*.test.tsx', '**/test-utils/**', '**/vitest.config.ts'],
+			rules: {
+				'max-lines': 'off',
+				'max-lines-per-function': 'off',
+				'no-magic-numbers': 'off',
+				'sort-keys': 'off',
+			},
+		},
+		{
 			files: ['**/*.tsx'],
 			plugins: ['react', 'nextjs'],
 			rules: {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
 		"lint:github": "turbo lint:github",
 		"lint:root": "oxlint --ignore-pattern packages",
 		"prepare": "lefthook install",
+		"test": "turbo test",
+		"test:affected": "turbo test --affected",
+		"test:coverage": "turbo test:coverage",
 		"typecheck": "turbo typecheck",
 		"typegen:routes": "turbo typegen:routes",
 		"typegen:sanity": "turbo typegen:sanity"

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
 		"@mheob/oxlint-config": "^3.0.1",
 		"@mheob/tsconfig": "^3.0.2",
 		"@types/node": "^24.13.3",
+		"@vitest/coverage-v8": "^4.1.11",
 		"cve-lite-cli": "^1.30.0",
 		"czg": "^1.14.0",
 		"eslint-plugin-better-tailwindcss": "^4.7.0",
@@ -43,7 +44,8 @@
 		"sanity": "^6.10.1",
 		"tailwindcss": "^4.3.3",
 		"turbo": "^2.10.11",
-		"typescript": "^7.0.2"
+		"typescript": "^7.0.2",
+		"vitest": "^4.1.11"
 	},
 	"engines": {
 		"node": "^24.19.0",

--- a/packages/email/lib/cleverreach-markers.test.ts
+++ b/packages/email/lib/cleverreach-markers.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+
+import { marker, stripCleverReachMarkers, toCleverReachTemplate } from './cleverreach-markers';
+
+describe('marker building', () => {
+	it('builds a marker without attributes', () => {
+		expect(marker('html')).toBe('@@CR|html@@');
+	});
+
+	it('appends every attribute', () => {
+		expect(marker('img', { name: 'hero', src: 'logo.png' })).toBe(
+			'@@CR|img|name=hero|src=logo.png@@',
+		);
+	});
+
+	it('drops attributes that are undefined', () => {
+		expect(marker('img', { name: 'hero', src: undefined })).toBe('@@CR|img|name=hero@@');
+	});
+});
+
+describe('template conversion', () => {
+	it('turns a marker into a CleverReach comment', () => {
+		expect(toCleverReachTemplate('<p>@@CR|html@@</p>')).toBe('<p><!--#html#--></p>');
+	});
+
+	it('renders attributes as HTML attributes', () => {
+		expect(toCleverReachTemplate('@@CR|img|name=hero@@')).toBe('<!--#img name="hero"#-->');
+	});
+
+	it('converts every marker in the document', () => {
+		expect(toCleverReachTemplate('@@CR|html@@ and @@CR|loopitem@@')).toBe(
+			'<!--#html#--> and <!--#loopitem#-->',
+		);
+	});
+
+	it('removes the separators React inserts between children', () => {
+		expect(toCleverReachTemplate('a<!-- -->b')).toBe('ab');
+	});
+
+	it('leaves HTML without markers untouched', () => {
+		expect(toCleverReachTemplate('<p>Hallo TSG-Familie!</p>')).toBe('<p>Hallo TSG-Familie!</p>');
+	});
+});
+
+describe('marker stripping', () => {
+	it('removes a marker and keeps the surrounding HTML', () => {
+		expect(stripCleverReachMarkers('<p>@@CR|html@@Text</p>')).toBe('<p>Text</p>');
+	});
+
+	it('removes every marker', () => {
+		expect(stripCleverReachMarkers('@@CR|html@@a@@CR|img|name=hero@@b')).toBe('ab');
+	});
+
+	it('leaves HTML without markers untouched', () => {
+		expect(stripCleverReachMarkers('<p>Text</p>')).toBe('<p>Text</p>');
+	});
+});

--- a/packages/email/package.json
+++ b/packages/email/package.json
@@ -14,7 +14,10 @@
 		"export": "email export",
 		"lint": "oxlint",
 		"lint:fix": "oxlint --fix",
-		"lint:github": "oxlint --format=github"
+		"lint:github": "oxlint --format=github",
+		"test": "vitest run",
+		"test:coverage": "vitest run --coverage",
+		"test:watch": "vitest"
 	},
 	"dependencies": {
 		"@react-email/ui": "^6.9.2",
@@ -24,12 +27,16 @@
 		"react-email": "^6.9.2"
 	},
 	"devDependencies": {
+		"@react-email/render": "^2.1.0",
 		"@types/node": "^24.13.3",
 		"@types/react": "^19.2.18",
 		"@types/react-dom": "^19.2.4",
+		"@vitejs/plugin-react": "^6.1.0",
+		"@vitest/coverage-v8": "^4.1.11",
 		"oxlint": "^1.79.0",
 		"oxlint-tsgolint": "^7.0.2001",
 		"tsx": "^4.21.0",
-		"typescript": "^7.0.2"
+		"typescript": "^7.0.2",
+		"vitest": "^4.1.11"
 	}
 }

--- a/packages/email/vitest.config.ts
+++ b/packages/email/vitest.config.ts
@@ -1,0 +1,15 @@
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	plugins: [react()],
+	test: {
+		coverage: {
+			reporter: ['text', 'html', 'lcov'],
+		},
+		environment: 'node',
+		exclude: ['.react-email/**', 'node_modules/**'],
+		include: ['{components,emails,lib,scripts}/**/*.test.{ts,tsx}'],
+		name: 'email',
+	},
+});

--- a/packages/email/vitest.config.ts
+++ b/packages/email/vitest.config.ts
@@ -5,7 +5,10 @@ export default defineConfig({
 	plugins: [react()],
 	test: {
 		coverage: {
+			exclude: ['**/*.test.{ts,tsx}', '**/test-utils/**', '**/*.config.ts', '**/*.generated.ts'],
+			provider: 'v8',
 			reporter: ['text', 'html', 'lcov'],
+			reportsDirectory: './coverage',
 		},
 		environment: 'node',
 		exclude: ['.react-email/**', 'node_modules/**'],

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -14,6 +14,9 @@
 		"lint": "oxlint",
 		"lint:fix": "oxlint --fix",
 		"lint:github": "oxlint --format=github",
+		"test": "vitest run",
+		"test:coverage": "vitest run --coverage",
+		"test:watch": "vitest",
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
@@ -26,8 +29,11 @@
 		"@mheob/tsconfig": "^3.0.1",
 		"@types/react": "^19.2.18",
 		"@types/react-dom": "^19.2.4",
+		"@vitest/coverage-v8": "^4.1.11",
 		"oxlint": "^1.79.0",
 		"oxlint-tsgolint": "^7.0.2001",
-		"typescript": "^7.0.2"
+		"typescript": "^7.0.2",
+		"vite-tsconfig-paths": "^6.1.1",
+		"vitest": "^4.1.11"
 	}
 }

--- a/packages/shared/src/utils/date.test.ts
+++ b/packages/shared/src/utils/date.test.ts
@@ -9,7 +9,7 @@ const DAYS_PER_WEEK = 7;
 const DAYS_PER_MONTH = 30;
 const DAYS_PER_YEAR = 365;
 
-describe('TIME_SPAN_IN_SECONDS', () => {
+describe('time span constants', () => {
 	it('holds one second', () => {
 		expect(TIME_SPAN_IN_SECONDS.second).toBe(1);
 	});
@@ -39,12 +39,16 @@ describe('TIME_SPAN_IN_SECONDS', () => {
 	});
 });
 
-describe('timeSpanInMilliSeconds', () => {
+describe('time span conversion', () => {
 	it('converts a span to milliseconds', () => {
-		expect(timeSpanInMilliSeconds('minute')).toBe(SECONDS_PER_MINUTE * MS_PER_SECOND);
+		expect(timeSpanInMilliSeconds('minute')).toBe(60_000);
 	});
 
 	it('converts the smallest span', () => {
-		expect(timeSpanInMilliSeconds('second')).toBe(MS_PER_SECOND);
+		expect(timeSpanInMilliSeconds('second')).toBe(1000);
+	});
+
+	it('exports one second in milliseconds', () => {
+		expect(MS_PER_SECOND).toBe(1000);
 	});
 });

--- a/packages/shared/src/utils/date.test.ts
+++ b/packages/shared/src/utils/date.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+
+import { MS_PER_SECOND, TIME_SPAN_IN_SECONDS, timeSpanInMilliSeconds } from './date';
+
+const SECONDS_PER_MINUTE = 60;
+const MINUTES_PER_HOUR = 60;
+const HOURS_PER_DAY = 24;
+const DAYS_PER_WEEK = 7;
+const DAYS_PER_MONTH = 30;
+const DAYS_PER_YEAR = 365;
+
+describe('TIME_SPAN_IN_SECONDS', () => {
+	it('holds one second', () => {
+		expect(TIME_SPAN_IN_SECONDS.second).toBe(1);
+	});
+
+	it('holds a minute in seconds', () => {
+		expect(TIME_SPAN_IN_SECONDS.minute).toBe(SECONDS_PER_MINUTE);
+	});
+
+	it('holds an hour in seconds', () => {
+		expect(TIME_SPAN_IN_SECONDS.hour).toBe(SECONDS_PER_MINUTE * MINUTES_PER_HOUR);
+	});
+
+	it('holds a day in seconds', () => {
+		expect(TIME_SPAN_IN_SECONDS.day).toBe(SECONDS_PER_MINUTE * MINUTES_PER_HOUR * HOURS_PER_DAY);
+	});
+
+	it('holds a week as seven days', () => {
+		expect(TIME_SPAN_IN_SECONDS.week).toBe(TIME_SPAN_IN_SECONDS.day * DAYS_PER_WEEK);
+	});
+
+	it('holds a month as thirty days', () => {
+		expect(TIME_SPAN_IN_SECONDS.month).toBe(TIME_SPAN_IN_SECONDS.day * DAYS_PER_MONTH);
+	});
+
+	it('holds a year as 365 days', () => {
+		expect(TIME_SPAN_IN_SECONDS.year).toBe(TIME_SPAN_IN_SECONDS.day * DAYS_PER_YEAR);
+	});
+});
+
+describe('timeSpanInMilliSeconds', () => {
+	it('converts a span to milliseconds', () => {
+		expect(timeSpanInMilliSeconds('minute')).toBe(SECONDS_PER_MINUTE * MS_PER_SECOND);
+	});
+
+	it('converts the smallest span', () => {
+		expect(timeSpanInMilliSeconds('second')).toBe(MS_PER_SECOND);
+	});
+});

--- a/packages/shared/src/utils/date.ts
+++ b/packages/shared/src/utils/date.ts
@@ -4,8 +4,8 @@ const MS_PER_SECOND = 1000;
 const TIME_SPAN_IN_SECONDS = {
 	second: 1,
 	minute: 60,
-	hour: 360,
-	day: 8640,
+	hour: 3600,
+	day: 86_400,
 	week: 604_800,
 	month: 2_592_000,
 	year: 31_536_000,

--- a/packages/shared/vitest.config.ts
+++ b/packages/shared/vitest.config.ts
@@ -1,0 +1,14 @@
+import tsconfigPaths from 'vite-tsconfig-paths';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	plugins: [tsconfigPaths()],
+	test: {
+		coverage: {
+			reporter: ['text', 'html', 'lcov'],
+		},
+		environment: 'node',
+		include: ['src/**/*.test.{ts,tsx}'],
+		name: 'shared',
+	},
+});

--- a/packages/shared/vitest.config.ts
+++ b/packages/shared/vitest.config.ts
@@ -5,7 +5,10 @@ export default defineConfig({
 	plugins: [tsconfigPaths()],
 	test: {
 		coverage: {
+			exclude: ['**/*.test.{ts,tsx}', '**/test-utils/**', '**/*.config.ts', '**/*.generated.ts'],
+			provider: 'v8',
 			reporter: ['text', 'html', 'lcov'],
+			reportsDirectory: './coverage',
 		},
 		environment: 'node',
 		include: ['src/**/*.test.{ts,tsx}'],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -325,6 +325,9 @@ importers:
         specifier: ^6.9.2
         version: 6.9.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
     devDependencies:
+      '@react-email/render':
+        specifier: ^2.1.0
+        version: 2.1.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@types/node':
         specifier: ^24.13.3
         version: 24.13.3
@@ -334,6 +337,12 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.4
         version: 19.2.4(@types/react@19.2.18)
+      '@vitejs/plugin-react':
+        specifier: ^6.1.0
+        version: 6.1.0(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(rolldown@1.2.5)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+      '@vitest/coverage-v8':
+        specifier: ^4.1.11
+        version: 4.1.11(vitest@4.1.11)
       oxlint:
         specifier: ^1.79.0
         version: 1.79.0(oxlint-tsgolint@7.0.2001)
@@ -346,6 +355,9 @@ importers:
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
+      vitest:
+        specifier: ^4.1.11
+        version: 4.1.11(@types/node@24.13.3)(@vitest/coverage-v8@4.1.11)(jsdom@30.0.1(@noble/hashes@2.3.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
 
   packages/shared:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,6 +34,9 @@ importers:
       '@types/node':
         specifier: ^24.13.3
         version: 24.13.3
+      '@vitest/coverage-v8':
+        specifier: ^4.1.11
+        version: 4.1.11(vitest@4.1.11)
       cve-lite-cli:
         specifier: ^1.30.0
         version: 1.30.0
@@ -57,7 +60,7 @@ importers:
         version: 7.0.2001
       sanity:
         specifier: ^6.10.1
-        version: 6.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(@noble/hashes@2.3.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(rolldown@1.2.5)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)))(@sanity/sdk@3.0.0-rc.1(@types/react@19.2.18)(immer@11.1.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(xstate@5.32.5))(@types/node@24.13.3)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.2)(immer@11.1.18)(jiti@2.7.0)(oxfmt@0.64.0)(prismjs@1.30.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.5)(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)(typescript@7.0.2)
+        version: 6.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(@noble/hashes@2.3.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(rolldown@1.2.5)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)))(@sanity/sdk@3.0.0-rc.1(@types/react@19.2.18)(immer@11.1.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(xstate@5.32.5))(@types/node@24.13.3)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.2)(immer@11.1.18)(jiti@2.7.0)(oxfmt@0.64.0)(prismjs@1.30.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.5)(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)(typescript@7.0.2)(vitest@4.1.11)
       tailwindcss:
         specifier: ^4.3.3
         version: 4.3.3
@@ -67,24 +70,27 @@ importers:
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
+      vitest:
+        specifier: ^4.1.11
+        version: 4.1.11(@types/node@24.13.3)(@vitest/coverage-v8@4.1.11)(jsdom@29.1.1(@noble/hashes@2.3.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
 
   apps/studio:
     dependencies:
       '@sanity/assist':
         specifier: ^6.1.21
-        version: 6.1.21(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sanity@6.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(@noble/hashes@2.3.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(rolldown@1.2.5)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)))(@sanity/sdk@3.0.0-rc.1(@types/react@19.2.18)(immer@11.1.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(xstate@5.32.5))(@types/node@24.13.3)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.2)(immer@11.1.18)(jiti@2.7.0)(oxfmt@0.64.0)(prismjs@1.30.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.5)(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)(typescript@7.0.2))(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)
+        version: 6.1.21(fd34fbbff975555bcdeffbb4d7004ab4)
       '@sanity/icons':
         specifier: ^5.2.1
         version: 5.2.1(react@19.2.8)
       '@sanity/locale-de-de':
         specifier: ^1.1.36
-        version: 1.1.36(sanity@6.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(@noble/hashes@2.3.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(rolldown@1.2.5)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)))(@sanity/sdk@3.0.0-rc.1(@types/react@19.2.18)(immer@11.1.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(xstate@5.32.5))(@types/node@24.13.3)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.2)(immer@11.1.18)(jiti@2.7.0)(oxfmt@0.64.0)(prismjs@1.30.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.5)(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)(typescript@7.0.2))
+        version: 1.1.36(sanity@6.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(@noble/hashes@2.3.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(rolldown@1.2.5)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)))(@sanity/sdk@3.0.0-rc.1(@types/react@19.2.18)(immer@11.1.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(xstate@5.32.5))(@types/node@24.13.3)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.2)(immer@11.1.18)(jiti@2.7.0)(oxfmt@0.64.0)(prismjs@1.30.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.5)(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)(typescript@7.0.2)(vitest@4.1.11(@types/node@24.13.3)(@vitest/coverage-v8@4.1.11)(jsdom@29.1.1(@noble/hashes@2.3.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))))
       '@sanity/ui':
         specifier: ^4.0.4
         version: 4.0.5(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
       '@sanity/vision':
         specifier: ^6.10.1
-        version: 6.10.1(@babel/runtime@7.29.7)(@codemirror/lint@6.9.7)(@codemirror/theme-one-dark@6.1.3)(codemirror@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sanity@6.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(@noble/hashes@2.3.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(rolldown@1.2.5)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)))(@sanity/sdk@3.0.0-rc.1(@types/react@19.2.18)(immer@11.1.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(xstate@5.32.5))(@types/node@24.13.3)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.2)(immer@11.1.18)(jiti@2.7.0)(oxfmt@0.64.0)(prismjs@1.30.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.5)(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)(typescript@7.0.2))(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
+        version: 6.10.1(6a7f3d16f54dd9c855e35016480c1f5f)
       '@tsgi-web/shared':
         specifier: workspace:*
         version: link:../../packages/shared
@@ -102,10 +108,10 @@ importers:
         version: 5.7.0(react@19.2.8)
       sanity:
         specifier: ^6.10.1
-        version: 6.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(@noble/hashes@2.3.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(rolldown@1.2.5)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)))(@sanity/sdk@3.0.0-rc.1(@types/react@19.2.18)(immer@11.1.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(xstate@5.32.5))(@types/node@24.13.3)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.2)(immer@11.1.18)(jiti@2.7.0)(oxfmt@0.64.0)(prismjs@1.30.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.5)(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)(typescript@7.0.2)
+        version: 6.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(@noble/hashes@2.3.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(rolldown@1.2.5)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)))(@sanity/sdk@3.0.0-rc.1(@types/react@19.2.18)(immer@11.1.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(xstate@5.32.5))(@types/node@24.13.3)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.2)(immer@11.1.18)(jiti@2.7.0)(oxfmt@0.64.0)(prismjs@1.30.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.5)(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)(typescript@7.0.2)(vitest@4.1.11)
       sanity-plugin-media:
         specifier: ^6.1.6
-        version: 6.1.6(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sanity@6.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(@noble/hashes@2.3.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(rolldown@1.2.5)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)))(@sanity/sdk@3.0.0-rc.1(@types/react@19.2.18)(immer@11.1.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(xstate@5.32.5))(@types/node@24.13.3)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.2)(immer@11.1.18)(jiti@2.7.0)(oxfmt@0.64.0)(prismjs@1.30.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.5)(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)(typescript@7.0.2))(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)
+        version: 6.1.6(fd34fbbff975555bcdeffbb4d7004ab4)
       slugify:
         specifier: ^1.6.9
         version: 1.6.9
@@ -172,7 +178,7 @@ importers:
         version: 1.1.19(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@sanity/client':
         specifier: ^8.2.0
-        version: 8.2.0
+        version: 8.2.0(vitest@4.1.11)
       '@sanity/image-url':
         specifier: ^2.1.1
         version: 2.1.1
@@ -208,7 +214,7 @@ importers:
         version: 8.6.1(next@16.3.2(@babel/core@7.29.7(supports-color@8.1.1))(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       next-sanity:
         specifier: ^13.3.3
-        version: 13.3.3(8d2a66b9087f2bca67bc4b27e03323c9)
+        version: 13.3.3(6a18327cd7a19db48a37e7fe1c1c69f5)
       react:
         specifier: 19.2.8
         version: 19.2.8
@@ -223,7 +229,7 @@ importers:
         version: 6.21.0(@react-email/render@2.1.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
       sanity:
         specifier: ^6.10.1
-        version: 6.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(@noble/hashes@2.3.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(rolldown@1.2.5)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)))(@sanity/sdk@3.0.0-rc.1(@types/react@19.2.18)(immer@11.1.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(xstate@5.32.5))(@types/node@24.13.3)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.2)(immer@11.1.18)(jiti@2.7.0)(oxfmt@0.64.0)(prismjs@1.30.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.5)(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)(typescript@7.0.2)
+        version: 6.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(@noble/hashes@2.3.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(rolldown@1.2.5)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)))(@sanity/sdk@3.0.0-rc.1(@types/react@19.2.18)(immer@11.1.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(xstate@5.32.5))(@types/node@24.13.3)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.2)(immer@11.1.18)(jiti@2.7.0)(oxfmt@0.64.0)(prismjs@1.30.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.5)(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)(typescript@7.0.2)(vitest@4.1.11)
       server-only:
         specifier: ^0.0.1
         version: 0.0.1
@@ -329,6 +335,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.4
         version: 19.2.4(@types/react@19.2.18)
+      '@vitest/coverage-v8':
+        specifier: ^4.1.11
+        version: 4.1.11(vitest@4.1.11)
       oxlint:
         specifier: ^1.79.0
         version: 1.79.0(oxlint-tsgolint@7.0.2001)
@@ -338,6 +347,12 @@ importers:
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
+      vite-tsconfig-paths:
+        specifier: ^6.1.1
+        version: 6.1.1(supports-color@8.1.1)(typescript@7.0.2)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+      vitest:
+        specifier: ^4.1.11
+        version: 4.1.11(@types/node@24.13.3)(@vitest/coverage-v8@4.1.11)(jsdom@29.1.1(@noble/hashes@2.3.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
 
 packages:
 
@@ -997,6 +1012,10 @@ packages:
   '@babel/types@7.29.8':
     resolution: {integrity: sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==}
     engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@bramus/specificity@2.4.2':
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
@@ -3969,8 +3988,17 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/cors@2.8.19':
     resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
   '@types/event-source-polyfill@1.0.5':
     resolution: {integrity: sha512-iaiDuDI2aIFft7XkcwMzDWLqo7LVDixd2sR6B4wxJut9xcp/Ev9bO4EFg4rm6S9QxATLBj5OPxdeocgmhjwKaw==}
@@ -4237,6 +4265,44 @@ packages:
       oxc-transform-react:
         optional: true
 
+  '@vitest/coverage-v8@4.1.11':
+    resolution: {integrity: sha512-8MVGEFnJIcdGjcbfKmeq8z0pZHH0JlVtoVZH9Q/qwUp6wyFnEJUBMrw9DCaj+ra3vShGmhavjalMIhPNxZAUcw==}
+    peerDependencies:
+      '@vitest/browser': 4.1.11
+      vitest: 4.1.11
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
+  '@vitest/expect@4.1.11':
+    resolution: {integrity: sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==}
+
+  '@vitest/mocker@4.1.11':
+    resolution: {integrity: sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.11':
+    resolution: {integrity: sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==}
+
+  '@vitest/runner@4.1.11':
+    resolution: {integrity: sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==}
+
+  '@vitest/snapshot@4.1.11':
+    resolution: {integrity: sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==}
+
+  '@vitest/spy@4.1.11':
+    resolution: {integrity: sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==}
+
+  '@vitest/utils@4.1.11':
+    resolution: {integrity: sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==}
+
   '@xstate/react@6.1.0':
     resolution: {integrity: sha512-ep9F0jGTI63B/jE8GHdMpUqtuz7yRebNaKv8EMUaiSi29NOglywc2X2YSOV/ygbIK+LtmgZ0q9anoEA2iBSEOw==}
     peerDependencies:
@@ -4340,6 +4406,13 @@ packages:
   arrify@3.0.0:
     resolution: {integrity: sha512-tLkvA81vQG/XqE2mjDkGQHoOINtMHtysSnemrmoGe6PydDPMRbVugqyk4A6V/WDWEfm3l+0d8anA9r8cv/5Jaw==}
     engines: {node: '>=12'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  ast-v8-to-istanbul@1.0.5:
+    resolution: {integrity: sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==}
 
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
@@ -4525,6 +4598,10 @@ packages:
     resolution: {integrity: sha512-QJ6k4lOD/btI08xG8jBPxRCGXvCnusGGkTsiXk0u3NqUu/W+BXRnFD4PYjwtqh8AWmGa5LDbGk0fLQsqr0nSMA==}
     peerDependencies:
       react: '>=17.0.0'
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -5012,6 +5089,9 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -5055,6 +5135,10 @@ packages:
   expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -5242,6 +5326,9 @@ packages:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
     engines: {node: '>=10'}
 
+  globrex@0.1.2:
+    resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
+
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
@@ -5312,6 +5399,9 @@ packages:
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   html-parse-stringify@4.0.1:
     resolution: {integrity: sha512-0zHsZJrK7S3K2aucXWL6ycoYJ/iNtIcFHC/nYQgFklPtrv5LpJctIiSCroWZWeuoXvuyFdzp6KzjJQ+OT5MfFw==}
@@ -5524,6 +5614,18 @@ packages:
     peerDependencies:
       ws: '*'
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
@@ -5531,6 +5633,9 @@ packages:
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -5873,9 +5978,16 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  magicast@0.5.4:
+    resolution: {integrity: sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==}
+
   make-dir@2.1.0:
     resolution: {integrity: sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==}
     engines: {node: '>=6'}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   markdown-it@14.3.0:
     resolution: {integrity: sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==}
@@ -6807,6 +6919,9 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -6873,8 +6988,14 @@ packages:
     resolution: {integrity: sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==}
     engines: {node: '>=0.10.0'}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   standardwebhooks@1.0.0:
     resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
 
   stdin-discarder@0.3.2:
     resolution: {integrity: sha512-eCPu1qRxPVkl5605OTWF8Wz40b4Mf45NY5LQmVPQ599knfs5QhASUm9GbJ5BDMDOXgrnh0wyEdvzmL//YMlw0A==}
@@ -7053,6 +7174,9 @@ packages:
   through2@4.0.2:
     resolution: {integrity: sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyexec@1.3.0:
     resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
     engines: {node: '>=18'}
@@ -7064,6 +7188,10 @@ packages:
   tinypool@2.1.0:
     resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
     engines: {node: ^20.0.0 || >=22.0.0}
+
+  tinyrainbow@3.1.1:
+    resolution: {integrity: sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==}
+    engines: {node: '>=14.0.0'}
 
   tldts-core@7.4.10:
     resolution: {integrity: sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==}
@@ -7089,6 +7217,17 @@ packages:
 
   ts-brand@0.2.0:
     resolution: {integrity: sha512-H5uo7OqMvd91D2EefFmltBP9oeNInNzWLAZUSt6coGDn8b814Eis6SnEtzyXORr9ccEb38PfzyiRVDacdkycSQ==}
+
+  tsconfck@3.1.6:
+    resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
+    engines: {node: ^18 || >=20}
+    deprecated: unmaintained
+    hasBin: true
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   tsconfig-paths-webpack-plugin@4.2.0:
     resolution: {integrity: sha512-zbem3rfRS8BgeNK50Zz5SIQgXzLafiHjOwUAvk/38/o1jHn/V5QAgVUcz884or7WYcPaH3N2CIfUc2u0ul7UcA==}
@@ -7282,6 +7421,11 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
+  vite-tsconfig-paths@6.1.1:
+    resolution: {integrity: sha512-2cihq7zliibCCZ8P9cKJrQBkfgdvcFkOOc3Y02o3GWUDLgqjWsZudaoiuOwO/gzTzy17cS5F7ZPo4bsnS4DGkg==}
+    peerDependencies:
+      vite: '*'
+
   vite@8.2.2:
     resolution: {integrity: sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -7325,6 +7469,47 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.1.11:
+    resolution: {integrity: sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.11
+      '@vitest/browser-preview': 4.1.11
+      '@vitest/browser-webdriverio': 4.1.11
+      '@vitest/coverage-istanbul': 4.1.11
+      '@vitest/coverage-v8': 4.1.11
+      '@vitest/ui': 4.1.11
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   w3c-keyname@2.2.8:
     resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
 
@@ -7358,6 +7543,11 @@ packages:
   which@6.0.1:
     resolution: {integrity: sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==}
     engines: {node: ^20.17.0 || >=22.9.0}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   widest-line@3.1.0:
@@ -8373,6 +8563,8 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@bramus/specificity@2.4.2':
     dependencies:
@@ -10336,10 +10528,10 @@ snapshots:
 
   '@sanity/asset-utils@2.3.0': {}
 
-  '@sanity/assist@6.1.21(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sanity@6.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(@noble/hashes@2.3.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(rolldown@1.2.5)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)))(@sanity/sdk@3.0.0-rc.1(@types/react@19.2.18)(immer@11.1.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(xstate@5.32.5))(@types/node@24.13.3)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.2)(immer@11.1.18)(jiti@2.7.0)(oxfmt@0.64.0)(prismjs@1.30.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.5)(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)(typescript@7.0.2))(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)':
+  '@sanity/assist@6.1.21(fd34fbbff975555bcdeffbb4d7004ab4)':
     dependencies:
       '@portabletext/types': 4.0.2
-      '@sanity/client': 8.2.0
+      '@sanity/client': 8.2.0(vitest@4.1.11)
       '@sanity/color': 3.0.8
       '@sanity/icons': 5.2.1(react@19.2.8)
       '@sanity/mutator': 6.10.1(@types/react@19.2.18)(supports-color@8.1.1)
@@ -10351,7 +10543,7 @@ snapshots:
       react-fast-compare: 3.2.2
       rxjs: 7.8.2
       rxjs-exhaustmap-with-trailing: 2.1.1(rxjs@7.8.2)
-      sanity: 6.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(@noble/hashes@2.3.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(rolldown@1.2.5)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)))(@sanity/sdk@3.0.0-rc.1(@types/react@19.2.18)(immer@11.1.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(xstate@5.32.5))(@types/node@24.13.3)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.2)(immer@11.1.18)(jiti@2.7.0)(oxfmt@0.64.0)(prismjs@1.30.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.5)(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)(typescript@7.0.2)
+      sanity: 6.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(@noble/hashes@2.3.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(rolldown@1.2.5)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)))(@sanity/sdk@3.0.0-rc.1(@types/react@19.2.18)(immer@11.1.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(xstate@5.32.5))(@types/node@24.13.3)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.2)(immer@11.1.18)(jiti@2.7.0)(oxfmt@0.64.0)(prismjs@1.30.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.5)(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)(typescript@7.0.2)(vitest@4.1.11)
       styled-components: 6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
     transitivePeerDependencies:
       - '@types/react'
@@ -10369,16 +10561,16 @@ snapshots:
     optionalDependencies:
       vite: 8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
 
-  '@sanity/cli-build@5.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(@noble/hashes@2.3.0)(@types/node@24.13.3)(@types/react@19.2.18)(esbuild@0.28.2)(jiti@2.7.0)(rolldown@1.2.5)(tsx@4.23.12)(typescript@7.0.2)(yaml@2.9.0)':
+  '@sanity/cli-build@5.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(@noble/hashes@2.3.0)(@types/node@24.13.3)(@types/react@19.2.18)(esbuild@0.28.2)(jiti@2.7.0)(rolldown@1.2.5)(tsx@4.23.12)(typescript@7.0.2)(vitest@4.1.11)(yaml@2.9.0)':
     dependencies:
       '@oclif/core': 4.14.0
       '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(rolldown@1.2.5)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
-      '@sanity/cli-core': 3.2.0(@noble/hashes@2.3.0)(@types/node@24.13.3)(esbuild@0.28.2)(yaml@2.9.0)
+      '@sanity/cli-core': 3.2.0(@noble/hashes@2.3.0)(@types/node@24.13.3)(esbuild@0.28.2)(vitest@4.1.11)(yaml@2.9.0)
       '@sanity/generate-help-url': 4.0.0
       '@sanity/schema': 6.10.1(@types/react@19.2.18)
       '@sanity/telemetry': 1.1.0(react@19.2.8)
       '@sanity/types': 6.10.1(@types/react@19.2.18)
-      '@sanity/workbench-cli': 2.0.2(@noble/hashes@2.3.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(rolldown@1.2.5)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)))(@types/node@24.13.3)(@types/react@19.2.18)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(typescript@7.0.2)(yaml@2.9.0)
+      '@sanity/workbench-cli': 2.0.2(@noble/hashes@2.3.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(rolldown@1.2.5)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)))(@types/node@24.13.3)(@types/react@19.2.18)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(typescript@7.0.2)(vitest@4.1.11)(yaml@2.9.0)
       '@vitejs/plugin-react': 6.1.0(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(rolldown@1.2.5)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
       chokidar: 5.0.0
       cjs-module-lexer: 2.2.1
@@ -10421,14 +10613,14 @@ snapshots:
       - vue-tsc
       - yaml
 
-  '@sanity/cli-core@3.2.0(@noble/hashes@2.3.0)(@types/node@24.13.3)(esbuild@0.28.2)(yaml@2.9.0)':
+  '@sanity/cli-core@3.2.0(@noble/hashes@2.3.0)(@types/node@24.13.3)(esbuild@0.28.2)(vitest@4.1.11)(yaml@2.9.0)':
     dependencies:
       '@inquirer/prompts': 8.6.0(@types/node@24.13.3)
       '@oclif/core': 4.14.0
-      '@sanity/client': 8.2.0
+      '@sanity/client': 8.2.0(vitest@4.1.11)
       boxen: 8.0.1
       empathic: 2.0.1
-      get-it: 9.5.1
+      get-it: 9.5.1(vitest@4.1.11)
       get-tsconfig: 4.14.3
       import-meta-resolve: 4.2.0
       jiti: 2.7.0
@@ -10458,27 +10650,27 @@ snapshots:
       - vitest
       - yaml
 
-  '@sanity/cli@8.2.1(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(@noble/hashes@2.3.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(rolldown@1.2.5)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)))(@types/node@24.13.3)(@types/react@19.2.18)(esbuild@0.28.2)(jiti@2.7.0)(oxfmt@0.64.0)(rolldown@1.2.5)(supports-color@8.1.1)(typescript@7.0.2)(xstate@5.32.5)':
+  '@sanity/cli@8.2.1(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(@noble/hashes@2.3.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(rolldown@1.2.5)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)))(@types/node@24.13.3)(@types/react@19.2.18)(esbuild@0.28.2)(jiti@2.7.0)(oxfmt@0.64.0)(rolldown@1.2.5)(supports-color@8.1.1)(typescript@7.0.2)(vitest@4.1.11)(xstate@5.32.5)':
     dependencies:
       '@oclif/core': 4.14.0
       '@oclif/plugin-help': 6.2.58
       '@oclif/plugin-not-found': 3.2.93(@types/node@24.13.3)
-      '@sanity/cli-build': 5.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(@noble/hashes@2.3.0)(@types/node@24.13.3)(@types/react@19.2.18)(esbuild@0.28.2)(jiti@2.7.0)(rolldown@1.2.5)(tsx@4.23.12)(typescript@7.0.2)(yaml@2.9.0)
-      '@sanity/cli-core': 3.2.0(@noble/hashes@2.3.0)(@types/node@24.13.3)(esbuild@0.28.2)(yaml@2.9.0)
-      '@sanity/client': 8.2.0
+      '@sanity/cli-build': 5.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(@noble/hashes@2.3.0)(@types/node@24.13.3)(@types/react@19.2.18)(esbuild@0.28.2)(jiti@2.7.0)(rolldown@1.2.5)(tsx@4.23.12)(typescript@7.0.2)(vitest@4.1.11)(yaml@2.9.0)
+      '@sanity/cli-core': 3.2.0(@noble/hashes@2.3.0)(@types/node@24.13.3)(esbuild@0.28.2)(vitest@4.1.11)(yaml@2.9.0)
+      '@sanity/client': 8.2.0(vitest@4.1.11)
       '@sanity/codegen': 8.0.0(oxfmt@0.64.0)(react@19.2.8)(supports-color@8.1.1)
       '@sanity/descriptors': 1.3.0
       '@sanity/export': 6.2.1(supports-color@8.1.1)
       '@sanity/generate-help-url': 4.0.0
       '@sanity/id-utils': 1.0.0
-      '@sanity/import': 6.0.4(@sanity/client@8.2.0)(@types/react@19.2.18)(supports-color@8.1.1)
+      '@sanity/import': 6.0.4(@sanity/client@8.2.0(vitest@4.1.11))(@types/react@19.2.18)(supports-color@8.1.1)
       '@sanity/migrate': 8.0.2(@types/react@19.2.18)(supports-color@8.1.1)(xstate@5.32.5)
-      '@sanity/runtime-cli': 17.9.0(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(@noble/hashes@2.3.0)(@types/node@24.13.3)(@types/react@19.2.18)(esbuild@0.28.2)(rolldown@1.2.5)(tsx@4.23.12)(typescript@7.0.2)(yaml@2.9.0)
+      '@sanity/runtime-cli': 17.9.0(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(@noble/hashes@2.3.0)(@types/node@24.13.3)(@types/react@19.2.18)(esbuild@0.28.2)(rolldown@1.2.5)(tsx@4.23.12)(typescript@7.0.2)(vitest@4.1.11)(yaml@2.9.0)
       '@sanity/schema': 6.10.1(@types/react@19.2.18)
       '@sanity/telemetry': 1.1.0(react@19.2.8)
       '@sanity/template-validator': 3.1.0
       '@sanity/types': 6.10.1(@types/react@19.2.18)
-      '@sanity/workbench-cli': 2.0.2(@noble/hashes@2.3.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(rolldown@1.2.5)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)))(@types/node@24.13.3)(@types/react@19.2.18)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(typescript@7.0.2)(yaml@2.9.0)
+      '@sanity/workbench-cli': 2.0.2(@noble/hashes@2.3.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(rolldown@1.2.5)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)))(@types/node@24.13.3)(@types/react@19.2.18)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(typescript@7.0.2)(vitest@4.1.11)(yaml@2.9.0)
       '@sanity/worker-channels': 2.0.0
       '@vercel/frameworks': 3.29.0
       chokidar: 5.0.0
@@ -10564,10 +10756,10 @@ snapshots:
       nanoid: 3.3.18
       rxjs: 7.8.2
 
-  '@sanity/client@8.2.0':
+  '@sanity/client@8.2.0(vitest@4.1.11)':
     dependencies:
       eventsource: 5.1.1
-      get-it: 9.5.1
+      get-it: 9.5.1(vitest@4.1.11)
       nanoid: 6.0.1
       obug: 2.1.4
       rxjs: 7.8.2
@@ -10670,10 +10862,10 @@ snapshots:
     dependencies:
       '@sanity/signed-urls': 2.0.5
 
-  '@sanity/import@6.0.4(@sanity/client@8.2.0)(@types/react@19.2.18)(supports-color@8.1.1)':
+  '@sanity/import@6.0.4(@sanity/client@8.2.0(vitest@4.1.11))(@types/react@19.2.18)(supports-color@8.1.1)':
     dependencies:
       '@sanity/asset-utils': 2.3.0
-      '@sanity/client': 8.2.0
+      '@sanity/client': 8.2.0(vitest@4.1.11)
       '@sanity/generate-help-url': 4.0.0
       '@sanity/mutator': 6.10.1(@types/react@19.2.18)(supports-color@8.1.1)
       debug: 4.4.3(supports-color@8.1.1)
@@ -10698,9 +10890,9 @@ snapshots:
       '@lezer/highlight': 1.2.3
       '@lezer/lr': 1.4.10
 
-  '@sanity/locale-de-de@1.1.36(sanity@6.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(@noble/hashes@2.3.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(rolldown@1.2.5)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)))(@sanity/sdk@3.0.0-rc.1(@types/react@19.2.18)(immer@11.1.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(xstate@5.32.5))(@types/node@24.13.3)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.2)(immer@11.1.18)(jiti@2.7.0)(oxfmt@0.64.0)(prismjs@1.30.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.5)(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)(typescript@7.0.2))':
+  '@sanity/locale-de-de@1.1.36(sanity@6.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(@noble/hashes@2.3.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(rolldown@1.2.5)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)))(@sanity/sdk@3.0.0-rc.1(@types/react@19.2.18)(immer@11.1.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(xstate@5.32.5))(@types/node@24.13.3)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.2)(immer@11.1.18)(jiti@2.7.0)(oxfmt@0.64.0)(prismjs@1.30.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.5)(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)(typescript@7.0.2)(vitest@4.1.11(@types/node@24.13.3)(@vitest/coverage-v8@4.1.11)(jsdom@29.1.1(@noble/hashes@2.3.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))))':
     dependencies:
-      sanity: 6.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(@noble/hashes@2.3.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(rolldown@1.2.5)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)))(@sanity/sdk@3.0.0-rc.1(@types/react@19.2.18)(immer@11.1.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(xstate@5.32.5))(@types/node@24.13.3)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.2)(immer@11.1.18)(jiti@2.7.0)(oxfmt@0.64.0)(prismjs@1.30.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.5)(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)(typescript@7.0.2)
+      sanity: 6.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(@noble/hashes@2.3.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(rolldown@1.2.5)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)))(@sanity/sdk@3.0.0-rc.1(@types/react@19.2.18)(immer@11.1.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(xstate@5.32.5))(@types/node@24.13.3)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.2)(immer@11.1.18)(jiti@2.7.0)(oxfmt@0.64.0)(prismjs@1.30.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.5)(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)(typescript@7.0.2)(vitest@4.1.11)
 
   '@sanity/logos@2.2.5(react@19.2.8)':
     dependencies:
@@ -10767,9 +10959,9 @@ snapshots:
     transitivePeerDependencies:
       - '@sanity/types'
 
-  '@sanity/preview-url-secret@4.1.4(@sanity/client@8.2.0)':
+  '@sanity/preview-url-secret@4.1.4(@sanity/client@8.2.0(vitest@4.1.11))':
     dependencies:
-      '@sanity/client': 8.2.0
+      '@sanity/client': 8.2.0(vitest@4.1.11)
       '@sanity/uuid': 3.0.3
 
   '@sanity/preview-url-secret@4.1.5(@sanity/client@7.26.2)':
@@ -10781,7 +10973,7 @@ snapshots:
     optionalDependencies:
       prismjs: 1.30.0
 
-  '@sanity/runtime-cli@17.9.0(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(@noble/hashes@2.3.0)(@types/node@24.13.3)(@types/react@19.2.18)(esbuild@0.28.2)(rolldown@1.2.5)(tsx@4.23.12)(typescript@7.0.2)(yaml@2.9.0)':
+  '@sanity/runtime-cli@17.9.0(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(@noble/hashes@2.3.0)(@types/node@24.13.3)(@types/react@19.2.18)(esbuild@0.28.2)(rolldown@1.2.5)(tsx@4.23.12)(typescript@7.0.2)(vitest@4.1.11)(yaml@2.9.0)':
     dependencies:
       '@architect/hydrate': 6.0.2
       '@architect/inventory': 6.1.0
@@ -10792,9 +10984,9 @@ snapshots:
       '@sanity-labs/oclif-plugin-skills-flag': 0.2.1(@oclif/core@4.14.0)
       '@sanity/blueprints': 0.23.6(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
       '@sanity/blueprints-parser': 0.5.0
-      '@sanity/cli-build': 5.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(@noble/hashes@2.3.0)(@types/node@24.13.3)(@types/react@19.2.18)(esbuild@0.28.2)(jiti@2.7.0)(rolldown@1.2.5)(tsx@4.23.12)(typescript@7.0.2)(yaml@2.9.0)
-      '@sanity/cli-core': 3.2.0(@noble/hashes@2.3.0)(@types/node@24.13.3)(esbuild@0.28.2)(yaml@2.9.0)
-      '@sanity/client': 8.2.0
+      '@sanity/cli-build': 5.3.0(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(@noble/hashes@2.3.0)(@types/node@24.13.3)(@types/react@19.2.18)(esbuild@0.28.2)(jiti@2.7.0)(rolldown@1.2.5)(tsx@4.23.12)(typescript@7.0.2)(vitest@4.1.11)(yaml@2.9.0)
+      '@sanity/cli-core': 3.2.0(@noble/hashes@2.3.0)(@types/node@24.13.3)(esbuild@0.28.2)(vitest@4.1.11)(yaml@2.9.0)
+      '@sanity/client': 8.2.0(vitest@4.1.11)
       adm-zip: 0.6.0
       array-treeify: 0.2.0
       cardinal: 2.1.1
@@ -10916,7 +11108,7 @@ snapshots:
       '@sanity/types': 6.10.1(@types/react@19.2.18)
       groq: 3.88.1-typegen-experimental.0
       groq-js: 2.0.0
-      reselect: 5.2.0
+      reselect: 5.3.0
       rxjs: 7.8.2
       zustand: 5.0.15(@types/react@19.2.18)(immer@11.1.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))
     transitivePeerDependencies:
@@ -11003,7 +11195,7 @@ snapshots:
     dependencies:
       uuid: 14.0.2
 
-  '@sanity/vision@6.10.1(@babel/runtime@7.29.7)(@codemirror/lint@6.9.7)(@codemirror/theme-one-dark@6.1.3)(codemirror@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sanity@6.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(@noble/hashes@2.3.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(rolldown@1.2.5)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)))(@sanity/sdk@3.0.0-rc.1(@types/react@19.2.18)(immer@11.1.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(xstate@5.32.5))(@types/node@24.13.3)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.2)(immer@11.1.18)(jiti@2.7.0)(oxfmt@0.64.0)(prismjs@1.30.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.5)(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)(typescript@7.0.2))(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
+  '@sanity/vision@6.10.1(6a7f3d16f54dd9c855e35016480c1f5f)':
     dependencies:
       '@codemirror/autocomplete': 6.20.3
       '@codemirror/commands': 6.11.0
@@ -11031,7 +11223,7 @@ snapshots:
       react: 19.2.8
       react-rx: 5.1.2(react@19.2.8)(rxjs@7.8.2)
       rxjs: 7.8.2
-      sanity: 6.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(@noble/hashes@2.3.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(rolldown@1.2.5)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)))(@sanity/sdk@3.0.0-rc.1(@types/react@19.2.18)(immer@11.1.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(xstate@5.32.5))(@types/node@24.13.3)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.2)(immer@11.1.18)(jiti@2.7.0)(oxfmt@0.64.0)(prismjs@1.30.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.5)(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)(typescript@7.0.2)
+      sanity: 6.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(@noble/hashes@2.3.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(rolldown@1.2.5)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)))(@sanity/sdk@3.0.0-rc.1(@types/react@19.2.18)(immer@11.1.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(xstate@5.32.5))(@types/node@24.13.3)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.2)(immer@11.1.18)(jiti@2.7.0)(oxfmt@0.64.0)(prismjs@1.30.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.5)(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)(typescript@7.0.2)(vitest@4.1.11)
       use-effect-event: 2.0.3(react@19.2.8)
     transitivePeerDependencies:
       - '@babel/runtime'
@@ -11041,18 +11233,18 @@ snapshots:
       - react-dom
       - styled-components
 
-  '@sanity/visual-editing-csm@3.0.16(@sanity/client@8.2.0)(@sanity/types@6.10.1(@types/react@19.2.18))(typescript@7.0.2)':
+  '@sanity/visual-editing-csm@3.0.16(@sanity/client@8.2.0(vitest@4.1.11))(@sanity/types@6.10.1(@types/react@19.2.18))(typescript@7.0.2)':
     dependencies:
-      '@sanity/client': 8.2.0
-      '@sanity/visual-editing-types': 2.1.0(@sanity/client@8.2.0)(@sanity/types@6.10.1(@types/react@19.2.18))
+      '@sanity/client': 8.2.0(vitest@4.1.11)
+      '@sanity/visual-editing-types': 2.1.0(@sanity/client@8.2.0(vitest@4.1.11))(@sanity/types@6.10.1(@types/react@19.2.18))
       valibot: 1.4.2(typescript@7.0.2)
     transitivePeerDependencies:
       - '@sanity/types'
       - typescript
 
-  '@sanity/visual-editing-types@2.1.0(@sanity/client@8.2.0)(@sanity/types@6.10.1(@types/react@19.2.18))':
+  '@sanity/visual-editing-types@2.1.0(@sanity/client@8.2.0(vitest@4.1.11))(@sanity/types@6.10.1(@types/react@19.2.18))':
     dependencies:
-      '@sanity/client': 8.2.0
+      '@sanity/client': 8.2.0(vitest@4.1.11)
     optionalDependencies:
       '@sanity/types': 6.10.1(@types/react@19.2.18)
 
@@ -11062,17 +11254,17 @@ snapshots:
     optionalDependencies:
       '@sanity/types': 6.10.1(@types/react@19.2.18)
 
-  '@sanity/visual-editing@6.1.0(@sanity/client@8.2.0)(@types/react@19.2.18)(next@16.3.2(@babel/core@7.29.7(supports-color@8.1.1))(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(typescript@7.0.2)':
+  '@sanity/visual-editing@6.1.0(@sanity/client@8.2.0(vitest@4.1.11))(@types/react@19.2.18)(next@16.3.2(@babel/core@7.29.7(supports-color@8.1.1))(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(typescript@7.0.2)':
     dependencies:
       '@sanity/comlink': 4.0.3
       '@sanity/icons': 5.2.1(react@19.2.8)
       '@sanity/mutate': 0.18.1(xstate@5.32.5)
       '@sanity/presentation-comlink': 2.2.3(@sanity/types@6.10.1(@types/react@19.2.18))
-      '@sanity/preview-url-secret': 4.1.4(@sanity/client@8.2.0)
+      '@sanity/preview-url-secret': 4.1.4(@sanity/client@8.2.0(vitest@4.1.11))
       '@sanity/types': 6.10.1(@types/react@19.2.18)
       '@sanity/ui': 4.0.5(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
-      '@sanity/visual-editing-csm': 3.0.16(@sanity/client@8.2.0)(@sanity/types@6.10.1(@types/react@19.2.18))(typescript@7.0.2)
-      '@sanity/visual-editing-types': 2.1.0(@sanity/client@8.2.0)(@sanity/types@6.10.1(@types/react@19.2.18))
+      '@sanity/visual-editing-csm': 3.0.16(@sanity/client@8.2.0(vitest@4.1.11))(@sanity/types@6.10.1(@types/react@19.2.18))(typescript@7.0.2)
+      '@sanity/visual-editing-types': 2.1.0(@sanity/client@8.2.0(vitest@4.1.11))(@sanity/types@6.10.1(@types/react@19.2.18))
       '@vercel/stega': 1.1.0
       dequal: 2.0.3
       lodash-es: 4.18.1
@@ -11084,7 +11276,7 @@ snapshots:
       styled-components: 6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       xstate: 5.32.5
     optionalDependencies:
-      '@sanity/client': 8.2.0
+      '@sanity/client': 8.2.0(vitest@4.1.11)
       next: 16.3.2(@babel/core@7.29.7(supports-color@8.1.1))(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
     transitivePeerDependencies:
       - '@types/react'
@@ -11092,10 +11284,10 @@ snapshots:
 
   '@sanity/webhook@4.0.4': {}
 
-  '@sanity/workbench-cli@2.0.2(@noble/hashes@2.3.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(rolldown@1.2.5)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)))(@types/node@24.13.3)(@types/react@19.2.18)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(typescript@7.0.2)(yaml@2.9.0)':
+  '@sanity/workbench-cli@2.0.2(@noble/hashes@2.3.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(rolldown@1.2.5)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)))(@types/node@24.13.3)(@types/react@19.2.18)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(typescript@7.0.2)(vitest@4.1.11)(yaml@2.9.0)':
     dependencies:
       '@module-federation/vite': 1.20.7(typescript@7.0.2)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
-      '@sanity/cli-core': 3.2.0(@noble/hashes@2.3.0)(@types/node@24.13.3)(esbuild@0.28.2)(yaml@2.9.0)
+      '@sanity/cli-core': 3.2.0(@noble/hashes@2.3.0)(@types/node@24.13.3)(esbuild@0.28.2)(vitest@4.1.11)(yaml@2.9.0)
       '@sanity/types': 6.10.1(@types/react@19.2.18)
       '@vitejs/plugin-react': 6.1.0(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(rolldown@1.2.5)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
       form-data: 4.0.6
@@ -11326,9 +11518,18 @@ snapshots:
   '@turbo/windows-arm64@2.10.11':
     optional: true
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/cors@2.8.19':
     dependencies:
       '@types/node': 24.13.3
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.9': {}
 
   '@types/event-source-polyfill@1.0.5': {}
 
@@ -11501,6 +11702,61 @@ snapshots:
     optionalDependencies:
       '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(rolldown@1.2.5)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
 
+  '@vitest/coverage-v8@4.1.11(vitest@4.1.11)':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.1.11
+      ast-v8-to-istanbul: 1.0.5
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.4
+      obug: 2.1.4
+      std-env: 4.2.0
+      tinyrainbow: 3.1.1
+      vitest: 4.1.11(@types/node@24.13.3)(@vitest/coverage-v8@4.1.11)(jsdom@29.1.1(@noble/hashes@2.3.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+
+  '@vitest/expect@4.1.11':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.11
+      '@vitest/utils': 4.1.11
+      chai: 6.2.2
+      tinyrainbow: 3.1.1
+
+  '@vitest/mocker@4.1.11(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.11
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
+
+  '@vitest/pretty-format@4.1.11':
+    dependencies:
+      tinyrainbow: 3.1.1
+
+  '@vitest/runner@4.1.11':
+    dependencies:
+      '@vitest/utils': 4.1.11
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.11':
+    dependencies:
+      '@vitest/pretty-format': 4.1.11
+      '@vitest/utils': 4.1.11
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.11': {}
+
+  '@vitest/utils@4.1.11':
+    dependencies:
+      '@vitest/pretty-format': 4.1.11
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.1
+
   '@xstate/react@6.1.0(@types/react@19.2.18)(react@19.2.8)(xstate@5.32.5)':
     dependencies:
       react: 19.2.8
@@ -11581,6 +11837,14 @@ snapshots:
   array-union@2.1.0: {}
 
   arrify@3.0.0: {}
+
+  assertion-error@2.0.1: {}
+
+  ast-v8-to-istanbul@1.0.5:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   asynckit@0.4.0: {}
 
@@ -11766,6 +12030,8 @@ snapshots:
   ce-la-react@0.3.2(react@19.2.8):
     dependencies:
       react: 19.2.8
+
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
@@ -12285,6 +12551,10 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
   esutils@2.0.3: {}
 
   event-source-polyfill@1.0.31: {}
@@ -12329,6 +12599,8 @@ snapshots:
   exif-component@1.0.1: {}
 
   expand-template@2.0.3: {}
+
+  expect-type@1.4.0: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -12456,9 +12728,11 @@ snapshots:
       through2: 4.0.2
       tunnel-agent: 0.6.0
 
-  get-it@9.5.1:
+  get-it@9.5.1(vitest@4.1.11):
     dependencies:
       undici: 7.29.0
+    optionalDependencies:
+      vitest: 4.1.11(@types/node@24.13.3)(@vitest/coverage-v8@4.1.11)(jsdom@29.1.1(@noble/hashes@2.3.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
 
   get-latest-version@6.0.1:
     dependencies:
@@ -12513,6 +12787,8 @@ snapshots:
       ignore: 5.3.2
       merge2: 1.4.1
       slash: 3.0.0
+
+  globrex@0.1.2: {}
 
   gopd@1.2.0: {}
 
@@ -12584,6 +12860,8 @@ snapshots:
       '@exodus/bytes': 1.15.1(@noble/hashes@2.3.0)
     transitivePeerDependencies:
       - '@noble/hashes'
+
+  html-escaper@2.0.2: {}
 
   html-parse-stringify@4.0.1: {}
 
@@ -12752,9 +13030,24 @@ snapshots:
     dependencies:
       ws: 8.21.0
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   jiti@2.6.1: {}
 
   jiti@2.7.0: {}
+
+  js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -13045,10 +13338,20 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  magicast@0.5.4:
+    dependencies:
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
+      source-map-js: 1.2.1
+
   make-dir@2.1.0:
     dependencies:
       pify: 4.0.1
       semver: 5.7.2
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.8.5
 
   markdown-it@14.3.0:
     dependencies:
@@ -13160,20 +13463,20 @@ snapshots:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
 
-  next-sanity@13.3.3(8d2a66b9087f2bca67bc4b27e03323c9):
+  next-sanity@13.3.3(6a18327cd7a19db48a37e7fe1c1c69f5):
     dependencies:
       '@portabletext/react': 7.0.1(react@19.2.8)
-      '@sanity/client': 8.2.0
+      '@sanity/client': 8.2.0(vitest@4.1.11)
       '@sanity/generate-help-url': 4.0.0
-      '@sanity/preview-url-secret': 4.1.4(@sanity/client@8.2.0)
-      '@sanity/visual-editing': 6.1.0(@sanity/client@8.2.0)(@types/react@19.2.18)(next@16.3.2(@babel/core@7.29.7(supports-color@8.1.1))(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(typescript@7.0.2)
+      '@sanity/preview-url-secret': 4.1.4(@sanity/client@8.2.0(vitest@4.1.11))
+      '@sanity/visual-editing': 6.1.0(@sanity/client@8.2.0(vitest@4.1.11))(@types/react@19.2.18)(next@16.3.2(@babel/core@7.29.7(supports-color@8.1.1))(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(typescript@7.0.2)
       '@sanity/webhook': 4.0.4
       groq: 6.10.1
       history: 5.3.0
       next: 16.3.2(@babel/core@7.29.7(supports-color@8.1.1))(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
-      sanity: 6.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(@noble/hashes@2.3.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(rolldown@1.2.5)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)))(@sanity/sdk@3.0.0-rc.1(@types/react@19.2.18)(immer@11.1.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(xstate@5.32.5))(@types/node@24.13.3)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.2)(immer@11.1.18)(jiti@2.7.0)(oxfmt@0.64.0)(prismjs@1.30.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.5)(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)(typescript@7.0.2)
+      sanity: 6.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(@noble/hashes@2.3.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(rolldown@1.2.5)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)))(@sanity/sdk@3.0.0-rc.1(@types/react@19.2.18)(immer@11.1.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(xstate@5.32.5))(@types/node@24.13.3)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.2)(immer@11.1.18)(jiti@2.7.0)(oxfmt@0.64.0)(prismjs@1.30.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.5)(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)(typescript@7.0.2)(vitest@4.1.11)
       styled-components: 6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
     transitivePeerDependencies:
       - '@sveltejs/kit'
@@ -13917,11 +14220,11 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sanity-plugin-media@6.1.6(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sanity@6.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(@noble/hashes@2.3.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(rolldown@1.2.5)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)))(@sanity/sdk@3.0.0-rc.1(@types/react@19.2.18)(immer@11.1.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(xstate@5.32.5))(@types/node@24.13.3)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.2)(immer@11.1.18)(jiti@2.7.0)(oxfmt@0.64.0)(prismjs@1.30.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.5)(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)(typescript@7.0.2))(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1):
+  sanity-plugin-media@6.1.6(fd34fbbff975555bcdeffbb4d7004ab4):
     dependencies:
       '@hookform/resolvers': 4.1.3(react-hook-form@7.85.0(react@19.2.8))
       '@reduxjs/toolkit': 2.12.0(react-redux@9.3.0(@types/react@19.2.18)(react@19.2.8)(redux@5.0.1))(react@19.2.8)
-      '@sanity/client': 8.2.0
+      '@sanity/client': 8.2.0(vitest@4.1.11)
       '@sanity/color': 3.0.8
       '@sanity/icons': 5.2.1(react@19.2.8)
       '@sanity/ui': 4.0.5(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
@@ -13945,7 +14248,7 @@ snapshots:
       redux: 5.0.1
       redux-observable: 3.0.0-rc.2(redux@5.0.1)(rxjs@7.8.2)
       rxjs: 7.8.2
-      sanity: 6.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(@noble/hashes@2.3.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(rolldown@1.2.5)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)))(@sanity/sdk@3.0.0-rc.1(@types/react@19.2.18)(immer@11.1.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(xstate@5.32.5))(@types/node@24.13.3)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.2)(immer@11.1.18)(jiti@2.7.0)(oxfmt@0.64.0)(prismjs@1.30.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.5)(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)(typescript@7.0.2)
+      sanity: 6.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(@noble/hashes@2.3.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(rolldown@1.2.5)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)))(@sanity/sdk@3.0.0-rc.1(@types/react@19.2.18)(immer@11.1.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(xstate@5.32.5))(@types/node@24.13.3)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.2)(immer@11.1.18)(jiti@2.7.0)(oxfmt@0.64.0)(prismjs@1.30.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.5)(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)(typescript@7.0.2)(vitest@4.1.11)
       styled-components: 6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       zod: 3.25.76
     transitivePeerDependencies:
@@ -13953,7 +14256,7 @@ snapshots:
       - supports-color
       - vitest
 
-  sanity@6.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(@noble/hashes@2.3.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(rolldown@1.2.5)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)))(@sanity/sdk@3.0.0-rc.1(@types/react@19.2.18)(immer@11.1.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(xstate@5.32.5))(@types/node@24.13.3)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.2)(immer@11.1.18)(jiti@2.7.0)(oxfmt@0.64.0)(prismjs@1.30.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.5)(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)(typescript@7.0.2):
+  sanity@6.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(@noble/hashes@2.3.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(rolldown@1.2.5)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)))(@sanity/sdk@3.0.0-rc.1(@types/react@19.2.18)(immer@11.1.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(xstate@5.32.5))(@types/node@24.13.3)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.2)(immer@11.1.18)(jiti@2.7.0)(oxfmt@0.64.0)(prismjs@1.30.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.5)(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)(typescript@7.0.2)(vitest@4.1.11):
     dependencies:
       '@algorithm.ts/lcs': 4.0.6
       '@date-fns/tz': 1.5.0
@@ -13981,7 +14284,7 @@ snapshots:
       '@sanity/access-ui': 6.10.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
       '@sanity/asset-utils': 2.3.0
       '@sanity/bifur-client': 1.0.0
-      '@sanity/cli': 8.2.1(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(@noble/hashes@2.3.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(rolldown@1.2.5)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)))(@types/node@24.13.3)(@types/react@19.2.18)(esbuild@0.28.2)(jiti@2.7.0)(oxfmt@0.64.0)(rolldown@1.2.5)(supports-color@8.1.1)(typescript@7.0.2)(xstate@5.32.5)
+      '@sanity/cli': 8.2.1(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(@noble/hashes@2.3.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(rolldown@1.2.5)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)))(@types/node@24.13.3)(@types/react@19.2.18)(esbuild@0.28.2)(jiti@2.7.0)(oxfmt@0.64.0)(rolldown@1.2.5)(supports-color@8.1.1)(typescript@7.0.2)(vitest@4.1.11)(xstate@5.32.5)
       '@sanity/client': 7.26.2
       '@sanity/color': 3.0.8
       '@sanity/comlink': 4.0.3
@@ -14184,6 +14487,8 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
 
   simple-concat@1.0.1: {}
@@ -14254,10 +14559,14 @@ snapshots:
 
   speakingurl@14.0.1: {}
 
+  stackback@0.0.2: {}
+
   standardwebhooks@1.0.0:
     dependencies:
       '@stablelib/base64': 1.0.1
       fast-sha256: 1.3.0
+
+  std-env@4.2.0: {}
 
   stdin-discarder@0.3.2: {}
 
@@ -14446,6 +14755,8 @@ snapshots:
     dependencies:
       readable-stream: 3.6.2
 
+  tinybench@2.9.0: {}
+
   tinyexec@1.3.0: {}
 
   tinyglobby@0.2.17:
@@ -14454,6 +14765,8 @@ snapshots:
       picomatch: 4.0.5
 
   tinypool@2.1.0: {}
+
+  tinyrainbow@3.1.1: {}
 
   tldts-core@7.4.10: {}
 
@@ -14476,6 +14789,10 @@ snapshots:
       punycode: 2.3.1
 
   ts-brand@0.2.0: {}
+
+  tsconfck@3.1.6(typescript@7.0.2):
+    optionalDependencies:
+      typescript: 7.0.2
 
   tsconfig-paths-webpack-plugin@4.2.0:
     dependencies:
@@ -14679,6 +14996,16 @@ snapshots:
       - tsx
       - yaml
 
+  vite-tsconfig-paths@6.1.1(supports-color@8.1.1)(typescript@7.0.2)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)):
+    dependencies:
+      debug: 4.4.3(supports-color@8.1.1)
+      globrex: 0.1.2
+      tsconfck: 3.1.6(typescript@7.0.2)
+      vite: 8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
   vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.33.0
@@ -14693,6 +15020,35 @@ snapshots:
       jiti: 2.7.0
       tsx: 4.23.12
       yaml: 2.9.0
+
+  vitest@4.1.11(@types/node@24.13.3)(@vitest/coverage-v8@4.1.11)(jsdom@29.1.1(@noble/hashes@2.3.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.11
+      '@vitest/mocker': 4.1.11(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.11
+      '@vitest/runner': 4.1.11
+      '@vitest/snapshot': 4.1.11
+      '@vitest/spy': 4.1.11
+      '@vitest/utils': 4.1.11
+      es-module-lexer: 2.3.2
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.3.0
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.1
+      vite: 8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.13.3
+      '@vitest/coverage-v8': 4.1.11(vitest@4.1.11)
+      jsdom: 29.1.1(@noble/hashes@2.3.0)
+    transitivePeerDependencies:
+      - msw
 
   w3c-keyname@2.2.8: {}
 
@@ -14723,6 +15079,11 @@ snapshots:
   which@6.0.1:
     dependencies:
       isexe: 4.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   widest-line@3.1.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -255,6 +255,9 @@ importers:
       '@types/react-dom':
         specifier: 19.2.4
         version: 19.2.4(@types/react@19.2.18)
+      '@vitest/coverage-v8':
+        specifier: ^4.1.11
+        version: 4.1.11(vitest@4.1.11)
       oxlint:
         specifier: ^1.79.0
         version: 1.79.0(oxlint-tsgolint@7.0.2001)
@@ -270,6 +273,12 @@ importers:
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
+      vite-tsconfig-paths:
+        specifier: ^6.1.1
+        version: 6.1.1(supports-color@8.1.1)(typescript@7.0.2)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+      vitest:
+        specifier: ^4.1.11
+        version: 4.1.11(@types/node@24.13.3)(@vitest/coverage-v8@4.1.11)(jsdom@29.1.1(@noble/hashes@2.3.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
 
   packages/email:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -261,6 +261,12 @@ importers:
         specifier: ^4.4.3
         version: 4.4.3
     devDependencies:
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@testing-library/user-event':
+        specifier: ^14.6.6
+        version: 14.6.6(@testing-library/dom@10.4.1)
       '@types/node':
         specifier: ^24.13.3
         version: 24.13.3
@@ -270,9 +276,15 @@ importers:
       '@types/react-dom':
         specifier: 19.2.4
         version: 19.2.4(@types/react@19.2.18)
+      '@vitejs/plugin-react':
+        specifier: ^6.1.0
+        version: 6.1.0(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(rolldown@1.2.5)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
       '@vitest/coverage-v8':
         specifier: ^4.1.11
         version: 4.1.11(vitest@4.1.11)
+      jsdom:
+        specifier: ^30.0.1
+        version: 30.0.1(@noble/hashes@2.3.0)
       oxlint:
         specifier: ^1.79.0
         version: 1.79.0(oxlint-tsgolint@7.0.2001)
@@ -3990,6 +4002,31 @@ packages:
   '@tanstack/virtual-core@3.17.8':
     resolution: {integrity: sha512-BfEvehNpOT75r5Ksc5xW6NZuXujTfb7nlSEyVu4XHG3gdxNg1KqXruWbDewXOUaUYIo4oRbSfkjIajz4MAT8tA==}
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@testing-library/user-event@14.6.6':
+    resolution: {integrity: sha512-Jbs9FpkkIDw8FgSc6kOVsOv8JuuqGAL7J4X1oot77JxAoDlkNn2GRkd0aYRVuQ+pVQAiHWVkE4rX/dkF5fBiCw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
   '@turbo/darwin-64@2.10.11':
     resolution: {integrity: sha512-v3R+1R/Ysozyo+p7Ri8MCIbndOvYt3DgPFrGLhrhQHfvyvbxyH3WyJj+A/2JTNmNleuAlh3JUyCV0iSVHIONTA==}
     cpu: [x64]
@@ -4019,6 +4056,9 @@ packages:
     resolution: {integrity: sha512-m8tJkIrTrbQ9O1uHxV0GUq623Zg1678xGna8eMsy4KbygUX/wVFgdZDYV/AxyoyaW/U7nyKoBvaDVwm22p9xqA==}
     cpu: [arm64]
     os: [win32]
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -4398,6 +4438,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
@@ -4423,6 +4467,9 @@ packages:
   aria-hidden@1.2.6:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   array-timsort@1.0.3:
     resolution: {integrity: sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==}
@@ -4968,6 +5015,9 @@ packages:
   doc-path@4.1.4:
     resolution: {integrity: sha512-yw5D++UCIB6a033PvQaUvSpW2QuKW0+DOId763n0Q4z3brxS7G8oQr8yBQ1nQFkognKrAVrV6I55TLeU9cfXTg==}
     engines: {node: '>=16'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
   dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
@@ -6016,6 +6066,10 @@ packages:
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -6511,6 +6565,10 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   pretty-ms@9.3.0:
     resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
     engines: {node: '>=18'}
@@ -6655,6 +6713,9 @@ packages:
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-is@19.2.8:
     resolution: {integrity: sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ==}
@@ -11560,6 +11621,31 @@ snapshots:
 
   '@tanstack/virtual-core@3.17.8': {}
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/runtime': 7.29.7
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@testing-library/dom': 10.4.1
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+    optionalDependencies:
+      '@types/react': 19.2.18
+      '@types/react-dom': 19.2.4(@types/react@19.2.18)
+
+  '@testing-library/user-event@14.6.6(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+
   '@turbo/darwin-64@2.10.11':
     optional: true
 
@@ -11577,6 +11663,8 @@ snapshots:
 
   '@turbo/windows-arm64@2.10.11':
     optional: true
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/chai@5.2.3':
     dependencies:
@@ -11871,6 +11959,8 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   ansi-styles@6.2.3: {}
 
   ansicolors@0.3.2: {}
@@ -11889,6 +11979,10 @@ snapshots:
   aria-hidden@1.2.6:
     dependencies:
       tslib: 2.8.1
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   array-timsort@1.0.3: {}
 
@@ -12408,6 +12502,8 @@ snapshots:
       path-type: 4.0.0
 
   doc-path@4.1.4: {}
+
+  dom-accessibility-api@0.5.16: {}
 
   dom-helpers@5.2.1:
     dependencies:
@@ -13420,6 +13516,8 @@ snapshots:
     dependencies:
       react: 19.2.8
 
+  lz-string@1.5.0: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -13906,6 +14004,12 @@ snapshots:
 
   prettier@3.9.6: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   pretty-ms@9.3.0:
     dependencies:
       parse-ms: 4.0.0
@@ -14067,6 +14171,8 @@ snapshots:
       react: 19.2.8
 
   react-is@16.13.1: {}
+
+  react-is@17.0.2: {}
 
   react-is@19.2.8: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,25 +72,25 @@ importers:
         version: 7.0.2
       vitest:
         specifier: ^4.1.11
-        version: 4.1.11(@types/node@24.13.3)(@vitest/coverage-v8@4.1.11)(jsdom@29.1.1(@noble/hashes@2.3.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+        version: 4.1.11(@types/node@24.13.3)(@vitest/coverage-v8@4.1.11)(jsdom@30.0.1(@noble/hashes@2.3.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
 
   apps/studio:
     dependencies:
       '@sanity/assist':
         specifier: ^6.1.21
-        version: 6.1.21(fd34fbbff975555bcdeffbb4d7004ab4)
+        version: 6.1.21(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sanity@6.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(@noble/hashes@2.3.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(rolldown@1.2.5)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)))(@sanity/sdk@3.0.0-rc.1(@types/react@19.2.18)(immer@11.1.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(xstate@5.32.5))(@types/node@24.13.3)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.2)(immer@11.1.18)(jiti@2.7.0)(oxfmt@0.64.0)(prismjs@1.30.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.5)(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)(typescript@7.0.2)(vitest@4.1.11))(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)(vitest@4.1.11)
       '@sanity/icons':
         specifier: ^5.2.1
         version: 5.2.1(react@19.2.8)
       '@sanity/locale-de-de':
         specifier: ^1.1.36
-        version: 1.1.36(sanity@6.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(@noble/hashes@2.3.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(rolldown@1.2.5)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)))(@sanity/sdk@3.0.0-rc.1(@types/react@19.2.18)(immer@11.1.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(xstate@5.32.5))(@types/node@24.13.3)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.2)(immer@11.1.18)(jiti@2.7.0)(oxfmt@0.64.0)(prismjs@1.30.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.5)(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)(typescript@7.0.2)(vitest@4.1.11(@types/node@24.13.3)(@vitest/coverage-v8@4.1.11)(jsdom@29.1.1(@noble/hashes@2.3.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))))
+        version: 1.1.36(sanity@6.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(@noble/hashes@2.3.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(rolldown@1.2.5)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)))(@sanity/sdk@3.0.0-rc.1(@types/react@19.2.18)(immer@11.1.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(xstate@5.32.5))(@types/node@24.13.3)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.2)(immer@11.1.18)(jiti@2.7.0)(oxfmt@0.64.0)(prismjs@1.30.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.5)(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)(typescript@7.0.2)(vitest@4.1.11))
       '@sanity/ui':
         specifier: ^4.0.4
         version: 4.0.5(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
       '@sanity/vision':
         specifier: ^6.10.1
-        version: 6.10.1(6a7f3d16f54dd9c855e35016480c1f5f)
+        version: 6.10.1(@babel/runtime@7.29.7)(@codemirror/lint@6.9.7)(@codemirror/theme-one-dark@6.1.3)(codemirror@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sanity@6.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(@noble/hashes@2.3.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(rolldown@1.2.5)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)))(@sanity/sdk@3.0.0-rc.1(@types/react@19.2.18)(immer@11.1.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(xstate@5.32.5))(@types/node@24.13.3)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.2)(immer@11.1.18)(jiti@2.7.0)(oxfmt@0.64.0)(prismjs@1.30.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.5)(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)(typescript@7.0.2)(vitest@4.1.11))(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
       '@tsgi-web/shared':
         specifier: workspace:*
         version: link:../../packages/shared
@@ -111,7 +111,7 @@ importers:
         version: 6.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(@noble/hashes@2.3.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(rolldown@1.2.5)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)))(@sanity/sdk@3.0.0-rc.1(@types/react@19.2.18)(immer@11.1.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(xstate@5.32.5))(@types/node@24.13.3)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.2)(immer@11.1.18)(jiti@2.7.0)(oxfmt@0.64.0)(prismjs@1.30.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.5)(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)(typescript@7.0.2)(vitest@4.1.11)
       sanity-plugin-media:
         specifier: ^6.1.6
-        version: 6.1.6(fd34fbbff975555bcdeffbb4d7004ab4)
+        version: 6.1.6(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sanity@6.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(@noble/hashes@2.3.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(rolldown@1.2.5)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)))(@sanity/sdk@3.0.0-rc.1(@types/react@19.2.18)(immer@11.1.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(xstate@5.32.5))(@types/node@24.13.3)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.2)(immer@11.1.18)(jiti@2.7.0)(oxfmt@0.64.0)(prismjs@1.30.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.5)(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)(typescript@7.0.2)(vitest@4.1.11))(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)(vitest@4.1.11)
       slugify:
         specifier: ^1.6.9
         version: 1.6.9
@@ -128,6 +128,15 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.4
         version: 19.2.4(@types/react@19.2.18)
+      '@vitejs/plugin-react':
+        specifier: ^6.1.0
+        version: 6.1.0(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(rolldown@1.2.5)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+      '@vitest/coverage-v8':
+        specifier: ^4.1.11
+        version: 4.1.11(vitest@4.1.11)
+      jsdom:
+        specifier: ^30.0.1
+        version: 30.0.1(@noble/hashes@2.3.0)
       oxlint:
         specifier: ^1.79.0
         version: 1.79.0(oxlint-tsgolint@7.0.2001)
@@ -137,6 +146,12 @@ importers:
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
+      vite-tsconfig-paths:
+        specifier: ^6.1.1
+        version: 6.1.1(supports-color@8.1.1)(typescript@7.0.2)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+      vitest:
+        specifier: ^4.1.11
+        version: 4.1.11(@types/node@24.13.3)(@vitest/coverage-v8@4.1.11)(jsdom@30.0.1(@noble/hashes@2.3.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
 
   apps/web:
     dependencies:
@@ -278,7 +293,7 @@ importers:
         version: 6.1.1(supports-color@8.1.1)(typescript@7.0.2)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
       vitest:
         specifier: ^4.1.11
-        version: 4.1.11(@types/node@24.13.3)(@vitest/coverage-v8@4.1.11)(jsdom@29.1.1(@noble/hashes@2.3.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+        version: 4.1.11(@types/node@24.13.3)(@vitest/coverage-v8@4.1.11)(jsdom@30.0.1(@noble/hashes@2.3.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
 
   packages/email:
     dependencies:
@@ -361,7 +376,7 @@ importers:
         version: 6.1.1(supports-color@8.1.1)(typescript@7.0.2)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
       vitest:
         specifier: ^4.1.11
-        version: 4.1.11(@types/node@24.13.3)(@vitest/coverage-v8@4.1.11)(jsdom@29.1.1(@noble/hashes@2.3.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+        version: 4.1.11(@types/node@24.13.3)(@vitest/coverage-v8@4.1.11)(jsdom@30.0.1(@noble/hashes@2.3.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
 
 packages:
 
@@ -422,12 +437,20 @@ packages:
     resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
+  '@asamuzakjp/css-color@6.0.7':
+    resolution: {integrity: sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==}
+    engines: {node: ^22.13.0 || >=24.0.0}
+
   '@asamuzakjp/dom-selector@6.8.1':
     resolution: {integrity: sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==}
 
   '@asamuzakjp/dom-selector@7.1.1':
     resolution: {integrity: sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@8.3.2':
+    resolution: {integrity: sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==}
+    engines: {node: ^22.13.0 || >=24.0.0}
 
   '@asamuzakjp/generational-cache@1.0.1':
     resolution: {integrity: sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==}
@@ -5671,6 +5694,15 @@ packages:
       canvas:
         optional: true
 
+  jsdom@30.0.1:
+    resolution: {integrity: sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+    peerDependencies:
+      canvas: ^3.2.3
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
     engines: {node: '>=6'}
@@ -7541,6 +7573,10 @@ packages:
     resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
+  whatwg-url@17.1.0:
+    resolution: {integrity: sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==}
+    engines: {node: ^22.14.0 || >=24.0.0}
+
   when-exit@2.1.5:
     resolution: {integrity: sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==}
 
@@ -7780,6 +7816,14 @@ snapshots:
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
 
+  '@asamuzakjp/css-color@6.0.7':
+    dependencies:
+      '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+      lru-cache: 11.5.2
+
   '@asamuzakjp/dom-selector@6.8.1':
     dependencies:
       '@asamuzakjp/nwsapi': 2.3.9
@@ -7795,6 +7839,13 @@ snapshots:
       bidi-js: 1.0.3
       css-tree: 3.2.1
       is-potential-custom-element-name: 1.0.1
+
+  '@asamuzakjp/dom-selector@8.3.2':
+    dependencies:
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.2
 
   '@asamuzakjp/generational-cache@1.0.1': {}
 
@@ -10537,7 +10588,7 @@ snapshots:
 
   '@sanity/asset-utils@2.3.0': {}
 
-  '@sanity/assist@6.1.21(fd34fbbff975555bcdeffbb4d7004ab4)':
+  '@sanity/assist@6.1.21(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sanity@6.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(@noble/hashes@2.3.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(rolldown@1.2.5)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)))(@sanity/sdk@3.0.0-rc.1(@types/react@19.2.18)(immer@11.1.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(xstate@5.32.5))(@types/node@24.13.3)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.2)(immer@11.1.18)(jiti@2.7.0)(oxfmt@0.64.0)(prismjs@1.30.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.5)(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)(typescript@7.0.2)(vitest@4.1.11))(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)(vitest@4.1.11)':
     dependencies:
       '@portabletext/types': 4.0.2
       '@sanity/client': 8.2.0(vitest@4.1.11)
@@ -10899,7 +10950,7 @@ snapshots:
       '@lezer/highlight': 1.2.3
       '@lezer/lr': 1.4.10
 
-  '@sanity/locale-de-de@1.1.36(sanity@6.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(@noble/hashes@2.3.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(rolldown@1.2.5)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)))(@sanity/sdk@3.0.0-rc.1(@types/react@19.2.18)(immer@11.1.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(xstate@5.32.5))(@types/node@24.13.3)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.2)(immer@11.1.18)(jiti@2.7.0)(oxfmt@0.64.0)(prismjs@1.30.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.5)(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)(typescript@7.0.2)(vitest@4.1.11(@types/node@24.13.3)(@vitest/coverage-v8@4.1.11)(jsdom@29.1.1(@noble/hashes@2.3.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))))':
+  '@sanity/locale-de-de@1.1.36(sanity@6.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(@noble/hashes@2.3.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(rolldown@1.2.5)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)))(@sanity/sdk@3.0.0-rc.1(@types/react@19.2.18)(immer@11.1.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(xstate@5.32.5))(@types/node@24.13.3)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.2)(immer@11.1.18)(jiti@2.7.0)(oxfmt@0.64.0)(prismjs@1.30.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.5)(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)(typescript@7.0.2)(vitest@4.1.11))':
     dependencies:
       sanity: 6.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(@noble/hashes@2.3.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(rolldown@1.2.5)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)))(@sanity/sdk@3.0.0-rc.1(@types/react@19.2.18)(immer@11.1.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(xstate@5.32.5))(@types/node@24.13.3)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.2)(immer@11.1.18)(jiti@2.7.0)(oxfmt@0.64.0)(prismjs@1.30.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.5)(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)(typescript@7.0.2)(vitest@4.1.11)
 
@@ -11204,7 +11255,7 @@ snapshots:
     dependencies:
       uuid: 14.0.2
 
-  '@sanity/vision@6.10.1(6a7f3d16f54dd9c855e35016480c1f5f)':
+  '@sanity/vision@6.10.1(@babel/runtime@7.29.7)(@codemirror/lint@6.9.7)(@codemirror/theme-one-dark@6.1.3)(codemirror@6.0.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sanity@6.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(@noble/hashes@2.3.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(rolldown@1.2.5)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)))(@sanity/sdk@3.0.0-rc.1(@types/react@19.2.18)(immer@11.1.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(xstate@5.32.5))(@types/node@24.13.3)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.2)(immer@11.1.18)(jiti@2.7.0)(oxfmt@0.64.0)(prismjs@1.30.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.5)(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)(typescript@7.0.2)(vitest@4.1.11))(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))':
     dependencies:
       '@codemirror/autocomplete': 6.20.3
       '@codemirror/commands': 6.11.0
@@ -11723,7 +11774,7 @@ snapshots:
       obug: 2.1.4
       std-env: 4.2.0
       tinyrainbow: 3.1.1
-      vitest: 4.1.11(@types/node@24.13.3)(@vitest/coverage-v8@4.1.11)(jsdom@29.1.1(@noble/hashes@2.3.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+      vitest: 4.1.11(@types/node@24.13.3)(@vitest/coverage-v8@4.1.11)(jsdom@30.0.1(@noble/hashes@2.3.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
 
   '@vitest/expect@4.1.11':
     dependencies:
@@ -12741,7 +12792,7 @@ snapshots:
     dependencies:
       undici: 7.29.0
     optionalDependencies:
-      vitest: 4.1.11(@types/node@24.13.3)(@vitest/coverage-v8@4.1.11)(jsdom@29.1.1(@noble/hashes@2.3.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+      vitest: 4.1.11(@types/node@24.13.3)(@vitest/coverage-v8@4.1.11)(jsdom@30.0.1(@noble/hashes@2.3.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
 
   get-latest-version@6.0.1:
     dependencies:
@@ -13113,6 +13164,32 @@ snapshots:
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
       whatwg-url: 16.0.1(@noble/hashes@2.3.0)
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  jsdom@30.0.1(@noble/hashes@2.3.0):
+    dependencies:
+      '@asamuzakjp/css-color': 6.0.7
+      '@asamuzakjp/dom-selector': 8.3.2
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.8(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.1(@noble/hashes@2.3.0)
+      css-tree: 3.2.1
+      data-urls: 7.0.0(@noble/hashes@2.3.0)
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0(@noble/hashes@2.3.0)
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.2
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.2
+      undici: 7.29.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 17.1.0(@noble/hashes@2.3.0)
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - '@noble/hashes'
@@ -14229,7 +14306,7 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sanity-plugin-media@6.1.6(fd34fbbff975555bcdeffbb4d7004ab4):
+  sanity-plugin-media@6.1.6(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sanity@6.10.1(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(@noble/hashes@2.3.0)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7(supports-color@8.1.1))(@babel/runtime@7.29.7)(rolldown@1.2.5)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)))(@sanity/sdk@3.0.0-rc.1(@types/react@19.2.18)(immer@11.1.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))(xstate@5.32.5))(@types/node@24.13.3)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.2)(immer@11.1.18)(jiti@2.7.0)(oxfmt@0.64.0)(prismjs@1.30.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.5)(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)(typescript@7.0.2)(vitest@4.1.11))(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@8.1.1)(vitest@4.1.11):
     dependencies:
       '@hookform/resolvers': 4.1.3(react-hook-form@7.85.0(react@19.2.8))
       '@reduxjs/toolkit': 2.12.0(react-redux@9.3.0(@types/react@19.2.18)(react@19.2.8)(redux@5.0.1))(react@19.2.8)
@@ -15030,7 +15107,7 @@ snapshots:
       tsx: 4.23.12
       yaml: 2.9.0
 
-  vitest@4.1.11(@types/node@24.13.3)(@vitest/coverage-v8@4.1.11)(jsdom@29.1.1(@noble/hashes@2.3.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)):
+  vitest@4.1.11(@types/node@24.13.3)(@vitest/coverage-v8@4.1.11)(jsdom@30.0.1(@noble/hashes@2.3.0))(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.11
       '@vitest/mocker': 4.1.11(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
@@ -15055,7 +15132,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.13.3
       '@vitest/coverage-v8': 4.1.11(vitest@4.1.11)
-      jsdom: 29.1.1(@noble/hashes@2.3.0)
+      jsdom: 30.0.1(@noble/hashes@2.3.0)
     transitivePeerDependencies:
       - msw
 
@@ -15072,6 +15149,14 @@ snapshots:
   whatwg-mimetype@5.0.0: {}
 
   whatwg-url@16.0.1(@noble/hashes@2.3.0):
+    dependencies:
+      '@exodus/bytes': 1.15.1(@noble/hashes@2.3.0)
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  whatwg-url@17.1.0(@noble/hashes@2.3.0):
     dependencies:
       '@exodus/bytes': 1.15.1(@noble/hashes@2.3.0)
       tr46: 6.0.0

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,7 +2,9 @@ sonar.projectKey=mheob_tsg-irlich-web
 sonar.organization=mheob
 
 # Coverage settings
-sonar.coverage.exclusions=**/*
+sonar.javascript.lcov.reportPaths=apps/web/coverage/lcov.info,apps/studio/coverage/lcov.info,packages/shared/coverage/lcov.info,packages/email/coverage/lcov.info
+sonar.test.inclusions=**/*.test.ts,**/*.test.tsx
+sonar.coverage.exclusions=**/*.config.ts,**/test-utils/**,**/*.generated.ts
 
 # This is the name and version displayed in the SonarCloud UI.
 #sonar.projectName=tsg-irlich-web

--- a/turbo.json
+++ b/turbo.json
@@ -55,6 +55,10 @@
 			],
 			"outputs": ["dist/**"]
 		},
+		"test": {},
+		"test:coverage": {
+			"outputs": ["coverage/**"]
+		},
 		"typecheck": {},
 		"typegen:routes": {},
 		"typegen:sanity": {


### PR DESCRIPTION
PR 1 of 5 for WEB-296. Dieser PR bringt die Test-Infrastruktur und zwei Bugfixes; die eigentliche Testabdeckung folgt in den PRs 2–5 gemäß der Spec.

## Was hier landet

**Vitest 4 in allen vier Workspaces** — je eine `vitest.config.ts` in `apps/web`, `apps/studio`, `packages/shared` und `packages/email`, jeweils mit `test`, `test:watch` und `test:coverage`.

- `apps/web` teilt sich in zwei Projekte innerhalb einer Config: `dom` (jsdom) für jeden `.test.tsx` unterhalb von `src/` sowie die `.test.ts` unter `src/components/` und `src/hooks/`, `node` für alle übrigen `.test.ts`. Die Aufteilung folgt der Dateiendung, damit auch ein Test neben einer kolokierten `'use client'`-Komponente unter `src/app/**` in jsdom landet.
- Ein kleines Vite-Plugin (`assetStub`) löst statische Bild-Importe auf; ohne das scheitert jedes Modul, das ein `.webp` importiert, schon beim Laden.
- `packages/email` schließt das generierte `.react-email`-Verzeichnis aus, das eigene `*.spec.*`-Dateien mitbringt.

**Geteilte Helfer** in `apps/web/test-utils/`:

- `setup-dom.ts` — Stubs für `matchMedia`, `ResizeObserver`, `IntersectionObserver` sowie die Pointer-Capture-API und `scrollIntoView`, die jsdom nicht kennt und Radix braucht.
- `env.ts` — `loadWithEnv` setzt die Modul-Registry zurück und stubbt Umgebungsvariablen, weil `src/lib/env.ts` validierte Werte in einer Modul-Map cached. Das zu testende Modul muss als `import type` importiert werden, sonst läuft der Reset ins Leere.
- `fetch-mock.ts` — Mock auf der `fetch`-Ebene für die Server Actions und den CleverReach-Client in PR 3. Aufgezeichnete Header-Namen sind kleingeschrieben (Normalisierung über `Headers`, wie beim echten `fetch`); `unqueued` macht eine zu kurze Response-Queue von einem echten Fehler unterscheidbar.

**Tooling und CI** — `test`/`test:coverage` als Turbo-Tasks plus drei Root-Scripts, eine Override für Testdateien in `oxlint.config.ts`, `coverage/lcov.info` pro Workspace, ein Testschritt in `check.yml` und die Coverage-Auswertung in `sonar.yml`. Bewusst ohne Mindestquote — die kommt in einem eigenen Ticket, sobald die Quote nach PR 5 bekannt ist.

**Dokumentation** in `AGENTS.md`, `apps/web/AGENTS.md` und `apps/studio/AGENTS.md`.

## Zwei Bugfixes

1. `packages/shared/src/utils/date.ts`: `hour` stand auf `360` statt `3600`, `day` auf `8640` statt `86_400` — Faktor zehn zu klein. Zur Laufzeit ändert sich heute nichts, weil im gesamten Repository nur `second` (`number-ticker.tsx`) und `minute` (`cleverreach.ts`) verwendet werden. Der neue `date.test.ts` prüft jede Zeitspanne gegen ihre arithmetische Definition.
2. `apps/web/src/actions/subscribe-to-newsletter.ts`: `'Bitte überprüfen Deine Eingaben.'` → `'Bitte überprüfe Deine Eingaben.'`, damit derselbe Zustand nicht zwei Grammatiken hat.

## Stand

46 Tests: `apps/web` 21, `packages/shared` 10, `packages/email` 11, `apps/studio` 4. `pnpm run lint`, `pnpm run format:check`, `pnpm run typecheck`, `pnpm run test` und `pnpm run build` laufen alle sauber.

## Bewusst offen

- `@testing-library/user-event` und `@react-email/render` sind bereits installiert, aber erst in den PRs 3 und 4 in Gebrauch.
- `check.yml` und `sonar.yml` führen beide die volle Suite aus. Das ist gewollt, damit der PR-Gate genau das abdeckt, worüber SonarQube berichtet — bei deutlich größerer Suite lohnt es sich, die Coverage stattdessen als Artefakt weiterzureichen.
- `packages/shared` hat noch kein jsdom-Projekt für seine beiden Icon-Komponenten; das kommt mit dem ersten Render-Test dort.

Design und Plan liegen unter `docs/superpowers/`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added unit testing and coverage support across web, studio, shared, and email packages.
  * Added reusable utilities for browser behavior, environment handling, and network requests.
  * Integrated test execution and coverage reporting into project workflows.

* **Bug Fixes**
  * Corrected hour and day duration calculations.
  * Fixed a German newsletter validation message.

* **Documentation**
  * Added testing guidance, conventions, and implementation documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->