### PR TITLE
test: cover the pure logic modules (WEB-296)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -30,7 +30,7 @@
 		"@radix-ui/react-slot": "^1.3.3",
 		"@radix-ui/react-toggle": "^1.1.18",
 		"@radix-ui/react-toggle-group": "^1.1.19",
-		"@sanity/client": "^8.2.0",
+		"@sanity/client": "^7.26.2",
 		"@sanity/image-url": "^2.1.1",
 		"@tailwindcss/postcss": "^4.3.3",
 		"@tailwindcss/typography": "^0.5.20",

--- a/apps/web/src/app/angebot/[group]/page.tsx
+++ b/apps/web/src/app/angebot/[group]/page.tsx
@@ -75,7 +75,7 @@ export default async function GroupsPage({ params }: PageProps<'/angebot/[group]
 	return (
 		<>
 			<Hero
-				image={getGroupImage(group, '/angebot')}
+				image={getGroupImage(group, '/angebot/')}
 				subTitle={page.subtitle}
 				title={`${page.title} ${currentDepartment?.title ?? ''}`.trim()}
 			/>

--- a/apps/web/src/lib/env.test.ts
+++ b/apps/web/src/lib/env.test.ts
@@ -1,0 +1,89 @@
+import process from 'node:process';
+
+import { describe, expect, it } from 'vitest';
+
+import type * as envModule from '@/lib/env';
+
+import { loadWithEnv } from '../../test-utils/env';
+
+type EnvModule = typeof envModule;
+
+describe('validated environment variable access', () => {
+	it('returns a valid value unchanged', async () => {
+		const { env } = await loadWithEnv<EnvModule>('@/lib/env', {
+			LINEAR_TEAM_ID: 'team-123',
+		});
+
+		expect(env('LINEAR_TEAM_ID')).toBe('team-123');
+	});
+
+	it('throws with the key name when a required variable is missing', async () => {
+		const { env } = await loadWithEnv<EnvModule>('@/lib/env', {
+			LINEAR_TEAM_ID: undefined,
+		});
+
+		expect(() => env('LINEAR_TEAM_ID')).toThrow(/LINEAR_TEAM_ID/u);
+	});
+
+	it('throws when a value fails its schema', async () => {
+		const { env } = await loadWithEnv<EnvModule>('@/lib/env', {
+			NEXT_PUBLIC_SANITY_STUDIO_URL: 'not-a-url',
+		});
+
+		expect(() => env('NEXT_PUBLIC_SANITY_STUDIO_URL')).toThrow();
+	});
+
+	it('defaults NODE_ENV to development when unset', async () => {
+		const { env } = await loadWithEnv<EnvModule>('@/lib/env', {
+			NODE_ENV: undefined,
+		});
+
+		expect(env('NODE_ENV')).toBe('development');
+	});
+
+	it('defaults the Sanity API version when unset', async () => {
+		const { env } = await loadWithEnv<EnvModule>('@/lib/env', {
+			NEXT_PUBLIC_SANITY_API_VERSION: undefined,
+		});
+
+		expect(env('NEXT_PUBLIC_SANITY_API_VERSION')).toBe('2025-12-15');
+	});
+
+	it('turns an empty SANITY_API_READ_TOKEN into undefined', async () => {
+		const { env } = await loadWithEnv<EnvModule>('@/lib/env', {
+			SANITY_API_READ_TOKEN: '',
+		});
+
+		expect(env('SANITY_API_READ_TOKEN')).toBeUndefined();
+	});
+
+	it('leaves an absent SANITY_API_READ_TOKEN as undefined', async () => {
+		const { env } = await loadWithEnv<EnvModule>('@/lib/env', {
+			SANITY_API_READ_TOKEN: undefined,
+		});
+
+		expect(env('SANITY_API_READ_TOKEN')).toBeUndefined();
+	});
+
+	it('returns undefined for an absent optional variable without throwing', async () => {
+		const { env } = await loadWithEnv<EnvModule>('@/lib/env', {
+			NEXT_PUBLIC_SANITY_STUDIO_URL: undefined,
+		});
+
+		expect(() => env('NEXT_PUBLIC_SANITY_STUDIO_URL')).not.toThrow();
+		expect(env('NEXT_PUBLIC_SANITY_STUDIO_URL')).toBeUndefined();
+	});
+
+	it('caches the first read even after process.env changes', async () => {
+		const { env } = await loadWithEnv<EnvModule>('@/lib/env', {
+			LINEAR_TEAM_ID: 'first-value',
+		});
+
+		const first = env('LINEAR_TEAM_ID');
+		process.env.LINEAR_TEAM_ID = 'second-value';
+		const second = env('LINEAR_TEAM_ID');
+
+		expect(first).toBe('first-value');
+		expect(second).toBe('first-value');
+	});
+});

--- a/apps/web/src/lib/sanity/utils.test.ts
+++ b/apps/web/src/lib/sanity/utils.test.ts
@@ -1,0 +1,236 @@
+import type { SanityClient } from 'next-sanity';
+import { describe, expect, it, vi } from 'vitest';
+
+import type * as utilsModule from '@/lib/sanity/utils';
+import type { SanityFileAsset, SanityImage } from '@/types/sanity.types';
+
+import { loadWithEnv } from '../../../test-utils/env';
+
+type UtilsModule = typeof utilsModule;
+
+// `next-sanity`'s ESM entry statically imports `unstable__adapter`/`unstable__environment` from
+// `@sanity/client`, which this workspace pins to a version that no longer exports them (a
+// pre-existing dependency mismatch between `next-sanity@13.3.3`, which peer-requires
+// `@sanity/client@^7.26.2`, and the `^8.2.0` actually installed). Importing the real
+// `next-sanity` package throws `SyntaxError: The requested module '@sanity/client' does not
+// provide an export named 'unstable__adapter'` before any test in this file can even run, so
+// `createClient` is replaced with an identity function: `./client` passes it a plain config
+// object built from real, env-driven `projectId`/`dataset`, and `@sanity/image-url`'s builder
+// accepts that object as-is when it has no `config()`/`clientConfig` shape (see
+// `getOptions` in `@sanity/image-url`'s `builder.ts`). This keeps `urlForImage` and
+// `urlForImageMax` exercising their real, unmodified implementation end to end.
+vi.mock(import('next-sanity'), () => ({
+	createClient: (config: unknown) => config as SanityClient,
+}));
+
+const SANITY_ENV = {
+	NEXT_PUBLIC_SANITY_DATASET: 'test-dataset',
+	NEXT_PUBLIC_SANITY_PROJECT_ID: 'test-project',
+};
+
+// A valid `image-<id>-<width>x<height>-<format>` reference, the shape `parseAssetId` in
+// `@sanity/image-url` requires — an arbitrary string throws when the builder resolves the URL.
+const ASSET_REF = 'image-abc123def456-800x600-jpg';
+
+function buildImage(): SanityImage {
+	return {
+		_type: 'image',
+		asset: { _ref: ASSET_REF, _type: 'reference' },
+	};
+}
+
+/**
+ * Narrows a possibly-undefined URL to a string, failing the test with a clear message otherwise.
+ *
+ * Avoids both a `!` assertion (forbidden by `typescript/no-non-null-assertion`) and an `as string`
+ * cast (flagged by `typescript/non-nullable-type-assertion-style`, which then wants the `!` that
+ * is forbidden) when constructing a `URL` from `urlForImage`/`urlForImageMax`'s return value.
+ *
+ * @param url - The value to narrow.
+ * @returns The same value, typed as a definite `string`.
+ */
+function assertUrlDefined(url: string | undefined): string {
+	if (url === undefined) {
+		throw new Error('Expected a url, got undefined.');
+	}
+	return url;
+}
+
+describe('building a download link for a file asset', () => {
+	it('falls back to a placeholder when the asset is undefined', async () => {
+		const { getDownloadFileUrl } = await loadWithEnv<UtilsModule>('@/lib/sanity/utils', SANITY_ENV);
+
+		expect(getDownloadFileUrl()).toBe('#!');
+	});
+
+	it('falls back to a placeholder when the asset is null', async () => {
+		const { getDownloadFileUrl } = await loadWithEnv<UtilsModule>('@/lib/sanity/utils', SANITY_ENV);
+
+		expect(getDownloadFileUrl(null)).toBe('#!');
+	});
+
+	it('falls back to a placeholder when the original filename is missing', async () => {
+		const { getDownloadFileUrl } = await loadWithEnv<UtilsModule>('@/lib/sanity/utils', SANITY_ENV);
+
+		const asset = { url: 'https://cdn.sanity.io/files/x/y/z.pdf' } as SanityFileAsset;
+
+		expect(getDownloadFileUrl(asset)).toBe('#!');
+	});
+
+	it('falls back to a placeholder when the url is missing', async () => {
+		const { getDownloadFileUrl } = await loadWithEnv<UtilsModule>('@/lib/sanity/utils', SANITY_ENV);
+
+		const asset = { originalFilename: 'broschuere.pdf' } as SanityFileAsset;
+
+		expect(getDownloadFileUrl(asset)).toBe('#!');
+	});
+
+	it('appends the original filename as a download parameter for a complete asset', async () => {
+		const { getDownloadFileUrl } = await loadWithEnv<UtilsModule>('@/lib/sanity/utils', SANITY_ENV);
+
+		const asset = {
+			originalFilename: 'Broschüre.pdf',
+			url: 'https://cdn.sanity.io/files/test-project/test-dataset/abc123.pdf',
+		} as SanityFileAsset;
+
+		expect(getDownloadFileUrl(asset)).toBe(
+			'https://cdn.sanity.io/files/test-project/test-dataset/abc123.pdf?dl=Broschüre.pdf',
+		);
+	});
+});
+
+describe('converting a byte count to a human readable size', () => {
+	it('shows a dash for an undefined size', async () => {
+		const { getFileSize } = await loadWithEnv<UtilsModule>('@/lib/sanity/utils', SANITY_ENV);
+
+		expect(getFileSize()).toBe('—');
+	});
+
+	it('shows a dash for a zero size', async () => {
+		const { getFileSize } = await loadWithEnv<UtilsModule>('@/lib/sanity/utils', SANITY_ENV);
+
+		expect(getFileSize(0)).toBe('—');
+	});
+
+	it('shows a dash for a negative size', async () => {
+		const { getFileSize } = await loadWithEnv<UtilsModule>('@/lib/sanity/utils', SANITY_ENV);
+
+		expect(getFileSize(-5)).toBe('—');
+	});
+
+	it('reports whole bytes without a decimal', async () => {
+		const { getFileSize } = await loadWithEnv<UtilsModule>('@/lib/sanity/utils', SANITY_ENV);
+
+		// index stays 0 (the "B" unit), and `toFixed(0)` drops the decimal point entirely.
+		expect(getFileSize(512)).toBe('512 B');
+	});
+
+	it('reports kilobytes with one decimal', async () => {
+		const { getFileSize } = await loadWithEnv<UtilsModule>('@/lib/sanity/utils', SANITY_ENV);
+
+		// 1024 crosses into the "KB" unit once (index 1), so `toFixed(1)` keeps one decimal.
+		expect(getFileSize(1024)).toBe('1.0 KB');
+	});
+
+	it('reports megabytes with two decimals', async () => {
+		const { getFileSize } = await loadWithEnv<UtilsModule>('@/lib/sanity/utils', SANITY_ENV);
+
+		// 1,572,864 = 1.5 * 1024 * 1024 crosses into "MB" (index 2), so `toFixed(2)` keeps two decimals.
+		expect(getFileSize(1_572_864)).toBe('1.50 MB');
+	});
+
+	it('reports gigabytes with three decimals', async () => {
+		const { getFileSize } = await loadWithEnv<UtilsModule>('@/lib/sanity/utils', SANITY_ENV);
+
+		// 2 * 1024^3 crosses into "GB" (index 3), so `toFixed(3)` keeps three decimals.
+		expect(getFileSize(2 * 1024 ** 3)).toBe('2.000 GB');
+	});
+
+	it('caps at the gigabyte unit for a value far beyond it', async () => {
+		const { getFileSize } = await loadWithEnv<UtilsModule>('@/lib/sanity/utils', SANITY_ENV);
+
+		// The loop stops once index reaches the last unit (GB, index 3), so a value equivalent to
+		// 3 TB is reported as an oversized "GB" figure rather than continuing to a "TB" unit that
+		// does not exist in the implementation's `units` array.
+		expect(getFileSize(3 * 1024 ** 4)).toBe('3072.000 GB');
+	});
+});
+
+describe('generating a sanity image url', () => {
+	it('returns undefined for an undefined image', async () => {
+		const { urlForImage } = await loadWithEnv<UtilsModule>('@/lib/sanity/utils', SANITY_ENV);
+
+		// `image` is a required parameter typed to accept `undefined`, so the argument cannot be
+		// omitted without a type error.
+		// oxlint-disable-next-line unicorn/no-useless-undefined
+		expect(urlForImage(undefined)).toBeUndefined();
+	});
+
+	it('returns undefined when the asset reference is missing', async () => {
+		const { urlForImage } = await loadWithEnv<UtilsModule>('@/lib/sanity/utils', SANITY_ENV);
+
+		expect(urlForImage({ _type: 'image' })).toBeUndefined();
+	});
+
+	it('builds a cropped square url from a height only', async () => {
+		const { urlForImage } = await loadWithEnv<UtilsModule>('@/lib/sanity/utils', SANITY_ENV);
+
+		const url = urlForImage(buildImage(), 300);
+
+		const params = new URL(assertUrlDefined(url)).searchParams;
+		expect(params.get('w')).toBe('300');
+		expect(params.get('h')).toBe('300');
+		expect(params.get('fit')).toBe('crop');
+		expect(params.get('q')).toBe('90');
+	});
+
+	it('builds on the fixed test project and dataset from loadWithEnv', async () => {
+		const { urlForImage } = await loadWithEnv<UtilsModule>('@/lib/sanity/utils', SANITY_ENV);
+
+		const url = urlForImage(buildImage(), 300);
+
+		expect(new URL(assertUrlDefined(url)).pathname).toContain('/images/test-project/test-dataset/');
+	});
+
+	it('builds a cropped url from an explicit width and height', async () => {
+		const { urlForImage } = await loadWithEnv<UtilsModule>('@/lib/sanity/utils', SANITY_ENV);
+
+		const url = urlForImage(buildImage(), 300, 400);
+
+		const params = new URL(assertUrlDefined(url)).searchParams;
+		expect(params.get('w')).toBe('400');
+		expect(params.get('h')).toBe('300');
+		expect(params.get('fit')).toBe('crop');
+	});
+
+	it('builds an uncropped url when neither dimension is given', async () => {
+		const { urlForImage } = await loadWithEnv<UtilsModule>('@/lib/sanity/utils', SANITY_ENV);
+
+		const url = urlForImage(buildImage());
+
+		const params = new URL(assertUrlDefined(url)).searchParams;
+		expect(params.get('fit')).toBe('max');
+		expect(params.get('q')).toBe('90');
+		expect(params.has('w')).toBe(false);
+		expect(params.has('h')).toBe(false);
+	});
+});
+
+describe('generating a scaled down sanity image url', () => {
+	it('returns undefined when the asset reference is missing', async () => {
+		const { urlForImageMax } = await loadWithEnv<UtilsModule>('@/lib/sanity/utils', SANITY_ENV);
+
+		expect(urlForImageMax({ _type: 'image' }, 2560)).toBeUndefined();
+	});
+
+	it('builds an uncropped url capped at the given width', async () => {
+		const { urlForImageMax } = await loadWithEnv<UtilsModule>('@/lib/sanity/utils', SANITY_ENV);
+
+		const url = urlForImageMax(buildImage(), 2560);
+
+		const params = new URL(assertUrlDefined(url)).searchParams;
+		expect(params.get('w')).toBe('2560');
+		expect(params.get('fit')).toBe('max');
+		expect(params.has('h')).toBe(false);
+	});
+});

--- a/apps/web/src/lib/sanity/utils.test.ts
+++ b/apps/web/src/lib/sanity/utils.test.ts
@@ -1,5 +1,4 @@
-import type { SanityClient } from 'next-sanity';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import type * as utilsModule from '@/lib/sanity/utils';
 import type { SanityFileAsset, SanityImage } from '@/types/sanity.types';
@@ -7,21 +6,6 @@ import type { SanityFileAsset, SanityImage } from '@/types/sanity.types';
 import { loadWithEnv } from '../../../test-utils/env';
 
 type UtilsModule = typeof utilsModule;
-
-// `next-sanity`'s ESM entry statically imports `unstable__adapter`/`unstable__environment` from
-// `@sanity/client`, which this workspace pins to a version that no longer exports them (a
-// pre-existing dependency mismatch between `next-sanity@13.3.3`, which peer-requires
-// `@sanity/client@^7.26.2`, and the `^8.2.0` actually installed). Importing the real
-// `next-sanity` package throws `SyntaxError: The requested module '@sanity/client' does not
-// provide an export named 'unstable__adapter'` before any test in this file can even run, so
-// `createClient` is replaced with an identity function: `./client` passes it a plain config
-// object built from real, env-driven `projectId`/`dataset`, and `@sanity/image-url`'s builder
-// accepts that object as-is when it has no `config()`/`clientConfig` shape (see
-// `getOptions` in `@sanity/image-url`'s `builder.ts`). This keeps `urlForImage` and
-// `urlForImageMax` exercising their real, unmodified implementation end to end.
-vi.mock(import('next-sanity'), () => ({
-	createClient: (config: unknown) => config as SanityClient,
-}));
 
 const SANITY_ENV = {
 	NEXT_PUBLIC_SANITY_DATASET: 'test-dataset',

--- a/apps/web/src/lib/validations/contact-form.test.ts
+++ b/apps/web/src/lib/validations/contact-form.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+
+import { contactFormSchema, contactFormWithReceiverSchema } from '@/lib/validations/contact-form';
+
+const VALID_PAYLOAD = {
+	email: 'test@example.com',
+	message: 'x'.repeat(32),
+	name: 'Al',
+	privacy: true,
+};
+
+const VALID_RECEIVER = { email: 'receiver@example.com', label: 'Vorstand' };
+
+describe('the base contact form schema', () => {
+	it('parses a complete valid payload without a receiver', () => {
+		const result = contactFormSchema.safeParse(VALID_PAYLOAD);
+
+		expect(result.success).toBe(true);
+	});
+
+	it('parses a complete valid payload with a receiver', () => {
+		const result = contactFormSchema.safeParse({ ...VALID_PAYLOAD, receiver: VALID_RECEIVER });
+
+		expect(result.success).toBe(true);
+	});
+
+	it('rejects an invalid email', () => {
+		const result = contactFormSchema.safeParse({ ...VALID_PAYLOAD, email: 'not-an-email' });
+
+		expect(result.success).toBe(false);
+		expect(result.error?.issues[0]?.message).toBe('Die E-Mail Adresse ist ungültig.');
+	});
+
+	it('rejects a message of 31 characters', () => {
+		const result = contactFormSchema.safeParse({ ...VALID_PAYLOAD, message: 'x'.repeat(31) });
+
+		expect(result.success).toBe(false);
+		expect(result.error?.issues[0]?.message).toBe(
+			'Die Nachricht muss mindestens 32 Zeichen lang sein.',
+		);
+	});
+
+	it('accepts a message of exactly 32 characters', () => {
+		const result = contactFormSchema.safeParse({ ...VALID_PAYLOAD, message: 'x'.repeat(32) });
+
+		expect(result.success).toBe(true);
+	});
+
+	it('rejects a name of 1 character', () => {
+		const result = contactFormSchema.safeParse({ ...VALID_PAYLOAD, name: 'A' });
+
+		expect(result.success).toBe(false);
+		expect(result.error?.issues[0]?.message).toBe('Der Name muss mindestens 2 Zeichen lang sein.');
+	});
+
+	it('accepts a name of exactly 2 characters', () => {
+		const result = contactFormSchema.safeParse({ ...VALID_PAYLOAD, name: 'AB' });
+
+		expect(result.success).toBe(true);
+	});
+
+	it('rejects privacy set to false', () => {
+		const result = contactFormSchema.safeParse({ ...VALID_PAYLOAD, privacy: false });
+
+		expect(result.success).toBe(false);
+	});
+
+	it('accepts privacy set to true', () => {
+		const result = contactFormSchema.safeParse({ ...VALID_PAYLOAD, privacy: true });
+
+		expect(result.success).toBe(true);
+	});
+
+	it('rejects a receiver with a bad email with the receiver message', () => {
+		const result = contactFormSchema.safeParse({
+			...VALID_PAYLOAD,
+			receiver: { email: 'not-an-email', label: 'Vorstand' },
+		});
+
+		expect(result.success).toBe(false);
+		expect(result.error?.issues[0]?.message).toBe('Kein Empfänger ausgewählt.');
+	});
+
+	it('accepts a missing receiver', () => {
+		const result = contactFormSchema.safeParse(VALID_PAYLOAD);
+
+		expect(result.success).toBe(true);
+	});
+});
+
+describe('the difference between the base and receiver-required schemas', () => {
+	it('rejects a missing receiver only when the receiver is required', () => {
+		const withoutReceiver = contactFormSchema.safeParse(VALID_PAYLOAD);
+		const withoutReceiverButRequired = contactFormWithReceiverSchema.safeParse(VALID_PAYLOAD);
+		const withReceiverAndRequired = contactFormWithReceiverSchema.safeParse({
+			...VALID_PAYLOAD,
+			receiver: VALID_RECEIVER,
+		});
+
+		expect(withoutReceiver.success).toBe(true);
+		expect(withoutReceiverButRequired.success).toBe(false);
+		expect(withReceiverAndRequired.success).toBe(true);
+	});
+});

--- a/apps/web/src/lib/validations/contact-form.test.ts
+++ b/apps/web/src/lib/validations/contact-form.test.ts
@@ -80,12 +80,6 @@ describe('the base contact form schema', () => {
 		expect(result.success).toBe(false);
 		expect(result.error?.issues[0]?.message).toBe('Kein Empfänger ausgewählt.');
 	});
-
-	it('accepts a missing receiver', () => {
-		const result = contactFormSchema.safeParse(VALID_PAYLOAD);
-
-		expect(result.success).toBe(true);
-	});
 });
 
 describe('the difference between the base and receiver-required schemas', () => {

--- a/apps/web/src/lib/validations/feedback.test.ts
+++ b/apps/web/src/lib/validations/feedback.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from 'vitest';
+
+import { feedbackFormSchema } from '@/lib/validations/feedback';
+
+const MINIMAL_PAYLOAD = {
+	description: 'x'.repeat(20),
+	privacy: true,
+	title: 'abcde',
+	type: 'bug',
+};
+
+describe('the feedback form schema', () => {
+	it('parses a minimal payload with only the required fields', () => {
+		const result = feedbackFormSchema.safeParse(MINIMAL_PAYLOAD);
+
+		expect(result.success).toBe(true);
+	});
+
+	it('rejects a title of 4 characters', () => {
+		const result = feedbackFormSchema.safeParse({ ...MINIMAL_PAYLOAD, title: 'abcd' });
+
+		expect(result.success).toBe(false);
+		expect(result.error?.issues[0]?.message).toBe('Der Titel muss mindestens 5 Zeichen lang sein');
+	});
+
+	it('accepts a title of exactly 5 characters', () => {
+		const result = feedbackFormSchema.safeParse({ ...MINIMAL_PAYLOAD, title: 'abcde' });
+
+		expect(result.success).toBe(true);
+	});
+
+	it('accepts a title of exactly 100 characters', () => {
+		const result = feedbackFormSchema.safeParse({ ...MINIMAL_PAYLOAD, title: 'a'.repeat(100) });
+
+		expect(result.success).toBe(true);
+	});
+
+	it('rejects a title of 101 characters', () => {
+		const result = feedbackFormSchema.safeParse({ ...MINIMAL_PAYLOAD, title: 'a'.repeat(101) });
+
+		expect(result.success).toBe(false);
+		expect(result.error?.issues[0]?.message).toBe('Der Titel darf maximal 100 Zeichen lang sein');
+	});
+
+	it('rejects a description of 19 characters', () => {
+		const result = feedbackFormSchema.safeParse({
+			...MINIMAL_PAYLOAD,
+			description: 'x'.repeat(19),
+		});
+
+		expect(result.success).toBe(false);
+		expect(result.error?.issues[0]?.message).toBe(
+			'Die Beschreibung muss mindestens 20 Zeichen lang sein',
+		);
+	});
+
+	it('accepts a description of exactly 20 characters', () => {
+		const result = feedbackFormSchema.safeParse({
+			...MINIMAL_PAYLOAD,
+			description: 'x'.repeat(20),
+		});
+
+		expect(result.success).toBe(true);
+	});
+
+	it('accepts a description of exactly 2000 characters', () => {
+		const result = feedbackFormSchema.safeParse({
+			...MINIMAL_PAYLOAD,
+			description: 'x'.repeat(2000),
+		});
+
+		expect(result.success).toBe(true);
+	});
+
+	it('rejects a description of 2001 characters', () => {
+		const result = feedbackFormSchema.safeParse({
+			...MINIMAL_PAYLOAD,
+			description: 'x'.repeat(2001),
+		});
+
+		expect(result.success).toBe(false);
+		expect(result.error?.issues[0]?.message).toBe(
+			'Die Beschreibung darf maximal 2000 Zeichen lang sein',
+		);
+	});
+
+	it('accepts a valid email', () => {
+		const result = feedbackFormSchema.safeParse({ ...MINIMAL_PAYLOAD, email: 'a@b.com' });
+
+		expect(result.success).toBe(true);
+	});
+
+	it('accepts an empty string email', () => {
+		const result = feedbackFormSchema.safeParse({ ...MINIMAL_PAYLOAD, email: '' });
+
+		expect(result.success).toBe(true);
+	});
+
+	it('rejects an invalid email', () => {
+		const result = feedbackFormSchema.safeParse({ ...MINIMAL_PAYLOAD, email: 'not-an-email' });
+
+		expect(result.success).toBe(false);
+		expect(result.error?.issues[0]?.message).toBe('Bitte gib eine gültige E-Mail-Adresse ein');
+	});
+
+	it('accepts a payload with the email field absent', () => {
+		const result = feedbackFormSchema.safeParse(MINIMAL_PAYLOAD);
+
+		expect(result.success).toBe(true);
+	});
+
+	it('rejects an unknown browser value', () => {
+		const result = feedbackFormSchema.safeParse({ ...MINIMAL_PAYLOAD, browser: 'ie6' });
+
+		expect(result.success).toBe(false);
+	});
+
+	it('rejects an unknown operating system value', () => {
+		const result = feedbackFormSchema.safeParse({
+			...MINIMAL_PAYLOAD,
+			operationSystem: 'amiga',
+		});
+
+		expect(result.success).toBe(false);
+	});
+
+	it('rejects an unknown type value', () => {
+		const result = feedbackFormSchema.safeParse({ ...MINIMAL_PAYLOAD, type: 'idea' });
+
+		expect(result.success).toBe(false);
+	});
+
+	it('produces the documented message when type is missing', () => {
+		const { type: _type, ...withoutType } = MINIMAL_PAYLOAD;
+
+		const result = feedbackFormSchema.safeParse(withoutType);
+
+		expect(result.success).toBe(false);
+		expect(result.error?.issues[0]?.message).toBe('Bitte wähle einen Typ aus');
+	});
+
+	it('rejects privacy set to false', () => {
+		const result = feedbackFormSchema.safeParse({ ...MINIMAL_PAYLOAD, privacy: false });
+
+		expect(result.success).toBe(false);
+	});
+
+	it('accepts an empty screenshotUrls array', () => {
+		const result = feedbackFormSchema.safeParse({ ...MINIMAL_PAYLOAD, screenshotUrls: [] });
+
+		expect(result.success).toBe(true);
+	});
+
+	it('accepts a populated screenshotUrls array', () => {
+		const result = feedbackFormSchema.safeParse({
+			...MINIMAL_PAYLOAD,
+			screenshotUrls: ['https://example.com/a.png'],
+		});
+
+		expect(result.success).toBe(true);
+	});
+
+	it('accepts a payload with screenshotUrls absent', () => {
+		const result = feedbackFormSchema.safeParse(MINIMAL_PAYLOAD);
+
+		expect(result.success).toBe(true);
+	});
+});

--- a/apps/web/src/utils/groups.test.ts
+++ b/apps/web/src/utils/groups.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+
+import type * as groupsModule from '@/utils/groups';
+
+import { loadWithEnv } from '../../test-utils/env';
+
+type GroupsModule = typeof groupsModule;
+
+const FALLBACK_ALT =
+	'Sporthalle mit drei verschiedenen Trainingsgruppen: Links üben Kinder und ein Trainer in weißen Taekwondo-Anzügen mit schwarzem Gürtel synchrone Kicks, in der Mitte zeigen Mädchen in türkis-blauen Gymnastik-Trikots mit bunten Federn eine Beinübung, und rechts spielen Kinder unter Anleitung von Trainern in dunkelblauen Shirts Fußball auf einer grünen Kunstrasenfläche. Im Hintergrund sind bunte Gymnastikbälle und Sportgeräte zu sehen.';
+
+describe('looking up the current department', () => {
+	it('returns the department whose slug matches the given group', async () => {
+		const { getCurrentDepartment } = await loadWithEnv<GroupsModule>('@/utils/groups', {});
+
+		const department = getCurrentDepartment('fussball');
+
+		expect(department?.slug).toBe('/angebot/fussball');
+		expect(department?._type).toBe('group.soccer');
+	});
+
+	it('returns undefined for a group without a department page', async () => {
+		const { getCurrentDepartment } = await loadWithEnv<GroupsModule>('@/utils/groups', {});
+
+		expect(getCurrentDepartment('gibtsnicht')).toBeUndefined();
+	});
+});
+
+describe('resolving a group image', () => {
+	it('returns the matching image using the default path', async () => {
+		const { getGroupImage } = await loadWithEnv<GroupsModule>('@/utils/groups', {});
+
+		expect(getGroupImage('/angebot/fussball').alt).toBe('Fußball');
+	});
+
+	it('returns the matching image using an explicit path', async () => {
+		const { getGroupImage } = await loadWithEnv<GroupsModule>('@/utils/groups', {});
+
+		expect(getGroupImage('fussball', '/angebot/').alt).toBe('Fußball');
+	});
+
+	it('falls back to the fallback image for an unknown group', async () => {
+		const { fallbackImage, getGroupImage } = await loadWithEnv<GroupsModule>('@/utils/groups', {});
+
+		expect(getGroupImage('gibtsnicht')).toBe(fallbackImage);
+	});
+});
+
+describe('building the group open graph image', () => {
+	it('builds the image of a known group on a fixed base url', async () => {
+		const { getOGImage } = await loadWithEnv<GroupsModule>('@/utils/groups', {
+			NODE_ENV: 'production',
+			VERCEL_PROJECT_PRODUCTION_URL: 'tsg-irlich.vercel.app',
+		});
+
+		expect(getOGImage('fussball')).toStrictEqual({
+			alt: 'Fußball',
+			height: 630,
+			url: 'https://tsg-irlich.vercel.app/og/angebot/groups/fussball.webp',
+			width: 1200,
+		});
+	});
+
+	it('falls back to the department overview image for an unknown group', async () => {
+		const { getOGImage } = await loadWithEnv<GroupsModule>('@/utils/groups', {
+			NODE_ENV: 'production',
+			VERCEL_PROJECT_PRODUCTION_URL: 'tsg-irlich.vercel.app',
+		});
+
+		expect(getOGImage('gibtsnicht')).toStrictEqual({
+			alt: FALLBACK_ALT,
+			height: 630,
+			url: 'https://tsg-irlich.vercel.app/og/angebot.webp',
+			width: 1200,
+		});
+	});
+});
+
+describe('the offer group sections themselves', () => {
+	it('gives every entry a slug below /angebot', async () => {
+		const { groupSections } = await loadWithEnv<GroupsModule>('@/utils/groups', {});
+
+		for (const section of groupSections) {
+			expect(section.slug.startsWith('/angebot/')).toBe(true);
+		}
+	});
+
+	it('gives every entry a non-empty alt text', async () => {
+		const { groupSections } = await loadWithEnv<GroupsModule>('@/utils/groups', {});
+
+		for (const section of groupSections) {
+			expect(section.image.alt.length).toBeGreaterThan(0);
+		}
+	});
+
+	it('gives every entry a unique type', async () => {
+		const { groupSections } = await loadWithEnv<GroupsModule>('@/utils/groups', {});
+
+		const types = new Set(groupSections.map((section) => section._type));
+
+		expect(types.size).toBe(groupSections.length);
+	});
+});

--- a/apps/web/src/utils/groups.test.ts
+++ b/apps/web/src/utils/groups.test.ts
@@ -11,12 +11,14 @@ const FALLBACK_ALT =
 
 describe('looking up the current department', () => {
 	it('returns the department whose slug matches the given group', async () => {
-		const { getCurrentDepartment } = await loadWithEnv<GroupsModule>('@/utils/groups', {});
+		const { getCurrentDepartment, groupSections } = await loadWithEnv<GroupsModule>(
+			'@/utils/groups',
+			{},
+		);
 
-		const department = getCurrentDepartment('fussball');
+		const soccerSection = groupSections[0];
 
-		expect(department?.slug).toBe('/angebot/fussball');
-		expect(department?._type).toBe('group.soccer');
+		expect(getCurrentDepartment('fussball')).toBe(soccerSection);
 	});
 
 	it('returns undefined for a group without a department page', async () => {
@@ -27,16 +29,26 @@ describe('looking up the current department', () => {
 });
 
 describe('resolving a group image', () => {
-	it('returns the matching image using the default path', async () => {
-		const { getGroupImage } = await loadWithEnv<GroupsModule>('@/utils/groups', {});
+	it('returns the matching image object using the default path', async () => {
+		const { getGroupImage, groupSections } = await loadWithEnv<GroupsModule>('@/utils/groups', {});
 
-		expect(getGroupImage('/angebot/fussball').alt).toBe('Fußball');
+		const soccerSection = groupSections[0];
+
+		expect(getGroupImage('/angebot/fussball')).toBe(soccerSection.image);
 	});
 
-	it('returns the matching image using an explicit path', async () => {
-		const { getGroupImage } = await loadWithEnv<GroupsModule>('@/utils/groups', {});
+	it('returns the matching image object using the path production actually passes', async () => {
+		const { getGroupImage, groupSections } = await loadWithEnv<GroupsModule>('@/utils/groups', {});
 
-		expect(getGroupImage('fussball', '/angebot/').alt).toBe('Fußball');
+		const soccerSection = groupSections[0];
+
+		expect(getGroupImage('fussball', '/angebot/')).toBe(soccerSection.image);
+	});
+
+	it('does not match when the path is missing its trailing separator', async () => {
+		const { fallbackImage, getGroupImage } = await loadWithEnv<GroupsModule>('@/utils/groups', {});
+
+		expect(getGroupImage('fussball', '/angebot')).toBe(fallbackImage);
 	});
 
 	it('falls back to the fallback image for an unknown group', async () => {

--- a/apps/web/src/utils/icon.test.ts
+++ b/apps/web/src/utils/icon.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+
+import { socialMediaMap } from '@/components/ui/social-media-icon';
+import { getSocialMediaEntries } from '@/utils/icon';
+
+describe('turning sanity social fields into renderable entries', () => {
+	it('returns no entries for a null social fields object', () => {
+		expect(getSocialMediaEntries(null)).toStrictEqual([]);
+	});
+
+	it('returns no entries for an undefined social fields object', () => {
+		const socialFields: Parameters<typeof getSocialMediaEntries>[0] = undefined;
+
+		expect(getSocialMediaEntries(socialFields)).toStrictEqual([]);
+	});
+
+	it('returns no entries for an empty social fields object', () => {
+		expect(getSocialMediaEntries({})).toStrictEqual([]);
+	});
+
+	it('turns a known platform with a url into one entry', () => {
+		const entries = getSocialMediaEntries({ facebook: 'https://facebook.com/tsg-irlich' });
+
+		expect(entries).toStrictEqual([
+			{ icon: socialMediaMap.facebook, name: 'facebook', url: 'https://facebook.com/tsg-irlich' },
+		]);
+	});
+
+	it('skips the sanity meta key', () => {
+		expect(getSocialMediaEntries({ _type: 'socialFields' })).toStrictEqual([]);
+	});
+
+	it('skips a known platform with an undefined url', () => {
+		expect(getSocialMediaEntries({ instagram: undefined })).toStrictEqual([]);
+	});
+
+	it('skips a known platform with an empty url', () => {
+		expect(getSocialMediaEntries({ instagram: '' })).toStrictEqual([]);
+	});
+
+	it('skips an unknown key', () => {
+		expect(getSocialMediaEntries({ mastodon: 'https://mastodon.social/@tsg' })).toStrictEqual([]);
+	});
+
+	it('returns several platforms in object-key order', () => {
+		const entries = getSocialMediaEntries({
+			whatsapp: 'https://wa.me/1234567',
+			youtube: 'https://youtube.com/tsg-irlich',
+		});
+
+		expect(entries).toStrictEqual([
+			{ icon: socialMediaMap.whatsapp, name: 'whatsapp', url: 'https://wa.me/1234567' },
+			{ icon: socialMediaMap.youtube, name: 'youtube', url: 'https://youtube.com/tsg-irlich' },
+		]);
+	});
+});

--- a/apps/web/src/utils/icon.test.ts
+++ b/apps/web/src/utils/icon.test.ts
@@ -1,6 +1,6 @@
+import { SiFacebook, SiWhatsapp, SiYoutube } from '@icons-pack/react-simple-icons';
 import { describe, expect, it } from 'vitest';
 
-import { socialMediaMap } from '@/components/ui/social-media-icon';
 import { getSocialMediaEntries } from '@/utils/icon';
 
 describe('turning sanity social fields into renderable entries', () => {
@@ -22,7 +22,7 @@ describe('turning sanity social fields into renderable entries', () => {
 		const entries = getSocialMediaEntries({ facebook: 'https://facebook.com/tsg-irlich' });
 
 		expect(entries).toStrictEqual([
-			{ icon: socialMediaMap.facebook, name: 'facebook', url: 'https://facebook.com/tsg-irlich' },
+			{ icon: SiFacebook, name: 'facebook', url: 'https://facebook.com/tsg-irlich' },
 		]);
 	});
 
@@ -49,8 +49,8 @@ describe('turning sanity social fields into renderable entries', () => {
 		});
 
 		expect(entries).toStrictEqual([
-			{ icon: socialMediaMap.whatsapp, name: 'whatsapp', url: 'https://wa.me/1234567' },
-			{ icon: socialMediaMap.youtube, name: 'youtube', url: 'https://youtube.com/tsg-irlich' },
+			{ icon: SiWhatsapp, name: 'whatsapp', url: 'https://wa.me/1234567' },
+			{ icon: SiYoutube, name: 'youtube', url: 'https://youtube.com/tsg-irlich' },
 		]);
 	});
 });

--- a/apps/web/src/utils/image.test.ts
+++ b/apps/web/src/utils/image.test.ts
@@ -1,0 +1,164 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { urlForImage, urlForImageMax } from '@/lib/sanity/utils';
+import { getGalleryImages, getInitials } from '@/utils/image';
+import type { GalleryImageSource } from '@/utils/image';
+
+// `getGalleryImages` only orchestrates `urlForImage`/`urlForImageMax`; Task 5
+// (`src/lib/sanity/utils.test.ts`) already pins their real behavior, so this file mocks both to
+// keep the assertions about the orchestration logic independent of the real Sanity image builder.
+vi.mock(import('@/lib/sanity/utils'), () => ({
+	urlForImage: vi.fn(),
+	urlForImageMax: vi.fn(),
+}));
+
+const mockedUrlForImage = vi.mocked(urlForImage);
+const mockedUrlForImageMax = vi.mocked(urlForImageMax);
+
+const IMAGE_A: GalleryImageSource = {
+	_key: 'img-a',
+	alt: 'Alt A',
+	asset: { _ref: 'image-aaa111-800x600-jpg', _type: 'reference' },
+	description: 'Caption A',
+};
+
+const IMAGE_B: GalleryImageSource = {
+	_key: 'img-b',
+	alt: 'Alt B',
+	asset: { _ref: 'image-bbb222-800x600-jpg', _type: 'reference' },
+};
+
+describe('generating initials from a first and last name', () => {
+	it('takes the first letter of each name', () => {
+		expect(getInitials('John', 'Doe')).toBe('JD');
+	});
+
+	it('upper-cases lower case names', () => {
+		expect(getInitials('jane', 'doe')).toBe('JD');
+	});
+
+	it('falls back to a question mark for a missing last name', () => {
+		expect(getInitials('Jane', '')).toBe('J?');
+	});
+
+	it('falls back to a question mark for a missing first name', () => {
+		expect(getInitials('', 'Doe')).toBe('?D');
+	});
+
+	it('falls back to two question marks when both names are missing', () => {
+		expect(getInitials('', '')).toBe('??');
+	});
+
+	it('falls back to two question marks when both names are whitespace only', () => {
+		expect(getInitials('   ', '   ')).toBe('??');
+	});
+
+	it('trims leading whitespace before taking the first letter', () => {
+		expect(getInitials('  Max', '')).toBe('M?');
+	});
+
+	it('upper-cases a non-ASCII first letter correctly', () => {
+		expect(getInitials('örs', '')).toBe('Ö?');
+	});
+});
+
+describe('building the gallery images a document exposes', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('returns an empty array for undefined images', () => {
+		// `images` is a required parameter typed to accept `undefined`, so the argument cannot be
+		// omitted without a type error.
+		// oxlint-disable-next-line unicorn/no-useless-undefined
+		expect(getGalleryImages(undefined)).toStrictEqual([]);
+	});
+
+	it('returns an empty array for an empty list', () => {
+		expect(getGalleryImages([])).toStrictEqual([]);
+	});
+
+	it('builds one entry from a single resolvable image', () => {
+		mockedUrlForImage.mockReturnValue('https://cdn.sanity.io/thumb-a.jpg');
+		mockedUrlForImageMax.mockReturnValue('https://cdn.sanity.io/full-a.jpg');
+
+		const result = getGalleryImages([IMAGE_A]);
+
+		expect(result).toStrictEqual([
+			{
+				alt: 'Alt A',
+				caption: 'Caption A',
+				key: 'img-a',
+				src: 'https://cdn.sanity.io/thumb-a.jpg',
+				srcFull: 'https://cdn.sanity.io/full-a.jpg',
+			},
+		]);
+	});
+
+	it('drops an image whose thumbnail url cannot be resolved', () => {
+		// `mockReturnValue` mirrors `urlForImage`'s own `string | undefined` return type, so the
+		// argument cannot be omitted without a type error.
+		// oxlint-disable-next-line unicorn/no-useless-undefined
+		mockedUrlForImage.mockReturnValue(undefined);
+		mockedUrlForImageMax.mockReturnValue('https://cdn.sanity.io/full-a.jpg');
+
+		expect(getGalleryImages([IMAGE_A])).toStrictEqual([]);
+	});
+
+	it('drops an image whose full screen url cannot be resolved', () => {
+		mockedUrlForImage.mockReturnValue('https://cdn.sanity.io/thumb-a.jpg');
+		// oxlint-disable-next-line unicorn/no-useless-undefined
+		mockedUrlForImageMax.mockReturnValue(undefined);
+
+		expect(getGalleryImages([IMAGE_A])).toStrictEqual([]);
+	});
+
+	it('keeps only the resolvable entries and preserves their order in a mixed list', () => {
+		const IMAGE_C: GalleryImageSource = { ...IMAGE_A, _key: 'img-c' };
+
+		// One `mockReturnValueOnce` per call, in call order (A, B, C), instead of branching on the
+		// image inside the implementation, keeps the mock free of a conditional.
+		mockedUrlForImage
+			.mockReturnValueOnce('thumb-img-a')
+			// oxlint-disable-next-line unicorn/no-useless-undefined -- mirrors urlForImage's real return type
+			.mockReturnValueOnce(undefined)
+			.mockReturnValueOnce('thumb-img-c');
+		mockedUrlForImageMax
+			.mockReturnValueOnce('full-img-a')
+			.mockReturnValueOnce('full-img-b')
+			.mockReturnValueOnce('full-img-c');
+
+		const result = getGalleryImages([IMAGE_A, IMAGE_B, IMAGE_C]);
+
+		expect(result.map((entry) => entry.key)).toStrictEqual(['img-a', 'img-c']);
+	});
+
+	it('forwards the height and width arguments to urlForImage', () => {
+		mockedUrlForImage.mockReturnValue('https://cdn.sanity.io/thumb-a.jpg');
+		mockedUrlForImageMax.mockReturnValue('https://cdn.sanity.io/full-a.jpg');
+
+		getGalleryImages([IMAGE_A], 700, 1244);
+
+		expect(mockedUrlForImage).toHaveBeenCalledWith(IMAGE_A, 700, 1244);
+	});
+
+	it('always calls urlForImageMax with the fixed full screen width', () => {
+		mockedUrlForImage.mockReturnValue('https://cdn.sanity.io/thumb-a.jpg');
+		mockedUrlForImageMax.mockReturnValue('https://cdn.sanity.io/full-a.jpg');
+
+		getGalleryImages([IMAGE_A], 700, 1244);
+
+		// The literal is asserted on purpose, not the module's private `FULL_IMAGE_WIDTH` constant,
+		// so a change to that constant's value is caught here rather than silently agreeing with it.
+		expect(mockedUrlForImageMax).toHaveBeenCalledWith(IMAGE_A, 2560);
+	});
+
+	it('sets the caption to undefined for an image without a description', () => {
+		mockedUrlForImage.mockReturnValue('https://cdn.sanity.io/thumb-b.jpg');
+		mockedUrlForImageMax.mockReturnValue('https://cdn.sanity.io/full-b.jpg');
+
+		const [entry] = getGalleryImages([IMAGE_B]);
+
+		expect(entry.caption).toBeUndefined();
+	});
+});

--- a/apps/web/src/utils/links.test.ts
+++ b/apps/web/src/utils/links.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+
+import { groupSections } from '@/utils/groups';
+import { getInternalHref } from '@/utils/links';
+
+describe('resolving internal link targets', () => {
+	it('resolves the home page to the site root', () => {
+		expect(getInternalHref({ _type: 'home', slug: 'home' })).toBe('/');
+	});
+
+	it('resolves a news article below its category', () => {
+		expect(getInternalHref({ _type: 'news.article', category: 'verein', slug: 'sommerfest' })).toBe(
+			'/news/verein/sommerfest',
+		);
+	});
+
+	it('leaves a news article without a category unresolved', () => {
+		expect(getInternalHref({ _type: 'news.article', slug: 'sommerfest' })).toBeUndefined();
+	});
+
+	it('resolves a news category below the news overview', () => {
+		expect(getInternalHref({ _type: 'news.category', slug: 'verein' })).toBe('/news/verein');
+	});
+
+	it('resolves a group below the department it belongs to', () => {
+		expect(getInternalHref({ _type: 'group.soccer', slug: 'herren-1' })).toBe(
+			'/angebot/fussball/herren-1',
+		);
+	});
+
+	it('resolves every group type in groupSections below its own department slug', () => {
+		for (const section of groupSections) {
+			expect(getInternalHref({ _type: section._type, slug: 'mitglied-1' })).toBe(
+				`${section.slug}/mitglied-1`,
+			);
+		}
+	});
+
+	it('leaves a group type without a department page unresolved', () => {
+		expect(getInternalHref({ _type: 'group.administration', slug: 'vorstand' })).toBeUndefined();
+	});
+
+	it('resolves an unknown type to a single page at its slug', () => {
+		expect(getInternalHref({ _type: 'membership', slug: 'mitgliedschaft' })).toBe(
+			'/mitgliedschaft',
+		);
+	});
+
+	it('leaves an undefined target unresolved', () => {
+		const undefinedTarget: Parameters<typeof getInternalHref>[0] = undefined;
+
+		expect(getInternalHref(undefinedTarget)).toBeUndefined();
+	});
+
+	it('leaves a null target unresolved', () => {
+		expect(getInternalHref(null)).toBeUndefined();
+	});
+
+	it('leaves an empty target unresolved', () => {
+		expect(getInternalHref({})).toBeUndefined();
+	});
+
+	it('leaves a target without a slug unresolved', () => {
+		expect(getInternalHref({ _type: 'home' })).toBeUndefined();
+	});
+
+	it('leaves a target without a type unresolved', () => {
+		expect(getInternalHref({ slug: 'x' })).toBeUndefined();
+	});
+
+	it('leaves a news article with a null category unresolved', () => {
+		expect(getInternalHref({ _type: 'news.article', category: null, slug: 'x' })).toBeUndefined();
+	});
+});

--- a/apps/web/src/utils/time.test.ts
+++ b/apps/web/src/utils/time.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import { getLocaleDate } from '@/utils/time';
+
+// Normalizes ICU whitespace so a future ICU update that swaps a plain space for a narrow
+// no-break space (U+202F) or a no-break space (U+00A0) does not break the comparison.
+function normalizeSpaces(value: string): string {
+	return value.replaceAll(' ', ' ').replaceAll(' ', ' ');
+}
+
+// Midday UTC so no local timezone shifts the calendar day.
+const NEW_YEAR = new Date('2024-01-01T12:00:00Z');
+const SINGLE_DIGIT_DAY = new Date('2024-01-05T12:00:00Z');
+
+describe('formatting a localized date', () => {
+	it('formats the default long variant', () => {
+		expect(normalizeSpaces(getLocaleDate(NEW_YEAR))).toBe(normalizeSpaces('1. Januar 2024'));
+	});
+
+	it('formats the short variant', () => {
+		expect(normalizeSpaces(getLocaleDate(NEW_YEAR, 'short'))).toBe(normalizeSpaces('01.01.2024'));
+	});
+
+	it('formats an ISO string input the same as the equivalent Date', () => {
+		expect(normalizeSpaces(getLocaleDate('2024-01-01T12:00:00Z', 'long'))).toBe(
+			normalizeSpaces(getLocaleDate(NEW_YEAR, 'long')),
+		);
+	});
+
+	it('changes the output for an explicit locale', () => {
+		expect(normalizeSpaces(getLocaleDate(NEW_YEAR, 'long', 'en-US'))).toBe(
+			normalizeSpaces('January 1, 2024'),
+		);
+	});
+
+	it('keeps 2-digit padding for a single-digit day in the short variant', () => {
+		expect(normalizeSpaces(getLocaleDate(SINGLE_DIGIT_DAY, 'short'))).toBe(
+			normalizeSpaces('05.01.2024'),
+		);
+	});
+
+	it('applies no padding for a single-digit day in the long variant', () => {
+		expect(normalizeSpaces(getLocaleDate(SINGLE_DIGIT_DAY, 'long'))).toBe(
+			normalizeSpaces('5. Januar 2024'),
+		);
+	});
+});

--- a/docs/superpowers/plans/2026-08-26-web-296-unit-tests-pr2-pure-logic.md
+++ b/docs/superpowers/plans/2026-08-26-web-296-unit-tests-pr2-pure-logic.md
@@ -42,13 +42,13 @@
 **Files:** commit this plan.
 
 **Interfaces:**
+
 - Consumes: nothing.
 - Produces: branch `test/web-296-unit-tests-pure-logic`, stacked on `test/web-296-unit-tests`.
 
 - [ ] **Step 1: Confirm the base**
 
-Run: `but status`
-Expected: `test/web-296-unit-tests` applied, working tree clean.
+Run: `but status` Expected: `test/web-296-unit-tests` applied, working tree clean.
 
 - [ ] **Step 2: Create the stacked branch and commit the plan**
 
@@ -60,19 +60,20 @@ but commit -b test/web-296-unit-tests-pure-logic \
 
 - [ ] **Step 3: Verify the stack**
 
-Run: `but status`
-Expected: the new branch sits above `test/web-296-unit-tests`, holding one commit.
+Run: `but status` Expected: the new branch sits above `test/web-296-unit-tests`, holding one commit.
 
 ---
 
 ### Task 2: `packages/shared` — array, cn, promise
 
 **Files:**
+
 - Create: `packages/shared/src/utils/array.test.ts`
 - Create: `packages/shared/src/utils/cn.test.ts`
 - Create: `packages/shared/src/utils/promise.test.ts`
 
 **Interfaces:**
+
 - Consumes: PR 1's `packages/shared/vitest.config.ts` (node environment).
 - Produces: nothing other tasks depend on.
 
@@ -130,8 +131,7 @@ Before committing, verify that last expectation by hand against the loop in `arr
 
 - [ ] **Step 4: Run the workspace suite**
 
-Run: `pnpm --filter @tsgi-web/shared test`
-Expected: the three new files green alongside the existing `date.test.ts`.
+Run: `pnpm --filter @tsgi-web/shared test` Expected: the three new files green alongside the existing `date.test.ts`.
 
 - [ ] **Step 5: Gates and commit**
 
@@ -145,9 +145,11 @@ but commit -b test/web-296-unit-tests-pure-logic -m "test(shared): cover the arr
 ### Task 3: `apps/web/src/utils/links.ts`
 
 **Files:**
+
 - Create: `apps/web/src/utils/links.test.ts`
 
 **Interfaces:**
+
 - Consumes: `getInternalHref(target: InternalLinkTarget | null | undefined): string | undefined`.
 - Produces: nothing.
 
@@ -160,6 +162,7 @@ Read `apps/web/src/utils/links.ts` and `apps/web/src/utils/groups.ts`. Note that
 - [ ] **Step 2: Write the test**
 
 Cases, each asserting the exact string:
+
 - `{ _type: 'home', slug: 'home' }` → `'/'`
 - `{ _type: 'news.article', slug: 'sommerfest', category: 'verein' }` → `'/news/verein/sommerfest'`
 - `{ _type: 'news.article', slug: 'sommerfest' }` (no category) → `undefined`
@@ -184,10 +187,12 @@ but commit -b test/web-296-unit-tests-pure-logic -m "test(web): cover the intern
 ### Task 4: `apps/web/src/utils/groups.ts` and `icon.ts`
 
 **Files:**
+
 - Create: `apps/web/src/utils/groups.test.ts`
 - Create: `apps/web/src/utils/icon.test.ts`
 
 **Interfaces:**
+
 - Consumes: `getOGImage`, `getGroupImage`, `getCurrentDepartment`, `groupSections`, `fallbackImage`; `getSocialMediaEntries`.
 - Produces: nothing.
 
@@ -219,9 +224,11 @@ but commit -b test/web-296-unit-tests-pure-logic -m "test(web): cover the group 
 ### Task 5: `apps/web/src/lib/sanity/utils.ts`
 
 **Files:**
+
 - Create: `apps/web/src/lib/sanity/utils.test.ts`
 
 **Interfaces:**
+
 - Consumes: `getDownloadFileUrl`, `getFileSize`, `urlForImage`, `urlForImageMax`.
 - Produces: the image-URL expectations Task 6 relies on — `getGalleryImages` mocks these two builders, so the real behavior is pinned here.
 
@@ -236,6 +243,7 @@ The module builds a Sanity image URL builder from `client`, which reads `NEXT_PU
 - [ ] **Step 2: Write the image-URL cases**
 
 Assert on the query string, not on a whole URL string built the way the implementation builds it:
+
 - `urlForImage(undefined)` and an image without `asset._ref` → `undefined`.
 - height only → the URL carries `w` and `h` equal to that height, `fit=crop`, `q=90`.
 - width and height → `w` and `h` as given, `fit=crop`.
@@ -256,9 +264,11 @@ but commit -b test/web-296-unit-tests-pure-logic -m "test(web): cover the sanity
 ### Task 6: `apps/web/src/utils/image.ts`
 
 **Files:**
+
 - Create: `apps/web/src/utils/image.test.ts`
 
 **Interfaces:**
+
 - Consumes: `getInitials`, `getGalleryImages`; mocks `@/lib/sanity/utils` (pinned for real in Task 5).
 - Produces: nothing.
 
@@ -269,6 +279,7 @@ but commit -b test/web-296-unit-tests-pure-logic -m "test(web): cover the sanity
 - [ ] **Step 2: Write `getGalleryImages` cases**
 
 Mock `@/lib/sanity/utils` with `vi.mock`, so `urlForImage` and `urlForImageMax` return predictable strings:
+
 - `undefined` and `[]` → `[]`.
 - one image → one entry carrying `alt`, `caption` from `description`, `key` from `_key`, `src` from `urlForImage` and `srcFull` from `urlForImageMax`.
 - an image whose `urlForImage` returns `undefined` is dropped; likewise for `urlForImageMax`; a mixed list keeps only the resolvable entries and preserves their order.
@@ -289,16 +300,19 @@ but commit -b test/web-296-unit-tests-pure-logic -m "test(web): cover the initia
 ### Task 7: `apps/web/src/utils/time.ts` and `apps/web/src/lib/env.ts`
 
 **Files:**
+
 - Create: `apps/web/src/utils/time.test.ts`
 - Create: `apps/web/src/lib/env.test.ts`
 
 **Interfaces:**
+
 - Consumes: `getLocaleDate`; `env`. Uses `loadWithEnv` from `apps/web/test-utils/env.ts`.
 - Produces: nothing.
 
 - [ ] **Step 1: Write `time.test.ts`**
 
 `getLocaleDate(date, variant = 'long', locale = DEFAULT_LOCALE)` formats through `Intl.DateTimeFormat`.
+
 - a `Date` in the default `'long'` variant → `'1. Januar 2024'` for `new Date('2024-01-01T12:00:00Z')`
 - the same date in `'short'` → `'01.01.2024'`
 - an ISO string input gives the same result as the equivalent `Date`
@@ -310,6 +324,7 @@ ICU output can contain narrow no-break spaces. Normalize both sides with `.repla
 - [ ] **Step 2: Write `env.test.ts`**
 
 `env(key)` validates one variable at a time through Zod and caches the result in a module-level `Map`. Every case loads the module through `loadWithEnv` so the cache starts empty.
+
 - a valid value comes back unchanged
 - a missing required variable throws, and the message contains the key name
 - a value failing its schema (e.g. `NEXT_PUBLIC_SANITY_STUDIO_URL` set to `'not-a-url'`) throws
@@ -331,10 +346,12 @@ but commit -b test/web-296-unit-tests-pure-logic -m "test(web): cover the date f
 ### Task 8: Zod validations
 
 **Files:**
+
 - Create: `apps/web/src/lib/validations/contact-form.test.ts`
 - Create: `apps/web/src/lib/validations/feedback.test.ts`
 
 **Interfaces:**
+
 - Consumes: `contactFormSchema`, `contactFormWithReceiverSchema`, `feedbackFormSchema`.
 - Produces: nothing.
 
@@ -376,13 +393,11 @@ but commit -b test/web-296-unit-tests-pure-logic -m "test(web): cover the contac
 
 - [ ] **Step 1: Full verification**
 
-Run: `pnpm run lint && pnpm run format:check && pnpm run typecheck && pnpm run test && pnpm run build`
-Expected: all green. Record the new test total.
+Run: `pnpm run lint && pnpm run format:check && pnpm run typecheck && pnpm run test && pnpm run build` Expected: all green. Record the new test total.
 
 - [ ] **Step 2: Coverage snapshot**
 
-Run: `pnpm run test:coverage`
-Expected: green. Note the line coverage for `packages/shared/src/utils` and `apps/web/src/utils` — the PR description quotes it, and it is the number the eventual coverage-threshold ticket will start from.
+Run: `pnpm run test:coverage` Expected: green. Note the line coverage for `packages/shared/src/utils` and `apps/web/src/utils` — the PR description quotes it, and it is the number the eventual coverage-threshold ticket will start from.
 
 - [ ] **Step 3: Report**
 

--- a/docs/superpowers/plans/2026-08-26-web-296-unit-tests-pr2-pure-logic.md
+++ b/docs/superpowers/plans/2026-08-26-web-296-unit-tests-pr2-pure-logic.md
@@ -1,0 +1,399 @@
+# WEB-296 Unit Tests — PR 2 (Pure Logic) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Cover every pure-logic module in `packages/shared` and `apps/web` with unit tests, on the infrastructure PR 1 built.
+
+**Architecture:** Tests only — no production code changes except where a test uncovers a real bug, which is reported before it is fixed. Every file gets a co-located `*.test.ts` in the `node` project of its workspace. No React, no jsdom, no HTTP: modules that reach an external service belong to PR 3, components to PR 4.
+
+**Tech Stack:** Vitest 4, `@vitest/coverage-v8`, Zod 4, `@sanity/image-url`, pnpm 11 workspaces, Turbo, GitButler CLI (`but`).
+
+**Spec:** `docs/superpowers/specs/2026-08-25-web-296-unit-tests-design.md` (its "PR 2 — Pure Logik" section)
+
+**Base branch:** `test/web-296-unit-tests` (PR 1, open as #471 against `next`). This work stacks on top of it, because every test here needs PR 1's Vitest setup. New branch: `test/web-296-unit-tests-pure-logic`.
+
+## Global Constraints
+
+- Node `^24.19.0`, pnpm `11.22.0` — `.nvmrc` and `packageManager` untouched.
+- Tests live next to their source: `foo.ts` → `foo.test.ts`.
+- Explicit imports from `vitest` — `describe`, `expect`, `it`, `vi`, and the hooks. No `globals: true`.
+- `describe` titles start lowercase and must never be identical to an imported identifier (oxlint `vitest/prefer-lowercase-title`, `vitest/prefer-describe-function-title`). Use a phrase: `describe('shuffling an array', …)`, not `describe('shuffleArray', …)`.
+- `beforeEach`/`afterEach`/`beforeAll`/`afterAll` sit INSIDE a `describe` block (`vitest/require-top-level-describe`).
+- Never widen the test-file override in `oxlint.config.ts`. If a file needs a suppression, use a narrow inline comment.
+- Every test file added by this PR belongs to the `node` project: it must be a `.test.ts` (never `.test.tsx`) and must not live under `apps/web/src/components/` or `apps/web/src/hooks/`.
+- No new dependency. No change to any `vitest.config.ts`, `turbo.json`, CI file or `sonar-project.properties`.
+- Commits through the GitButler CLI (`but commit -b test/web-296-unit-tests-pure-logic`), never `git commit`. Conventional Commits, no `Co-Authored-By`, no generator trailer.
+- After every task: `pnpm run lint`, `pnpm run format:check`, `pnpm run typecheck` clean, and `pnpm run test` green. Format with `pnpm run format` (oxfmt). One pre-existing oxlint warning in `packages/shared/src/utils/promise.ts` is known and not ours.
+- **Expected values are derived from the implementation, never from this plan's prose.** Where a case below states an expected value, verify it against the code first. If they disagree, that is a finding: report it prominently, write the assertion that reflects real behavior, and do not "fix" either side silently.
+- **A test that only restates the implementation is worse than no test.** Never build an expected value by calling the same helper or importing the same constant the implementation uses (PR 1 hit exactly this with `GOOGLE_MAPS_URL`). Hard-code the literal.
+
+## Already covered by PR 1 — do not duplicate
+
+`packages/shared/src/utils/date.ts`, `apps/web/src/utils/typography.ts`, `apps/web/src/utils/url.ts` (both `getBaseUrl` and `printGoogleMapsLink`), `apps/web/src/hooks/use-media-query.ts`, `apps/studio/utils/time.ts`, `packages/email/lib/cleverreach-markers.ts`.
+
+## Out of scope (later PRs)
+
+`src/actions/**` and `src/lib/cleverreach.ts` (PR 3); components and hooks (PR 4); studio schemas and email templates (PR 5). Also permanently skipped, per the spec: `packages/shared/src/utils/jsx.ts`, every `index.ts` barrel, `src/lib/sanity/queries/**`, `src/lib/actions/safe-action.ts`, `src/lib/resend.ts`, `src/lib/sanity/client.ts`, `src/lib/sanity/live.ts`.
+
+---
+
+### Task 1: Branch
+
+**Files:** commit this plan.
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: branch `test/web-296-unit-tests-pure-logic`, stacked on `test/web-296-unit-tests`.
+
+- [ ] **Step 1: Confirm the base**
+
+Run: `but status`
+Expected: `test/web-296-unit-tests` applied, working tree clean.
+
+- [ ] **Step 2: Create the stacked branch and commit the plan**
+
+```bash
+but commit -b test/web-296-unit-tests-pure-logic \
+  -m "docs: add the pure logic test plan for WEB-296" \
+  docs/superpowers/plans/2026-08-26-web-296-unit-tests-pr2-pure-logic.md
+```
+
+- [ ] **Step 3: Verify the stack**
+
+Run: `but status`
+Expected: the new branch sits above `test/web-296-unit-tests`, holding one commit.
+
+---
+
+### Task 2: `packages/shared` — array, cn, promise
+
+**Files:**
+- Create: `packages/shared/src/utils/array.test.ts`
+- Create: `packages/shared/src/utils/cn.test.ts`
+- Create: `packages/shared/src/utils/promise.test.ts`
+
+**Interfaces:**
+- Consumes: PR 1's `packages/shared/vitest.config.ts` (node environment).
+- Produces: nothing other tasks depend on.
+
+- [ ] **Step 1: Write `array.test.ts`**
+
+`shuffleArray` is Fisher-Yates over a copy. Cases: returns a new array (`not.toBe` the input) with the same length; the input is not mutated; every member survives (compare sorted copies); an empty array and a single-element array come back equal; with `Math.random` stubbed to a fixed value the output order is deterministic — assert the exact resulting array, and derive that expectation by reasoning about the algorithm, not by running it and pasting whatever came out.
+
+```ts
+import { describe, expect, it, vi } from 'vitest';
+
+import { shuffleArray } from './array';
+
+describe('shuffling an array', () => {
+	it('returns a new array', () => {
+		const input = [1, 2, 3];
+		expect(shuffleArray(input)).not.toBe(input);
+	});
+
+	it('leaves the input untouched', () => {
+		const input = [1, 2, 3];
+		shuffleArray(input);
+		expect(input).toEqual([1, 2, 3]);
+	});
+
+	it('keeps every member', () => {
+		expect([...shuffleArray([1, 2, 3, 4])].sort()).toEqual([1, 2, 3, 4]);
+	});
+
+	it('handles an empty array', () => {
+		expect(shuffleArray([])).toEqual([]);
+	});
+
+	it('handles a single element', () => {
+		expect(shuffleArray(['a'])).toEqual(['a']);
+	});
+
+	it('is deterministic when Math.random is fixed', () => {
+		vi.spyOn(Math, 'random').mockReturnValue(0);
+		// With random() === 0 every swap index is 0, so the loop rotates the array.
+		expect(shuffleArray([1, 2, 3])).toEqual([3, 1, 2]);
+		vi.restoreAllMocks();
+	});
+});
+```
+
+Before committing, verify that last expectation by hand against the loop in `array.ts`; if the real result differs, the comment and the expectation both change to match the code.
+
+- [ ] **Step 2: Write `cn.test.ts`**
+
+`cn` is `twMerge(clsx(inputs))`. Cases: plain strings join; a conditional object includes only truthy keys; `undefined`/`null`/`false` entries are dropped; nested arrays flatten; a later Tailwind class beats an earlier conflicting one (`cn('p-2', 'p-4')` → `'p-4'`); non-conflicting utilities both survive; no arguments → `''`.
+
+- [ ] **Step 3: Write `promise.test.ts`**
+
+`settle` never throws. Cases: a resolved promise gives `{ ok: true, value }`; a rejected promise gives `{ ok: false, error }` with the original error identity (`toBe`); a plain thenable resolves; a non-promise value passed through `Promise.resolve` resolves; rejection with a non-`Error` value (e.g. a string) is preserved as-is; the returned promise itself never rejects (`await expect(settle(Promise.reject(new Error('x')))).resolves.toMatchObject({ ok: false })`).
+
+- [ ] **Step 4: Run the workspace suite**
+
+Run: `pnpm --filter @tsgi-web/shared test`
+Expected: the three new files green alongside the existing `date.test.ts`.
+
+- [ ] **Step 5: Gates and commit**
+
+```bash
+pnpm run lint && pnpm run format:check && pnpm run typecheck
+but commit -b test/web-296-unit-tests-pure-logic -m "test(shared): cover the array, class name and promise utils"
+```
+
+---
+
+### Task 3: `apps/web/src/utils/links.ts`
+
+**Files:**
+- Create: `apps/web/src/utils/links.test.ts`
+
+**Interfaces:**
+- Consumes: `getInternalHref(target: InternalLinkTarget | null | undefined): string | undefined`.
+- Produces: nothing.
+
+This module is the highest-value file in the PR: every internal link on the site resolves through it, and its branches are silent when wrong (a bad type returns `undefined` and the link disappears).
+
+- [ ] **Step 1: Read the module and enumerate its branches**
+
+Read `apps/web/src/utils/links.ts` and `apps/web/src/utils/groups.ts`. Note that `getGroupHref` resolves through `groupSections`, so a group type with no department page returns `undefined` by design.
+
+- [ ] **Step 2: Write the test**
+
+Cases, each asserting the exact string:
+- `{ _type: 'home', slug: 'home' }` → `'/'`
+- `{ _type: 'news.article', slug: 'sommerfest', category: 'verein' }` → `'/news/verein/sommerfest'`
+- `{ _type: 'news.article', slug: 'sommerfest' }` (no category) → `undefined`
+- `{ _type: 'news.category', slug: 'verein' }` → `'/news/verein'`
+- a group type that has a department page, e.g. `{ _type: 'group.soccer', slug: 'herren-1' }` → `'/angebot/fussball/herren-1'`
+- every one of the six group types in `groupSections` resolves to `'<department slug>/<slug>'` — write this as one `it` looping the array, asserting the prefix comes from that entry's `slug` field
+- a `group.*` type that is NOT in `groupSections` (e.g. `{ _type: 'group.administration', slug: 'vorstand' }`) → `undefined`
+- an unknown type, e.g. `{ _type: 'membership', slug: 'mitgliedschaft' }` → `'/mitgliedschaft'`
+- `undefined` target, `null` target, `{}`, `{ _type: 'home' }` without slug, `{ slug: 'x' }` without type → all `undefined`
+- `{ _type: 'news.article', slug: 'x', category: null }` → `undefined` (the `?? undefined` path)
+
+- [ ] **Step 3: Run, gate, commit**
+
+```bash
+pnpm --filter web test src/utils/links.test.ts
+pnpm run lint && pnpm run format:check && pnpm run typecheck
+but commit -b test/web-296-unit-tests-pure-logic -m "test(web): cover the internal link resolution"
+```
+
+---
+
+### Task 4: `apps/web/src/utils/groups.ts` and `icon.ts`
+
+**Files:**
+- Create: `apps/web/src/utils/groups.test.ts`
+- Create: `apps/web/src/utils/icon.test.ts`
+
+**Interfaces:**
+- Consumes: `getOGImage`, `getGroupImage`, `getCurrentDepartment`, `groupSections`, `fallbackImage`; `getSocialMediaEntries`.
+- Produces: nothing.
+
+`groups.ts` imports `.webp` files — PR 1's `assetStub` plugin in `apps/web/vitest.config.ts` resolves those. If an import error appears, that is an infrastructure finding, not something to work around in the test.
+
+- [ ] **Step 1: Write `groups.test.ts`**
+
+- `getCurrentDepartment('fussball')` returns the entry whose `slug` is `/angebot/fussball`; `getCurrentDepartment('gibtsnicht')` returns `undefined`.
+- `getGroupImage` with a slug that matches an entry returns that entry's image; with an unknown slug returns `fallbackImage` (assert `toBe(fallbackImage)`); the `path` parameter prefixes the lookup — cover both the default `''` and an explicit `'/angebot'`.
+- `getOGImage('fussball')` returns `{ alt, height: 630, width: 1200, url }` where `url` ends in `/og/angebot/groups/fussball.webp` and `alt` is that group's image alt.
+- `getOGImage('gibtsnicht')` falls back: url ends in `/og/angebot.webp` and `alt` is `fallbackImage.alt`.
+- `getOGImage` builds its URL on `getBaseUrl()`, which reads the environment — use PR 1's helper, `loadWithEnv` from `apps/web/test-utils/env.ts`, exactly as `src/utils/url.test.ts` does, and import the module under test as `import type` only.
+- `groupSections` itself: every entry has a slug starting `/angebot/`, a non-empty `alt`, and a unique `_type` (assert the set size equals the array length).
+
+- [ ] **Step 2: Write `icon.test.ts`**
+
+`getSocialMediaEntries` takes the Sanity `socialFields` object. Cases: `null` and `undefined` → `[]`; `{}` → `[]`; a known platform with a URL yields one entry with `name`, `url` and a defined `icon`; the meta key `_type` is skipped; a known platform whose URL is `undefined` or `''` is skipped; an unknown key is skipped; several platforms yield entries in object-key order. Read `apps/web/src/components/ui/social-media-icon.tsx` for the real keys of `socialMediaMap` rather than guessing them.
+
+- [ ] **Step 3: Run, gate, commit**
+
+```bash
+pnpm --filter web test src/utils/groups.test.ts src/utils/icon.test.ts
+pnpm run lint && pnpm run format:check && pnpm run typecheck
+but commit -b test/web-296-unit-tests-pure-logic -m "test(web): cover the group and social media helpers"
+```
+
+---
+
+### Task 5: `apps/web/src/lib/sanity/utils.ts`
+
+**Files:**
+- Create: `apps/web/src/lib/sanity/utils.test.ts`
+
+**Interfaces:**
+- Consumes: `getDownloadFileUrl`, `getFileSize`, `urlForImage`, `urlForImageMax`.
+- Produces: the image-URL expectations Task 6 relies on — `getGalleryImages` mocks these two builders, so the real behavior is pinned here.
+
+The module builds a Sanity image URL builder from `client`, which reads `NEXT_PUBLIC_SANITY_PROJECT_ID` and `NEXT_PUBLIC_SANITY_DATASET` at import time and throws if they are missing. Load the module through `loadWithEnv` with both set to fixed test values, and assert against those values.
+
+- [ ] **Step 1: Write the file-helper cases**
+
+- `getDownloadFileUrl(undefined)`, `(null)`, `({ url: 'x' })` without `originalFilename`, `({ originalFilename: 'x' })` without url → all `'#!'`.
+- a complete asset → `'<url>?dl=<originalFilename>'`, asserted as a literal.
+- `getFileSize`: `undefined`, `0` and a negative value → `'—'`; `512` → `'512 B'`; `1024` → `'1.0 KB'`; `1_572_864` → `'1.50 MB'`; a gigabyte-scale value → the `GB` unit; a value far beyond `GB` still reports `GB` (the loop stops at the last unit). Verify the decimal count per unit against the `toFixed(index)` in the implementation before writing the literals.
+
+- [ ] **Step 2: Write the image-URL cases**
+
+Assert on the query string, not on a whole URL string built the way the implementation builds it:
+- `urlForImage(undefined)` and an image without `asset._ref` → `undefined`.
+- height only → the URL carries `w` and `h` equal to that height, `fit=crop`, `q=90`.
+- width and height → `w` and `h` as given, `fit=crop`.
+- neither → `fit=max`, `q=90`, and no `w`/`h`.
+- `urlForImageMax(image, 2560)` → `w=2560`, `fit=max`, no `h`.
+- Parse with `new URL(...).searchParams` and assert per parameter; that survives a reordering of the builder's chain.
+
+- [ ] **Step 3: Run, gate, commit**
+
+```bash
+pnpm --filter web test src/lib/sanity/utils.test.ts
+pnpm run lint && pnpm run format:check && pnpm run typecheck
+but commit -b test/web-296-unit-tests-pure-logic -m "test(web): cover the sanity file and image url helpers"
+```
+
+---
+
+### Task 6: `apps/web/src/utils/image.ts`
+
+**Files:**
+- Create: `apps/web/src/utils/image.test.ts`
+
+**Interfaces:**
+- Consumes: `getInitials`, `getGalleryImages`; mocks `@/lib/sanity/utils` (pinned for real in Task 5).
+- Produces: nothing.
+
+- [ ] **Step 1: Write `getInitials` cases**
+
+`('John', 'Doe')` → `'JD'`; `('jane', 'doe')` → `'JD'`; `('Jane', '')` → `'J?'`; `('', 'Doe')` → `'?D'`; `('', '')` → `'??'`; whitespace-only inputs → `'??'`; leading whitespace is trimmed before the first letter is taken; a non-ASCII first letter (e.g. `'Örs'`) upper-cases correctly.
+
+- [ ] **Step 2: Write `getGalleryImages` cases**
+
+Mock `@/lib/sanity/utils` with `vi.mock`, so `urlForImage` and `urlForImageMax` return predictable strings:
+- `undefined` and `[]` → `[]`.
+- one image → one entry carrying `alt`, `caption` from `description`, `key` from `_key`, `src` from `urlForImage` and `srcFull` from `urlForImageMax`.
+- an image whose `urlForImage` returns `undefined` is dropped; likewise for `urlForImageMax`; a mixed list keeps only the resolvable entries and preserves their order.
+- the `height`/`width` arguments are forwarded to `urlForImage` — assert on the mock's call arguments.
+- `urlForImageMax` is always called with `2560` (the module's `FULL_IMAGE_WIDTH`); assert the literal, not the imported constant.
+- an image without `description` yields `caption: undefined`.
+
+- [ ] **Step 3: Run, gate, commit**
+
+```bash
+pnpm --filter web test src/utils/image.test.ts
+pnpm run lint && pnpm run format:check && pnpm run typecheck
+but commit -b test/web-296-unit-tests-pure-logic -m "test(web): cover the initials and gallery image helpers"
+```
+
+---
+
+### Task 7: `apps/web/src/utils/time.ts` and `apps/web/src/lib/env.ts`
+
+**Files:**
+- Create: `apps/web/src/utils/time.test.ts`
+- Create: `apps/web/src/lib/env.test.ts`
+
+**Interfaces:**
+- Consumes: `getLocaleDate`; `env`. Uses `loadWithEnv` from `apps/web/test-utils/env.ts`.
+- Produces: nothing.
+
+- [ ] **Step 1: Write `time.test.ts`**
+
+`getLocaleDate(date, variant = 'long', locale = DEFAULT_LOCALE)` formats through `Intl.DateTimeFormat`.
+- a `Date` in the default `'long'` variant → `'1. Januar 2024'` for `new Date('2024-01-01T12:00:00Z')`
+- the same date in `'short'` → `'01.01.2024'`
+- an ISO string input gives the same result as the equivalent `Date`
+- an explicit locale (`'en-US'`) changes the output
+- a date whose day is single-digit keeps the `2-digit` padding in `'short'` and no padding in `'long'`
+
+ICU output can contain narrow no-break spaces. Normalize both sides with `.replaceAll(' ', ' ').replaceAll(' ', ' ')` before comparing, so an ICU update does not break the suite. The date fixtures must be timezone-safe: use midday UTC timestamps so no local zone shifts the calendar day.
+
+- [ ] **Step 2: Write `env.test.ts`**
+
+`env(key)` validates one variable at a time through Zod and caches the result in a module-level `Map`. Every case loads the module through `loadWithEnv` so the cache starts empty.
+- a valid value comes back unchanged
+- a missing required variable throws, and the message contains the key name
+- a value failing its schema (e.g. `NEXT_PUBLIC_SANITY_STUDIO_URL` set to `'not-a-url'`) throws
+- defaults apply: `NODE_ENV` unset → `'development'`; `NEXT_PUBLIC_SANITY_API_VERSION` unset → its default string
+- `SANITY_API_READ_TOKEN` set to `''` → `undefined` (the `preprocess` path), and absent → `undefined`
+- the cache holds: read a key, mutate `process.env` for that key afterwards, read again, and assert the first value is returned
+- an optional variable that is absent returns `undefined` without throwing
+
+- [ ] **Step 3: Run, gate, commit**
+
+```bash
+pnpm --filter web test src/utils/time.test.ts src/lib/env.test.ts
+pnpm run lint && pnpm run format:check && pnpm run typecheck
+but commit -b test/web-296-unit-tests-pure-logic -m "test(web): cover the date formatting and env access"
+```
+
+---
+
+### Task 8: Zod validations
+
+**Files:**
+- Create: `apps/web/src/lib/validations/contact-form.test.ts`
+- Create: `apps/web/src/lib/validations/feedback.test.ts`
+
+**Interfaces:**
+- Consumes: `contactFormSchema`, `contactFormWithReceiverSchema`, `feedbackFormSchema`.
+- Produces: nothing.
+
+Assert on `safeParse` results, and on the German messages — those messages are user-facing copy, and pinning them is half the value of these tests. Read each message from the schema rather than retyping it from memory.
+
+- [ ] **Step 1: Write `contact-form.test.ts`**
+
+- a complete valid payload parses, with and without `receiver`
+- an invalid email fails with `'Die E-Mail Adresse ist ungültig.'`
+- a message of 31 characters fails; exactly 32 passes (test the boundary on both sides)
+- a name of 1 character fails; 2 passes
+- `privacy: false` fails; `privacy: true` passes
+- `receiver` with a bad email fails with the receiver message; `receiver` missing passes in `contactFormSchema`
+- `contactFormWithReceiverSchema` rejects the same payload when `receiver` is absent, and accepts it when present — one `it` proving the two schemas differ in exactly that way
+
+- [ ] **Step 2: Write `feedback.test.ts`**
+
+- a minimal valid payload (only the required fields) parses
+- `title`: 4 characters fails, 5 passes, 100 passes, 101 fails — with the documented messages
+- `description`: 19 fails, 20 passes, 2000 passes, 2001 fails
+- `email`: a valid address passes; `''` passes (the `.or(z.literal(''))` path); an invalid address fails; the field absent passes
+- each of `browser`, `operationSystem` and `type` rejects an unknown value; `type` missing produces `'Bitte wähle einen Typ aus'`
+- `privacy: false` fails
+- `screenshotUrls` accepts an empty array, a populated array, and is optional
+
+- [ ] **Step 3: Run, gate, commit**
+
+```bash
+pnpm --filter web test src/lib/validations
+pnpm run lint && pnpm run format:check && pnpm run typecheck
+but commit -b test/web-296-unit-tests-pure-logic -m "test(web): cover the contact and feedback form schemas"
+```
+
+---
+
+### Task 9: Close out
+
+**Files:** none.
+
+- [ ] **Step 1: Full verification**
+
+Run: `pnpm run lint && pnpm run format:check && pnpm run typecheck && pnpm run test && pnpm run build`
+Expected: all green. Record the new test total.
+
+- [ ] **Step 2: Coverage snapshot**
+
+Run: `pnpm run test:coverage`
+Expected: green. Note the line coverage for `packages/shared/src/utils` and `apps/web/src/utils` — the PR description quotes it, and it is the number the eventual coverage-threshold ticket will start from.
+
+- [ ] **Step 3: Report**
+
+Summarize for the pull request: the files covered, the new test total, the coverage figures, and every disagreement found between this plan's expected values and real behavior. Pushing the branch, opening the PR against `test/web-296-unit-tests` and commenting on the Linear ticket are the user's call, not this plan's.
+
+---
+
+## Self-Review
+
+**Spec coverage:** every file in the spec's "PR 2 — Pure Logik" section maps to a task — `packages/shared` array/cn/promise (Task 2, `date.ts` done in PR 1), `typography` and `url` already done in PR 1, `links` (3), `groups` and `icon` (4), `sanity/utils` (5), `image` (6), `time` and `env` (7), both validation schemas (8). The spec's skip list is reproduced verbatim under "Out of scope".
+
+**Placeholder scan:** no TBD/TODO. Task 2 carries literal code; Tasks 3-8 carry enumerated cases with their expected values, which is the right grain for files whose assertions are one line each — and every task is bound by the Global Constraint that expected values are verified against the implementation before being written.
+
+**Type consistency:** `loadWithEnv` (Tasks 4, 5, 7) and the `vi.mock` of `@/lib/sanity/utils` (Task 6) match what PR 1 shipped; `FULL_IMAGE_WIDTH` is asserted as the literal `2560` rather than imported, per the anti-tautology constraint.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
 		"build": "turbo build",
 		"build:affected": "turbo build --affected",
 		"cve": "cve-lite . --fail-on high --verbose --cache-dir .cache/cve-lite",
+		"db:sync": "node scripts/sync-dev-db.ts",
 		"dev": "turbo dev",
 		"dev:email": "turbo dev:email",
 		"extract-types": "turbo extract-types",

--- a/packages/email/package.json
+++ b/packages/email/package.json
@@ -8,7 +8,7 @@
 	},
 	"scripts": {
 		"build": "tsc --noEmit",
-		"build:cleverreach": "tsx scripts/build-cleverreach-template.ts",
+		"build:cleverreach": "node scripts/build-cleverreach-template.ts",
 		"build:preview": "email build",
 		"dev:email": "email dev --port 3001",
 		"export": "email export",
@@ -35,7 +35,6 @@
 		"@vitest/coverage-v8": "^4.1.11",
 		"oxlint": "^1.79.0",
 		"oxlint-tsgolint": "^7.0.2001",
-		"tsx": "^4.21.0",
 		"typescript": "^7.0.2",
 		"vitest": "^4.1.11"
 	}

--- a/packages/shared/src/utils/array.test.ts
+++ b/packages/shared/src/utils/array.test.ts
@@ -1,17 +1,27 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { shuffleArray } from './array';
 
 describe('shuffling an array', () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
 	it('returns a new array', () => {
 		const input = [1, 2, 3];
-		expect(shuffleArray(input)).not.toBe(input);
+		const result = shuffleArray(input);
+		expect(result).not.toBe(input);
+		expect(result).toHaveLength(3);
 	});
 
 	it('leaves the input untouched', () => {
-		const input = [1, 2, 3];
+		// Stubbed so a bug that mutates the input in place would show a deterministic,
+		// non-identity permutation here rather than passing by luck. A five-element input also
+		// means a single self-swap cannot mask the mutation the way it could with three.
+		vi.spyOn(Math, 'random').mockReturnValue(0);
+		const input = [1, 2, 3, 4, 5];
 		shuffleArray(input);
-		expect(input).toStrictEqual([1, 2, 3]);
+		expect(input).toStrictEqual([1, 2, 3, 4, 5]);
 	});
 
 	it('keeps every member', () => {
@@ -33,7 +43,6 @@ describe('shuffling an array', () => {
 		//   i=2: swap(2, 0) on [1, 2, 3] -> [3, 2, 1]
 		//   i=1: swap(1, 0) on [3, 2, 1] -> [2, 3, 1]
 		expect(shuffleArray([1, 2, 3])).toStrictEqual([2, 3, 1]);
-		vi.restoreAllMocks();
 	});
 
 	it('is deterministic when Math.random is fixed just under 1', () => {
@@ -43,6 +52,5 @@ describe('shuffling an array', () => {
 		// and the array comes back unchanged. A version that multiplied by `i` instead of
 		// `i + 1` would produce [3, 1, 2] here instead.
 		expect(shuffleArray([1, 2, 3])).toStrictEqual([1, 2, 3]);
-		vi.restoreAllMocks();
 	});
 });

--- a/packages/shared/src/utils/array.test.ts
+++ b/packages/shared/src/utils/array.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { shuffleArray } from './array';
+
+describe('shuffling an array', () => {
+	it('returns a new array', () => {
+		const input = [1, 2, 3];
+		expect(shuffleArray(input)).not.toBe(input);
+	});
+
+	it('leaves the input untouched', () => {
+		const input = [1, 2, 3];
+		shuffleArray(input);
+		expect(input).toStrictEqual([1, 2, 3]);
+	});
+
+	it('keeps every member', () => {
+		expect([...shuffleArray([1, 2, 3, 4])].toSorted((a, b) => a - b)).toStrictEqual([1, 2, 3, 4]);
+	});
+
+	it('handles an empty array', () => {
+		expect(shuffleArray([])).toStrictEqual([]);
+	});
+
+	it('handles a single element', () => {
+		expect(shuffleArray(['a'])).toStrictEqual(['a']);
+	});
+
+	it('is deterministic when Math.random is fixed at 0', () => {
+		vi.spyOn(Math, 'random').mockReturnValue(0);
+		// The loop runs i = 2, then i = 1. With random() === 0, index = floor(0 * (i + 1)) = 0
+		// every time, so each step swaps position i with position 0:
+		//   i=2: swap(2, 0) on [1, 2, 3] -> [3, 2, 1]
+		//   i=1: swap(1, 0) on [3, 2, 1] -> [2, 3, 1]
+		expect(shuffleArray([1, 2, 3])).toStrictEqual([2, 3, 1]);
+		vi.restoreAllMocks();
+	});
+
+	it('is deterministic when Math.random is fixed just under 1', () => {
+		vi.spyOn(Math, 'random').mockReturnValue(0.999999);
+		// index = floor(0.999999 * (i + 1)), which equals i itself for both loop steps
+		// (floor(0.999999 * 3) = 2, floor(0.999999 * 2) = 1), so every swap is a self-swap
+		// and the array comes back unchanged. A version that multiplied by `i` instead of
+		// `i + 1` would produce [3, 1, 2] here instead.
+		expect(shuffleArray([1, 2, 3])).toStrictEqual([1, 2, 3]);
+		vi.restoreAllMocks();
+	});
+});

--- a/packages/shared/src/utils/cn.test.ts
+++ b/packages/shared/src/utils/cn.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { cn } from './cn';
+
+describe('merging class names', () => {
+	it('joins plain strings', () => {
+		expect(cn('flex', 'items-center')).toBe('flex items-center');
+	});
+
+	it('includes only the truthy keys of a conditional object', () => {
+		expect(cn({ active: false, disabled: true, selected: true })).toBe('disabled selected');
+	});
+
+	it('drops undefined, null and false entries', () => {
+		expect(cn('flex', undefined, null, false, 'items-center')).toBe('flex items-center');
+	});
+
+	it('flattens nested arrays', () => {
+		expect(cn(['flex', ['items-center', ['justify-between']]])).toBe(
+			'flex items-center justify-between',
+		);
+	});
+
+	it('lets a later conflicting Tailwind class win', () => {
+		expect(cn('p-2', 'p-4')).toBe('p-4');
+	});
+
+	it('keeps both classes when they do not conflict', () => {
+		expect(cn('p-4', 'text-white')).toBe('p-4 text-white');
+	});
+
+	it('returns an empty string for no arguments', () => {
+		expect(cn()).toBe('');
+	});
+});

--- a/packages/shared/src/utils/promise.test.ts
+++ b/packages/shared/src/utils/promise.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+
+import { settle } from './promise';
+
+describe('settling a promise', () => {
+	it('reports a resolved value', async () => {
+		const outcome = await settle(Promise.resolve('hello'));
+		expect(outcome).toStrictEqual({ ok: true, value: 'hello' });
+	});
+
+	it('reports a rejection with the original error identity', async () => {
+		const error = new Error('boom');
+		const outcome = await settle(Promise.reject(error));
+		expect(outcome.ok).toBe(false);
+		const failure = outcome as { error: unknown; ok: false };
+		expect(failure.error).toBe(error);
+	});
+
+	it('resolves a plain thenable', async () => {
+		const thenable = {
+			// oxlint-disable-next-line unicorn/no-thenable -- deliberately a thenable, not a real Promise
+			then(onFulfilled: (value: string) => void) {
+				onFulfilled('thenable-value');
+			},
+		} as unknown as PromiseLike<string>;
+		const outcome = await settle(thenable);
+		expect(outcome).toStrictEqual({ ok: true, value: 'thenable-value' });
+	});
+
+	it('resolves a non-promise value passed through Promise.resolve', async () => {
+		// `settle` wraps its argument with `Promise.resolve`, so even a value that is not
+		// actually a promise (bypassing the `PromiseLike<T>` parameter type here) settles.
+		const outcome = await settle(42 as unknown as PromiseLike<number>);
+		expect(outcome).toStrictEqual({ ok: true, value: 42 });
+	});
+
+	it('preserves a non-Error rejection reason as-is', async () => {
+		const reason = 'plain string failure';
+		// oxlint-disable-next-line typescript/prefer-promise-reject-errors prefer-promise-reject-errors -- deliberately a non-Error rejection reason
+		const rejectedPromise = Promise.reject(reason);
+		const outcome = await settle(rejectedPromise);
+		expect(outcome).toStrictEqual({ error: reason, ok: false });
+	});
+
+	it('never rejects the promise it returns', async () => {
+		const rejectedPromise = Promise.reject(new Error('x'));
+		await expect(settle(rejectedPromise)).resolves.toMatchObject({ ok: false });
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -193,8 +193,8 @@ importers:
         specifier: ^1.1.19
         version: 1.1.19(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@sanity/client':
-        specifier: ^8.2.0
-        version: 8.2.0(vitest@4.1.11)
+        specifier: ^7.26.2
+        version: 7.26.2
       '@sanity/image-url':
         specifier: ^2.1.1
         version: 2.1.1
@@ -230,7 +230,7 @@ importers:
         version: 8.6.1(next@16.3.2(@babel/core@7.29.7(supports-color@8.1.1))(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       next-sanity:
         specifier: ^13.3.3
-        version: 13.3.3(6a18327cd7a19db48a37e7fe1c1c69f5)
+        version: 13.3.3(1aa4ab3b08366b3f2c4cfb7882defe56)
       react:
         specifier: 19.2.8
         version: 19.2.8
@@ -11090,9 +11090,9 @@ snapshots:
     transitivePeerDependencies:
       - '@sanity/types'
 
-  '@sanity/preview-url-secret@4.1.4(@sanity/client@8.2.0(vitest@4.1.11))':
+  '@sanity/preview-url-secret@4.1.4(@sanity/client@7.26.2)':
     dependencies:
-      '@sanity/client': 8.2.0(vitest@4.1.11)
+      '@sanity/client': 7.26.2
       '@sanity/uuid': 3.0.3
 
   '@sanity/preview-url-secret@4.1.5(@sanity/client@7.26.2)':
@@ -11364,18 +11364,18 @@ snapshots:
       - react-dom
       - styled-components
 
-  '@sanity/visual-editing-csm@3.0.16(@sanity/client@8.2.0(vitest@4.1.11))(@sanity/types@6.10.1(@types/react@19.2.18))(typescript@7.0.2)':
+  '@sanity/visual-editing-csm@3.0.16(@sanity/client@7.26.2)(@sanity/types@6.10.1(@types/react@19.2.18))(typescript@7.0.2)':
     dependencies:
-      '@sanity/client': 8.2.0(vitest@4.1.11)
-      '@sanity/visual-editing-types': 2.1.0(@sanity/client@8.2.0(vitest@4.1.11))(@sanity/types@6.10.1(@types/react@19.2.18))
+      '@sanity/client': 7.26.2
+      '@sanity/visual-editing-types': 2.1.0(@sanity/client@7.26.2)(@sanity/types@6.10.1(@types/react@19.2.18))
       valibot: 1.4.2(typescript@7.0.2)
     transitivePeerDependencies:
       - '@sanity/types'
       - typescript
 
-  '@sanity/visual-editing-types@2.1.0(@sanity/client@8.2.0(vitest@4.1.11))(@sanity/types@6.10.1(@types/react@19.2.18))':
+  '@sanity/visual-editing-types@2.1.0(@sanity/client@7.26.2)(@sanity/types@6.10.1(@types/react@19.2.18))':
     dependencies:
-      '@sanity/client': 8.2.0(vitest@4.1.11)
+      '@sanity/client': 7.26.2
     optionalDependencies:
       '@sanity/types': 6.10.1(@types/react@19.2.18)
 
@@ -11385,17 +11385,17 @@ snapshots:
     optionalDependencies:
       '@sanity/types': 6.10.1(@types/react@19.2.18)
 
-  '@sanity/visual-editing@6.1.0(@sanity/client@8.2.0(vitest@4.1.11))(@types/react@19.2.18)(next@16.3.2(@babel/core@7.29.7(supports-color@8.1.1))(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(typescript@7.0.2)':
+  '@sanity/visual-editing@6.1.0(@sanity/client@7.26.2)(@types/react@19.2.18)(next@16.3.2(@babel/core@7.29.7(supports-color@8.1.1))(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(typescript@7.0.2)':
     dependencies:
       '@sanity/comlink': 4.0.3
       '@sanity/icons': 5.2.1(react@19.2.8)
       '@sanity/mutate': 0.18.1(xstate@5.32.5)
       '@sanity/presentation-comlink': 2.2.3(@sanity/types@6.10.1(@types/react@19.2.18))
-      '@sanity/preview-url-secret': 4.1.4(@sanity/client@8.2.0(vitest@4.1.11))
+      '@sanity/preview-url-secret': 4.1.4(@sanity/client@7.26.2)
       '@sanity/types': 6.10.1(@types/react@19.2.18)
       '@sanity/ui': 4.0.5(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))
-      '@sanity/visual-editing-csm': 3.0.16(@sanity/client@8.2.0(vitest@4.1.11))(@sanity/types@6.10.1(@types/react@19.2.18))(typescript@7.0.2)
-      '@sanity/visual-editing-types': 2.1.0(@sanity/client@8.2.0(vitest@4.1.11))(@sanity/types@6.10.1(@types/react@19.2.18))
+      '@sanity/visual-editing-csm': 3.0.16(@sanity/client@7.26.2)(@sanity/types@6.10.1(@types/react@19.2.18))(typescript@7.0.2)
+      '@sanity/visual-editing-types': 2.1.0(@sanity/client@7.26.2)(@sanity/types@6.10.1(@types/react@19.2.18))
       '@vercel/stega': 1.1.0
       dequal: 2.0.3
       lodash-es: 4.18.1
@@ -11407,7 +11407,7 @@ snapshots:
       styled-components: 6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       xstate: 5.32.5
     optionalDependencies:
-      '@sanity/client': 8.2.0(vitest@4.1.11)
+      '@sanity/client': 7.26.2
       next: 16.3.2(@babel/core@7.29.7(supports-color@8.1.1))(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
     transitivePeerDependencies:
       - '@types/react'
@@ -13657,13 +13657,13 @@ snapshots:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
 
-  next-sanity@13.3.3(6a18327cd7a19db48a37e7fe1c1c69f5):
+  next-sanity@13.3.3(1aa4ab3b08366b3f2c4cfb7882defe56):
     dependencies:
       '@portabletext/react': 7.0.1(react@19.2.8)
-      '@sanity/client': 8.2.0(vitest@4.1.11)
+      '@sanity/client': 7.26.2
       '@sanity/generate-help-url': 4.0.0
-      '@sanity/preview-url-secret': 4.1.4(@sanity/client@8.2.0(vitest@4.1.11))
-      '@sanity/visual-editing': 6.1.0(@sanity/client@8.2.0(vitest@4.1.11))(@types/react@19.2.18)(next@16.3.2(@babel/core@7.29.7(supports-color@8.1.1))(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(typescript@7.0.2)
+      '@sanity/preview-url-secret': 4.1.4(@sanity/client@7.26.2)
+      '@sanity/visual-editing': 6.1.0(@sanity/client@7.26.2)(@types/react@19.2.18)(next@16.3.2(@babel/core@7.29.7(supports-color@8.1.1))(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(styled-components@6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(typescript@7.0.2)
       '@sanity/webhook': 4.0.4
       groq: 6.10.1
       history: 5.3.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   '@sanity/sdk-react': 2.19.0
+  fast-uri: ^3.1.6
   js-yaml: '>=4.3.1'
   postcss-selector-parser: ^6.1.3
   smol-toml: '>=1.6.1'
@@ -349,9 +350,6 @@ importers:
       oxlint-tsgolint:
         specifier: ^7.0.2001
         version: 7.0.2001
-      tsx:
-        specifier: ^4.21.0
-        version: 4.23.12
       typescript:
         specifier: ^7.0.2
         version: 7.0.2
@@ -3742,8 +3740,8 @@ packages:
       react-dom: ^19.2
       styled-components: ^6.1
 
-  '@sanity/ui@5.0.0-alpha.4':
-    resolution: {integrity: sha512-+YGO6vlZUOBqQ+2+UTkbutxiRhnM4EE0JKVfnsNDcye3JYNGf4ZcapdSCW6QKMOwIbBnLSjan+2th14whRLgWg==}
+  '@sanity/ui@5.0.0-alpha.5':
+    resolution: {integrity: sha512-wNVAxvbs9td//7Yth1tq1WNz19YyFZrSZQKt9cp703Yvy9/O56uVIz2SBIeBET9EjWBv2FMmRrCAetZRMYrqDQ==}
     engines: {node: '>=20.19 <22 || >=22.12'}
     hasBin: true
     peerDependencies:
@@ -5256,8 +5254,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.6:
+    resolution: {integrity: sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -11303,7 +11301,7 @@ snapshots:
       styled-components: 6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       use-effect-event: 2.0.3(react@19.2.8)
 
-  '@sanity/ui@5.0.0-alpha.4(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@sanity/ui@5.0.0-alpha.5(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@sanity-labs/design-tokens': 0.0.2-alpha.4
       '@sanity/icons': 3.8.0(react@19.2.8)
@@ -11951,7 +11949,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.6
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -12794,7 +12792,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.6: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:
@@ -14564,7 +14562,7 @@ snapshots:
       speakingurl: 14.0.1
       styled-components: 6.5.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       swr: 2.5.1(react@19.2.8)
-      ui5: '@sanity/ui@5.0.0-alpha.4(react-dom@19.2.8(react@19.2.8))(react@19.2.8)'
+      ui5: '@sanity/ui@5.0.0-alpha.5(react-dom@19.2.8(react@19.2.8))(react@19.2.8)'
       urlpattern-polyfill: 10.1.0
       use-device-pixel-ratio: 1.1.2(react@19.2.8)
       use-effect-event: 2.0.3(react@19.2.8)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,6 +16,9 @@ minimumReleaseAgeExclude:
 overrides:
   # 2.20.0 ships untranspiled JSX in dist; 2.20.1 fixes it but is still inside the age gate
   "@sanity/sdk-react": 2.19.0
+  # react-email → conf → ajv pulls fast-uri 3.1.5, vulnerable to improper hex-encoding
+  # handling in URL normalization (CVE-2026-76172); 3.1.6 fixes it and stays in ajv's ^3 range
+  fast-uri: "^3.1.6"
   js-yaml: ">=4.3.1"
   # @tailwindcss/typography pins 6.0.10, which is vulnerable to uncontrolled recursion
   # in `toString()` (CVE-2026-9358); fixed in 6.1.3


### PR DESCRIPTION
PR 2 von 5 für WEB-296, aufbauend auf der in #471 gemergten Test-Infrastruktur. Dieser PR deckt die reine Logik ab: keine React-Komponenten, kein jsdom, kein HTTP. Server Actions folgen in PR 3, Komponenten in PR 4, Studio und E-Mail in PR 5.

## Abgedeckte Module

**`packages/shared`** — `array.ts` (Fisher-Yates: Kopie, unveränderte Eingabe, deterministische Reihenfolge bei gestubbtem `Math.random`), `cn.ts`, `promise.ts` (`settle` in allen Zweigen).

**`apps/web/src/utils`** — `links.ts` (jeder Zweig der internen Link-Auflösung, inklusive der Gruppen ohne Abteilungsseite), `groups.ts`, `icon.ts`, `image.ts`, `time.ts`.

**`apps/web/src/lib`** — `sanity/utils.ts` (Download-URLs, Dateigrößen über alle Einheiten, beide Bild-URL-Builder pro Query-Parameter geprüft), `env.ts` (Defaults, Fehlermeldungen, der Modul-Cache), `validations/contact-form.ts` und `validations/feedback.ts` (jede Grenze beidseitig, alle deutschen Meldungen als Literale).

Damit ist die Liste des Specs für PR 2 vollständig. `date.ts`, `typography.ts`, `url.ts`, `use-media-query.ts`, das Studio-`time.ts` und `cleverreach-markers.ts` kamen bereits mit PR 1.

## Ein Bugfix, den die Tests gefunden haben

`apps/web/src/app/angebot/[group]/page.tsx` rief `getGroupImage(group, '/angebot')` auf. `getGroupImage` verkettet `${path}${group}`, der Suchschlüssel war also `/angebotfussball` und traf keinen Eintrag — das Hero-Bild **jeder** Abteilungsseite fiel still auf das generische Bild zurück. Der Aufruf übergibt jetzt `/angebot/`, und ein zusätzlicher Testfall hält den Vertrag fest.

Ehrlich dazu gesagt: kein Test in dieser Suite rendert `page.tsx`, der neue Fall dokumentiert das Verhalten also für Leser, er ist keine automatische Absicherung des Aufrufs. Die gehört zu PR 4 beziehungsweise zum E2E-Ticket.

## Zwei Abhängigkeits-Änderungen

1. `fix(deps): override fast-uri to patch CVE-2026-76172` — der Override in `pnpm-workspace.yaml`, der den `cve`-Gate passieren lässt.
2. `fix(deps): align @sanity/client with the version next-sanity supports` — `next-sanity@13.3.3` erwartet `@sanity/client@^7.26.2` und importiert `unstable__adapter` daraus; in 8.x existiert dieser Export nicht mehr. `apps/web` war die einzige Stelle, die 8.2.0 hereinzog, während das gesamte übrige Sanity-Ökosystem 7.26.2 auflöst. Unter dem Next-Bundler fiel das nicht auf, jeder Import über Node hingegen brach — womit auch kein Test den echten Client laden konnte. Die Range steht jetzt auf `^7.26.2`, kein Override nötig, und der Workaround (ein gemocktes `createClient`) ist entfallen: die Sanity-Tests laufen gegen den echten Client.

## Stand

185 Tests: `apps/web` 140, `packages/shared` 30, `packages/email` 11, `apps/studio` 4. `lint`, `format:check`, `typecheck`, `test`, `build` und `cve` laufen alle sauber.

## Bewusst offen

- `apps/web/src/components/ui/group-card.tsx` ruft `getGroupImage(slug)` mit dem Slug einer einzelnen Gruppe und ohne Pfad auf. Da `groupSections` nach Abteilungspfaden schlüsselt, trifft dieser Aufruf nie — Gruppen ohne `featuredImage` zeigen das generische statt des Abteilungsbildes. Bestand schon vorher, ändert Darstellung, deshalb nicht in einem Test-PR.
- `env.ts` cached über `cached !== undefined`, ein Key mit validiertem `undefined` (`SANITY_API_READ_TOKEN`, `NEXT_PUBLIC_SANITY_STUDIO_URL`) wird also jedes Mal neu geparst. Harmlos, aber unschön.

Plan und Design liegen unter `docs/superpowers/`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved group page image resolution to ensure the correct hero image is displayed.
  - Updated supporting tooling for more reliable local database synchronization.

- **Security**
  - Applied a security update addressing a known URL-processing vulnerability.

- **Tests**
  - Expanded automated coverage for forms, images, links, groups, dates, environment settings, Sanity utilities, and shared helpers.
  - Added validation for edge cases including missing, invalid, and optional values.

- **Chores**
  - Streamlined email build tooling and refreshed supporting package configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->