### PR TITLE
test: cover the server actions and the cleverreach client (WEB-296)

### DIFF
--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -87,6 +87,8 @@ Three helpers live in `test-utils/`:
 - `env.ts` — `loadWithEnv` resets the module registry and stubs the environment, because `src/lib/env.ts` caches validated values in a module-level `Map`. A test using it must import the module under test only as `import type` and get its runtime binding from `loadWithEnv`'s return value — see `src/utils/url.test.ts`.
 - `fetch-mock.ts` — `createFetchMock` replaces `fetch` with a queue of canned responses and records every call. Recorded headers are normalized through `Headers`, same as the real `fetch`, so they come back lowercased — assert against lowercase header names.
 
+A `vi.fn()` created inside a `vi.mock(import('…'), factory)` is not reset by `vi.resetModules()` or `vi.restoreAllMocks()` — call it explicitly in an `afterEach` (`mockedFn.mockReset()`), or its call history accumulates across cases. See `src/actions/send-contact-form.test.ts` for the pattern.
+
 ## Gotchas
 
 - No `try`/`catch`/`finally` in components or hooks — the React Compiler bails out on `finally`. Await with `settle()` from `@tsgi-web/shared` and branch on `outcome.ok`.

--- a/apps/web/src/actions/create-linear-issue.test.ts
+++ b/apps/web/src/actions/create-linear-issue.test.ts
@@ -1,0 +1,327 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type * as createLinearIssueModule from '@/actions/create-linear-issue';
+import type { FeedbackFormValues } from '@/lib/validations/feedback';
+
+import { loadWithEnv } from '../../test-utils/env';
+import { createFetchMock, type FetchCall } from '../../test-utils/fetch-mock';
+
+type CreateLinearIssueModule = typeof createLinearIssueModule;
+
+const LINEAR_ENV = {
+	LINEAR_API_KEY: 'test-api-key',
+	LINEAR_ASSIGNEE_ID: 'test-assignee-id',
+	LINEAR_LABEL_ID: 'test-label-id',
+	LINEAR_TEAM_ID: 'test-team-id',
+};
+
+// The installed `next-safe-action` (8.6.1, see
+// `node_modules/next-safe-action/dist/index.mjs`) ships a `DEFAULT_SERVER_ERROR_MESSAGE` of
+// exactly this string, and `src/lib/actions/safe-action.ts` sets no custom `handleServerError`, so
+// every thrown `Error` in `postLinearMutation`/`extractIssueResult` is masked behind this fixed
+// message in the envelope. Its default error handler also does `console.error('Action error:',
+// e.message)` before masking, which is the only place the specific message is still observable —
+// see the failure-path tests below.
+const GENERIC_SERVER_ERROR = 'Something went wrong while executing the operation.';
+
+function validFeedbackInput(): FeedbackFormValues {
+	return {
+		description: 'Der Anmeldebutton reagiert auf mobilen Geräten nicht mehr.',
+		privacy: true,
+		title: 'Anmeldebutton kaputt',
+		type: 'bug',
+	};
+}
+
+/**
+ * Parses a recorded fetch call's JSON body as the Linear GraphQL request it is expected to be.
+ *
+ * @param call - The recorded fetch call to read the body from.
+ * @returns The parsed `{ query, variables }` payload.
+ */
+function parseGraphqlBody(call: FetchCall): { query: string; variables: Record<string, unknown> } {
+	if (!call.body) {
+		throw new Error(`Expected a JSON string body for ${call.url}`);
+	}
+	// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- `JSON.parse` widens to `any`
+	// here, so this narrows a JSON body this test file itself constructed, not an external payload.
+	return JSON.parse(call.body) as { query: string; variables: Record<string, unknown> };
+}
+
+describe('building the linear issue description and mutation variables', () => {
+	let mock: ReturnType<typeof createFetchMock> | undefined;
+
+	afterEach(() => {
+		mock?.restore();
+		vi.restoreAllMocks();
+	});
+
+	it('omits the screenshot section and skips falsy metadata fields when there are no screenshot urls', async () => {
+		mock = createFetchMock();
+		const { createLinearIssue } = await loadWithEnv<CreateLinearIssueModule>(
+			'@/actions/create-linear-issue',
+			LINEAR_ENV,
+		);
+		mock.enqueueJson({
+			data: { issueCreate: { issue: { id: 'id-1', identifier: 'ID-1' }, success: true } },
+		});
+
+		await createLinearIssue({
+			description: 'Der Anmeldebutton reagiert auf mobilen Geräten nicht mehr.',
+			privacy: true,
+			title: 'Anmeldebutton kaputt',
+			type: 'bug',
+		});
+
+		const expectedDescription = [
+			'Der Anmeldebutton reagiert auf mobilen Geräten nicht mehr.',
+			'',
+			'---',
+			'**Type:** bug',
+			'**Privacy checked:** true',
+			'**Source:** Feedback Form from tsg-irlich.de',
+		].join('\n');
+
+		expect(parseGraphqlBody(mock.calls[0]).variables).toStrictEqual({
+			input: {
+				assigneeId: 'test-assignee-id',
+				description: expectedDescription,
+				labelIds: ['test-label-id'],
+				teamId: 'test-team-id',
+				title: '[BUG] Anmeldebutton kaputt',
+			},
+		});
+		expect(mock.unqueued).toStrictEqual([]);
+	});
+
+	it('renders one screenshot markdown image per url, every truthy metadata line, and Source last', async () => {
+		mock = createFetchMock();
+		const { createLinearIssue } = await loadWithEnv<CreateLinearIssueModule>(
+			'@/actions/create-linear-issue',
+			LINEAR_ENV,
+		);
+		mock.enqueueJson({
+			data: { issueCreate: { issue: { id: 'id-1', identifier: 'ID-1' }, success: true } },
+		});
+
+		await createLinearIssue({
+			browser: 'chrome',
+			description: 'Ein Screenshot zeigt den fehlerhaften Zustand des Formulars.',
+			device: 'iPhone 15',
+			email: 'reporter@example.com',
+			operationSystem: 'ios',
+			privacy: true,
+			screenshotUrls: ['https://cdn.example.com/a.png', 'https://cdn.example.com/b.png'],
+			title: 'Formular fehlerhaft',
+			type: 'feature',
+		});
+
+		const expectedDescription = [
+			'Ein Screenshot zeigt den fehlerhaften Zustand des Formulars.',
+			'',
+			'## Screenshots',
+			'![Screenshot](https://cdn.example.com/a.png)',
+			'![Screenshot](https://cdn.example.com/b.png)',
+			'',
+			'---',
+			'**Type:** feature',
+			'**Browser:** chrome',
+			'**Operation System:** ios',
+			'**Device:** iPhone 15',
+			'**Reporter Email:** reporter@example.com',
+			'**Privacy checked:** true',
+			'**Source:** Feedback Form from tsg-irlich.de',
+		].join('\n');
+
+		const { variables } = parseGraphqlBody(mock.calls[0]);
+
+		expect(variables).toStrictEqual({
+			input: {
+				assigneeId: 'test-assignee-id',
+				description: expectedDescription,
+				labelIds: ['test-label-id'],
+				teamId: 'test-team-id',
+				title: '[FEATURE] Formular fehlerhaft',
+			},
+		});
+		expect(expectedDescription.split('\n').at(-1)).toBe(
+			'**Source:** Feedback Form from tsg-irlich.de',
+		);
+		expect(mock.unqueued).toStrictEqual([]);
+	});
+});
+
+describe('surfacing a failure from the linear api', () => {
+	let mock: ReturnType<typeof createFetchMock> | undefined;
+
+	afterEach(() => {
+		mock?.restore();
+		vi.restoreAllMocks();
+	});
+
+	it('surfaces "HTTP error: <status>" for a non-ok response, masked behind the generic envelope message', async () => {
+		mock = createFetchMock();
+		const { createLinearIssue } = await loadWithEnv<CreateLinearIssueModule>(
+			'@/actions/create-linear-issue',
+			LINEAR_ENV,
+		);
+		const errorSpy = vi.spyOn(console, 'error').mockReturnValue();
+
+		mock.enqueue({ body: 'Internal Server Error', status: 503 });
+
+		const result = await createLinearIssue(validFeedbackInput());
+
+		expect(result).toStrictEqual({ serverError: GENERIC_SERVER_ERROR });
+		expect(errorSpy).toHaveBeenCalledExactlyOnceWith('Action error:', 'HTTP error: 503');
+		expect(mock.unqueued).toStrictEqual([]);
+	});
+
+	it('surfaces "Failed to create issue" for a graphql errors array, after logging it', async () => {
+		mock = createFetchMock();
+		const { createLinearIssue } = await loadWithEnv<CreateLinearIssueModule>(
+			'@/actions/create-linear-issue',
+			LINEAR_ENV,
+		);
+		const errorSpy = vi.spyOn(console, 'error').mockReturnValue();
+
+		mock.enqueueJson({ errors: [{ message: 'field X is required' }] });
+
+		const result = await createLinearIssue(validFeedbackInput());
+
+		expect(result).toStrictEqual({ serverError: GENERIC_SERVER_ERROR });
+		expect(errorSpy).toHaveBeenCalledWith('Linear API errors:', [
+			{ message: 'field X is required' },
+		]);
+		expect(errorSpy).toHaveBeenCalledWith('Action error:', 'Failed to create issue');
+		expect(mock.unqueued).toStrictEqual([]);
+	});
+
+	it('surfaces "Issue creation failed" when issueCreate.success is false', async () => {
+		mock = createFetchMock();
+		const { createLinearIssue } = await loadWithEnv<CreateLinearIssueModule>(
+			'@/actions/create-linear-issue',
+			LINEAR_ENV,
+		);
+		const errorSpy = vi.spyOn(console, 'error').mockReturnValue();
+
+		mock.enqueueJson({ data: { issueCreate: { issue: null, success: false } } });
+
+		const result = await createLinearIssue(validFeedbackInput());
+
+		expect(result).toStrictEqual({ serverError: GENERIC_SERVER_ERROR });
+		expect(errorSpy).toHaveBeenCalledExactlyOnceWith('Action error:', 'Issue creation failed');
+		expect(mock.unqueued).toStrictEqual([]);
+	});
+
+	it('surfaces "Issue creation failed" when the issue is missing despite success:true', async () => {
+		mock = createFetchMock();
+		const { createLinearIssue } = await loadWithEnv<CreateLinearIssueModule>(
+			'@/actions/create-linear-issue',
+			LINEAR_ENV,
+		);
+		const errorSpy = vi.spyOn(console, 'error').mockReturnValue();
+
+		mock.enqueueJson({ data: { issueCreate: { issue: null, success: true } } });
+
+		const result = await createLinearIssue(validFeedbackInput());
+
+		expect(result).toStrictEqual({ serverError: GENERIC_SERVER_ERROR });
+		expect(errorSpy).toHaveBeenCalledExactlyOnceWith('Action error:', 'Issue creation failed');
+		expect(mock.unqueued).toStrictEqual([]);
+	});
+
+	it('surfaces a zod error instead of a silent success when the payload fails linearResponseSchema', async () => {
+		mock = createFetchMock();
+		const { createLinearIssue } = await loadWithEnv<CreateLinearIssueModule>(
+			'@/actions/create-linear-issue',
+			LINEAR_ENV,
+		);
+		const errorSpy = vi.spyOn(console, 'error').mockReturnValue();
+
+		// `success` must be a boolean per `linearIssueCreateSchema`; a string fails `.parse`.
+		mock.enqueueJson({ data: { issueCreate: { issue: null, success: 'yes' } } });
+
+		const result = await createLinearIssue(validFeedbackInput());
+
+		expect(result).toStrictEqual({ serverError: GENERIC_SERVER_ERROR });
+		// zod 4's `ZodError.message` for a caught `.parse()` failure is this pretty-printed issues
+		// array (see `src/lib/cleverreach.test.ts`'s `EXPECTED_VALIDATION_ERROR_MESSAGE` for the same
+		// convention) — hard-coded here rather than derived from a schema this test doesn't import.
+		expect(errorSpy).toHaveBeenCalledExactlyOnceWith(
+			'Action error:',
+			JSON.stringify(
+				[
+					{
+						expected: 'boolean',
+						code: 'invalid_type',
+						path: ['data', 'issueCreate', 'success'],
+						message: 'Invalid input: expected boolean, received string',
+					},
+				],
+				null,
+				2,
+			),
+		);
+		expect(mock.unqueued).toStrictEqual([]);
+	});
+
+	it('never reaches fetch when the input fails feedbackFormSchema', async () => {
+		mock = createFetchMock();
+		const { createLinearIssue } = await loadWithEnv<CreateLinearIssueModule>(
+			'@/actions/create-linear-issue',
+			LINEAR_ENV,
+		);
+
+		const result = await createLinearIssue({
+			description: 'Der Anmeldebutton reagiert auf mobilen Geräten nicht mehr.',
+			privacy: true,
+			title: 'x',
+			type: 'bug',
+		});
+
+		expect(result).toStrictEqual({
+			validationErrors: {
+				title: { _errors: ['Der Titel muss mindestens 5 Zeichen lang sein'] },
+			},
+		});
+		expect(mock.calls).toStrictEqual([]);
+	});
+});
+
+describe('completing a linear issue creation', () => {
+	let mock: ReturnType<typeof createFetchMock> | undefined;
+
+	afterEach(() => {
+		mock?.restore();
+		vi.restoreAllMocks();
+	});
+
+	it('returns the created issue id and identifier, authenticated with the linear api key', async () => {
+		mock = createFetchMock();
+		const { createLinearIssue } = await loadWithEnv<CreateLinearIssueModule>(
+			'@/actions/create-linear-issue',
+			LINEAR_ENV,
+		);
+
+		mock.enqueueJson({
+			data: { issueCreate: { issue: { id: 'issue-abc', identifier: 'ISS-42' }, success: true } },
+		});
+
+		const result = await createLinearIssue(validFeedbackInput());
+
+		expect(result).toStrictEqual({ data: { issueId: 'issue-abc', issueIdentifier: 'ISS-42' } });
+		expect(mock.calls).toHaveLength(1);
+		expect({
+			authorization: mock.calls[0].headers.authorization,
+			contentType: mock.calls[0].headers['content-type'],
+			method: mock.calls[0].method,
+			url: mock.calls[0].url,
+		}).toStrictEqual({
+			authorization: 'test-api-key',
+			contentType: 'application/json',
+			method: 'POST',
+			url: 'https://api.linear.app/graphql',
+		});
+		expect(mock.unqueued).toStrictEqual([]);
+	});
+});

--- a/apps/web/src/actions/create-linear-issue.test.ts
+++ b/apps/web/src/actions/create-linear-issue.test.ts
@@ -144,9 +144,6 @@ describe('building the linear issue description and mutation variables', () => {
 				title: '[FEATURE] Formular fehlerhaft',
 			},
 		});
-		expect(expectedDescription.split('\n').at(-1)).toBe(
-			'**Source:** Feedback Form from tsg-irlich.de',
-		);
 		expect(mock.unqueued).toStrictEqual([]);
 	});
 });

--- a/apps/web/src/actions/send-contact-form.test.ts
+++ b/apps/web/src/actions/send-contact-form.test.ts
@@ -1,0 +1,221 @@
+import type { Resend } from 'resend';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { ContactForwardEmail } from '@tsgi-web/email';
+
+import type * as sendContactFormModule from '@/actions/send-contact-form';
+import { resend } from '@/lib/resend';
+import type { ContactFormData } from '@/lib/validations/contact-form';
+
+import { loadWithEnv } from '../../test-utils/env';
+
+type SendContactFormModule = typeof sendContactFormModule;
+
+// `sendContactForm` calls `resend.emails.send` (see `src/lib/resend.ts`) directly, so the whole
+// module is replaced with a fake `Resend` instance whose `emails.send` is a spy. This sidesteps
+// `resend.ts`'s own `env('RESEND_API_KEY')` call at import time, so no `RESEND_API_KEY` stub is
+// needed. The cast is necessary because the real `Resend` class carries many more readonly
+// properties (`apiKeys`, `batch`, `contacts`, ...) that this fake never implements.
+vi.mock(import('@/lib/resend'), () => ({
+	resend: { emails: { send: vi.fn() } } as unknown as Resend,
+}));
+
+// `vi.mocked` only needs the reference to the mock function object; it is never invoked as a bare,
+// unbound `this`-dependent call.
+// oxlint-disable-next-line typescript/unbound-method
+const mockedSend = vi.mocked(resend.emails.send);
+
+// The action builds its email by calling `ContactForwardEmail({...})` directly (not as JSX), so
+// mocking it turns that call's arguments into the observable "props handed to react" the task
+// brief asks for — the value `react:` receives is otherwise just the fully rendered element tree,
+// which does not expose the props it was built from.
+vi.mock(import('@tsgi-web/email'), () => ({ ContactForwardEmail: vi.fn() }));
+
+const mockedContactForwardEmail = vi.mocked(ContactForwardEmail);
+
+// `next-safe-action`'s default `handleServerError` (see `create-linear-issue.test.ts` for the full
+// citation) masks every thrown `Error` behind this fixed message in the envelope, logging the real
+// message first via `console.error('Action error:', e.message)`.
+const GENERIC_SERVER_ERROR = 'Something went wrong while executing the operation.';
+
+const MESSAGE = 'Dies ist eine ausführliche Testnachricht für das Kontaktformular.';
+
+function validContactInput(overrides: Partial<ContactFormData> = {}): ContactFormData {
+	return {
+		email: 'sender@example.com',
+		message: MESSAGE,
+		name: 'Max Mustermann',
+		privacy: true,
+		...overrides,
+	};
+}
+
+function mockSendSuccess(): void {
+	mockedSend.mockResolvedValue({
+		data: { id: 'email-id-1' },
+		error: null,
+		headers: null,
+	});
+}
+
+describe('choosing the email recipient', () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+		mockedSend.mockReset();
+		mockedContactForwardEmail.mockReset();
+	});
+
+	it('sends to the receiver in production when one is given', async () => {
+		mockSendSuccess();
+		const { sendContactForm } = await loadWithEnv<SendContactFormModule>(
+			'@/actions/send-contact-form',
+			{ NODE_ENV: 'production' },
+		);
+
+		await sendContactForm(
+			validContactInput({
+				receiver: { email: 'trainer@tsg-irlich.de', label: 'Trainerteam Fußball' },
+			}),
+		);
+
+		expect(mockedSend.mock.calls[0][0].to).toBe('trainer@tsg-irlich.de');
+	});
+
+	it('falls back to info@tsg-irlich.de in production without a receiver', async () => {
+		mockSendSuccess();
+		const { sendContactForm } = await loadWithEnv<SendContactFormModule>(
+			'@/actions/send-contact-form',
+			{ NODE_ENV: 'production' },
+		);
+
+		await sendContactForm(validContactInput());
+
+		expect(mockedSend.mock.calls[0][0].to).toBe('info@tsg-irlich.de');
+	});
+
+	it('forces it@tsg-irlich.de outside production even when a receiver is given', async () => {
+		mockSendSuccess();
+		const { sendContactForm } = await loadWithEnv<SendContactFormModule>(
+			'@/actions/send-contact-form',
+			{ NODE_ENV: 'development' },
+		);
+
+		await sendContactForm(
+			validContactInput({
+				receiver: { email: 'trainer@tsg-irlich.de', label: 'Trainerteam Fußball' },
+			}),
+		);
+
+		expect(mockedSend.mock.calls[0][0].to).toBe('it@tsg-irlich.de');
+	});
+});
+
+describe('building the resend request', () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+		mockedSend.mockReset();
+		mockedContactForwardEmail.mockReset();
+	});
+
+	it('sets bcc to it@tsg-irlich.de, replyTo to the sender and the exact subject', async () => {
+		mockSendSuccess();
+		const { sendContactForm } = await loadWithEnv<SendContactFormModule>(
+			'@/actions/send-contact-form',
+			{ NODE_ENV: 'development' },
+		);
+
+		await sendContactForm(
+			validContactInput({ email: 'sender@example.com', name: 'Erika Musterfrau' }),
+		);
+
+		const [sendArgs] = mockedSend.mock.calls[0];
+		expect({
+			bcc: sendArgs.bcc,
+			replyTo: sendArgs.replyTo,
+			subject: sendArgs.subject,
+		}).toStrictEqual({
+			bcc: ['it@tsg-irlich.de'],
+			replyTo: 'sender@example.com',
+			subject: 'Webseiten-Kontaktformular: Neue Nachricht von Erika Musterfrau',
+		});
+	});
+
+	it('passes the input-derived props to the contact forward email, plus a baseUrl', async () => {
+		mockSendSuccess();
+		const { sendContactForm } = await loadWithEnv<SendContactFormModule>(
+			'@/actions/send-contact-form',
+			{ NODE_ENV: 'development' },
+		);
+
+		await sendContactForm(
+			validContactInput({
+				email: 'sender@example.com',
+				message: MESSAGE,
+				name: 'Erika Musterfrau',
+				receiver: { email: 'trainer@tsg-irlich.de', label: 'Trainerteam Fußball' },
+			}),
+		);
+
+		const [props] = mockedContactForwardEmail.mock.calls[0];
+		expect(mockedContactForwardEmail).toHaveBeenCalledOnce();
+		expect(props).toMatchObject({
+			contactEmail: 'sender@example.com',
+			contactMessage: MESSAGE,
+			contactName: 'Erika Musterfrau',
+			receiver: 'Trainerteam Fußball',
+		});
+		expect(props.baseUrl).toBeTypeOf('string');
+	});
+});
+
+describe('surfacing a resend failure', () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+		mockedSend.mockReset();
+		mockedContactForwardEmail.mockReset();
+	});
+
+	it('surfaces "Email could not be sent" when resend returns an error, after logging it', async () => {
+		const errorSpy = vi.spyOn(console, 'error').mockReturnValue();
+		const resendError = {
+			message: 'Missing required field',
+			name: 'missing_required_field' as const,
+			statusCode: 422,
+		};
+		mockedSend.mockResolvedValue({ data: null, error: resendError, headers: null });
+		const { sendContactForm } = await loadWithEnv<SendContactFormModule>(
+			'@/actions/send-contact-form',
+			{ NODE_ENV: 'development' },
+		);
+
+		const result = await sendContactForm(validContactInput());
+
+		expect(result).toStrictEqual({ serverError: GENERIC_SERVER_ERROR });
+		expect(errorSpy).toHaveBeenCalledWith('Resend API error:', resendError);
+		expect(errorSpy).toHaveBeenCalledWith('Action error:', 'Email could not be sent');
+	});
+});
+
+describe('validating the submitted input', () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+		mockedSend.mockReset();
+		mockedContactForwardEmail.mockReset();
+	});
+
+	it('never calls send when the input fails contactFormSchema', async () => {
+		const { sendContactForm } = await loadWithEnv<SendContactFormModule>(
+			'@/actions/send-contact-form',
+			{ NODE_ENV: 'development' },
+		);
+
+		const result = await sendContactForm(validContactInput({ message: 'zu kurz' }));
+
+		expect(result).toStrictEqual({
+			validationErrors: {
+				message: { _errors: ['Die Nachricht muss mindestens 32 Zeichen lang sein.'] },
+			},
+		});
+		expect(mockedSend).not.toHaveBeenCalled();
+	});
+});

--- a/apps/web/src/actions/send-contact-form.test.ts
+++ b/apps/web/src/actions/send-contact-form.test.ts
@@ -33,6 +33,12 @@ vi.mock(import('@tsgi-web/email'), () => ({ ContactForwardEmail: vi.fn() }));
 
 const mockedContactForwardEmail = vi.mocked(ContactForwardEmail);
 
+// A stand-in for whatever `ContactForwardEmail(...)` returns, so the full-payload assertion below
+// can compare `react` against a known value instead of describing a rendered element tree.
+const CONTACT_FORWARD_EMAIL_STUB = 'contact-forward-email-stub' as unknown as ReturnType<
+	typeof ContactForwardEmail
+>;
+
 // `next-safe-action`'s default `handleServerError` (see `create-linear-issue.test.ts` for the full
 // citation) masks every thrown `Error` behind this fixed message in the envelope, logging the real
 // message first via `console.error('Action error:', e.message)`.
@@ -119,6 +125,7 @@ describe('building the resend request', () => {
 
 	it('sets bcc to it@tsg-irlich.de, replyTo to the sender and the exact subject', async () => {
 		mockSendSuccess();
+		mockedContactForwardEmail.mockReturnValue(CONTACT_FORWARD_EMAIL_STUB);
 		const { sendContactForm } = await loadWithEnv<SendContactFormModule>(
 			'@/actions/send-contact-form',
 			{ NODE_ENV: 'development' },
@@ -129,14 +136,19 @@ describe('building the resend request', () => {
 		);
 
 		const [sendArgs] = mockedSend.mock.calls[0];
-		expect({
-			bcc: sendArgs.bcc,
-			replyTo: sendArgs.replyTo,
-			subject: sendArgs.subject,
-		}).toStrictEqual({
+		// The full argument object, not a picked subset — this is the one case in the file that
+		// guards `from` (and any unexpected extra field), so a regression that corrupts, drops or
+		// hardcodes the wrong sender address would otherwise be invisible to this suite. `from` is
+		// hard-coded from `send-contact-form.ts` rather than imported. `react` is matched against
+		// the mocked `ContactForwardEmail`'s stubbed return value, since the mock's actual props are
+		// covered by the dedicated test below.
+		expect(sendArgs).toStrictEqual({
 			bcc: ['it@tsg-irlich.de'],
+			from: 'TSG Irlich - Benachrichtigungen <webseite@notifications.tsg-irlich.de>',
+			react: CONTACT_FORWARD_EMAIL_STUB,
 			replyTo: 'sender@example.com',
 			subject: 'Webseiten-Kontaktformular: Neue Nachricht von Erika Musterfrau',
+			to: 'it@tsg-irlich.de',
 		});
 	});
 

--- a/apps/web/src/actions/send-contact-form.test.ts
+++ b/apps/web/src/actions/send-contact-form.test.ts
@@ -170,13 +170,19 @@ describe('building the resend request', () => {
 
 		const [props] = mockedContactForwardEmail.mock.calls[0];
 		expect(mockedContactForwardEmail).toHaveBeenCalledOnce();
-		expect(props).toMatchObject({
+		// The whole prop object, not a subset — `baseUrl` is pinned to a literal rather than merely
+		// typed. `getBaseUrl()` (`src/utils/url.ts`) checks `VERCEL_PROJECT_PRODUCTION_URL` first, which
+		// is left unstubbed by the `{ NODE_ENV: 'development' }` env below and is unset in this test
+		// run, then `NODE_ENV`, which is `'development'` here — so it falls through to the localhost
+		// default. Hard-coded here rather than imported, per the "never derive an expected value from a
+		// constant the implementation also imports" rule.
+		expect(props).toStrictEqual({
+			baseUrl: 'http://localhost:3000',
 			contactEmail: 'sender@example.com',
 			contactMessage: MESSAGE,
 			contactName: 'Erika Musterfrau',
 			receiver: 'Trainerteam Fußball',
 		});
-		expect(props.baseUrl).toBeTypeOf('string');
 	});
 });
 

--- a/apps/web/src/actions/subscribe-to-newsletter.test.ts
+++ b/apps/web/src/actions/subscribe-to-newsletter.test.ts
@@ -1,0 +1,313 @@
+import { headers } from 'next/headers';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type * as subscribeToNewsletterModule from '@/actions/subscribe-to-newsletter';
+import type * as cleverreachModule from '@/lib/cleverreach';
+
+import { loadWithEnv } from '../../test-utils/env';
+import { createFetchMock, type FetchCall } from '../../test-utils/fetch-mock';
+
+type SubscribeToNewsletterModule = typeof subscribeToNewsletterModule;
+type CleverreachModule = typeof cleverreachModule;
+
+// `getRequestMetadata` in `subscribe-to-newsletter.ts` reads the referer, user agent and
+// `x-forwarded-for` headers through `await headers()`, so `next/headers` has to be mocked. The
+// static import above gives `vi.mocked` a typed handle on the same mock the dynamically
+// re-imported action (via `loadWithEnv`) resolves to.
+vi.mock(import('next/headers'), () => ({ headers: vi.fn() }));
+
+const mockedHeaders = vi.mocked(headers);
+
+const CLEVERREACH_ENV = {
+	CLEVERREACH_CLIENT_ID: 'test-client-id',
+	CLEVERREACH_CLIENT_SECRET: 'test-client-secret',
+	CLEVERREACH_FORM_ID: 'test-form-id',
+	CLEVERREACH_LIST_ID: 'test-list-id',
+};
+
+/**
+ * Parses a recorded fetch call's JSON body. See `src/lib/cleverreach.test.ts` for the identical
+ * helper — kept local rather than shared, since `test-utils/` is not to be modified for this task.
+ *
+ * @param call - The recorded fetch call to read the body from.
+ * @returns The parsed JSON body.
+ */
+function parseJsonBody(call: FetchCall): unknown {
+	if (!call.body) {
+		throw new Error(`Expected a JSON string body for ${call.url}`);
+	}
+	return JSON.parse(call.body);
+}
+
+function emailFormData(email: string): FormData {
+	const formData = new FormData();
+	formData.set('email', email);
+	return formData;
+}
+
+describe('validating the submitted email before contacting cleverreach', () => {
+	let mock: ReturnType<typeof createFetchMock> | undefined;
+
+	afterEach(() => {
+		mock?.restore();
+		vi.restoreAllMocks();
+	});
+
+	it('returns the validation error state when the email field is missing, without any fetch', async () => {
+		mock = createFetchMock();
+		const { subscribeToNewsletter } = await loadWithEnv<SubscribeToNewsletterModule>(
+			'@/actions/subscribe-to-newsletter',
+			CLEVERREACH_ENV,
+		);
+
+		const result = await subscribeToNewsletter(null, new FormData());
+
+		expect(result).toStrictEqual({
+			error: undefined,
+			message: 'Bitte überprüfe Deine Eingaben.',
+			success: false,
+			title: 'Fehler',
+		});
+		expect(mock.calls).toStrictEqual([]);
+	});
+
+	it('returns the validation error state for an invalid email address, without any fetch', async () => {
+		mock = createFetchMock();
+		const { subscribeToNewsletter } = await loadWithEnv<SubscribeToNewsletterModule>(
+			'@/actions/subscribe-to-newsletter',
+			CLEVERREACH_ENV,
+		);
+
+		const result = await subscribeToNewsletter(null, emailFormData('not-an-email'));
+
+		expect(result).toStrictEqual({
+			error: undefined,
+			message: 'Bitte überprüfe Deine Eingaben.',
+			success: false,
+			title: 'Fehler',
+		});
+		expect(mock.calls).toStrictEqual([]);
+	});
+});
+
+describe('resolving the request metadata for the DOI email', () => {
+	let mock: ReturnType<typeof createFetchMock> | undefined;
+
+	afterEach(() => {
+		mock?.restore();
+		vi.restoreAllMocks();
+	});
+
+	it('takes the first ip from a multi-value x-forwarded-for header, trimmed', async () => {
+		mockedHeaders.mockResolvedValue(
+			new Headers({
+				referer: 'https://tsg-irlich.de/newsletter',
+				'user-agent': 'TestAgent/2.0',
+				'x-forwarded-for': ' 203.0.113.9 , 10.0.0.5',
+			}),
+		);
+		mock = createFetchMock();
+		const { subscribeToNewsletter } = await loadWithEnv<SubscribeToNewsletterModule>(
+			'@/actions/subscribe-to-newsletter',
+			CLEVERREACH_ENV,
+		);
+
+		mock.enqueueJson({ access_token: 'token-abc', expires_in: 3600 });
+		mock.enqueueJson({});
+		mock.enqueueJson({});
+
+		await subscribeToNewsletter(null, emailFormData('person@example.com'));
+
+		expect(parseJsonBody(mock.calls[2])).toStrictEqual({
+			doidata: {
+				referer: 'https://tsg-irlich.de/newsletter',
+				user_agent: 'TestAgent/2.0',
+				user_ip: '203.0.113.9',
+			},
+			email: 'person@example.com',
+			groups_ids: ['test-list-id'],
+		});
+		expect(mock.unqueued).toStrictEqual([]);
+	});
+
+	it('falls back to an empty referer, the default user agent and the default ip when headers are missing', async () => {
+		mockedHeaders.mockResolvedValue(new Headers());
+		mock = createFetchMock();
+		const { subscribeToNewsletter } = await loadWithEnv<SubscribeToNewsletterModule>(
+			'@/actions/subscribe-to-newsletter',
+			CLEVERREACH_ENV,
+		);
+
+		mock.enqueueJson({ access_token: 'token-abc', expires_in: 3600 });
+		mock.enqueueJson({});
+		mock.enqueueJson({});
+
+		await subscribeToNewsletter(null, emailFormData('person@example.com'));
+
+		expect(parseJsonBody(mock.calls[2])).toStrictEqual({
+			doidata: {
+				referer: '',
+				user_agent: 'Mozilla/5.0',
+				user_ip: '0.0.0.0',
+			},
+			email: 'person@example.com',
+			groups_ids: ['test-list-id'],
+		});
+		expect(mock.unqueued).toStrictEqual([]);
+	});
+});
+
+describe('mapping a cleverreach failure to its german message', () => {
+	let mock: ReturnType<typeof createFetchMock> | undefined;
+
+	afterEach(() => {
+		mock?.restore();
+		vi.doUnmock('@/lib/cleverreach');
+		vi.restoreAllMocks();
+	});
+
+	it('maps ALREADY_SUBSCRIBED to its german message', async () => {
+		mockedHeaders.mockResolvedValue(new Headers());
+		mock = createFetchMock();
+		const { subscribeToNewsletter } = await loadWithEnv<SubscribeToNewsletterModule>(
+			'@/actions/subscribe-to-newsletter',
+			CLEVERREACH_ENV,
+		);
+
+		mock.enqueueJson({ access_token: 'token-abc', expires_in: 3600 });
+		mock.enqueue({ body: JSON.stringify({}), status: 409 });
+
+		const result = await subscribeToNewsletter(null, emailFormData('person@example.com'));
+
+		expect(result).toStrictEqual({
+			error: 'This email is already subscribed',
+			message: 'Diese E-Mail-Adresse ist bereits für den Newsletter registriert.',
+			success: false,
+			title: 'Fehler',
+		});
+		expect(mock.unqueued).toStrictEqual([]);
+	});
+
+	it('maps INTERNAL_ERROR to its german message', async () => {
+		const errorSpy = vi.spyOn(console, 'error').mockReturnValue();
+		mockedHeaders.mockResolvedValue(new Headers());
+		mock = createFetchMock();
+		const { subscribeToNewsletter } = await loadWithEnv<SubscribeToNewsletterModule>(
+			'@/actions/subscribe-to-newsletter',
+			CLEVERREACH_ENV,
+		);
+
+		mock.enqueue({ body: 'invalid_client', status: 401 });
+
+		const result = await subscribeToNewsletter(null, emailFormData('person@example.com'));
+
+		expect(result).toStrictEqual({
+			error: 'An unexpected error occurred. Please try again later.',
+			message: 'Ein Fehler ist aufgetreten. Bitte versuche es später erneut.',
+			success: false,
+			title: 'Fehler',
+		});
+		expect(errorSpy).toHaveBeenCalledWith(
+			'CleverReach subscription error:',
+			expect.objectContaining({
+				message: 'CleverReach authentication failed: invalid_client',
+			}),
+		);
+		expect(mock.unqueued).toStrictEqual([]);
+	});
+
+	// `subscribe()`'s own `VALIDATION_ERROR` branch (in `src/lib/cleverreach.ts`) re-runs the exact
+	// same `subscriberSchema` this action already validated the email against in `validateEmail`, so
+	// a value that reaches `subscribe()` from this action can never fail that second parse — the
+	// branch is unreachable "by shaping the CleverReach responses" as the task brief suggested.
+	// `@/lib/cleverreach`'s `subscribe` export is stubbed directly for this one case instead, to
+	// exercise `toErrorState`'s mapping for a code that is otherwise dead code from this action's
+	// perspective. `subscriberSchema` itself (used by `validateEmail`) is kept real via
+	// `importOriginal`, so the email still has to pass validation first.
+	it('maps VALIDATION_ERROR to its german message', async () => {
+		mockedHeaders.mockResolvedValue(new Headers());
+		mock = createFetchMock();
+		vi.doMock(import('@/lib/cleverreach'), async (importOriginal) => {
+			const actual = await importOriginal<CleverreachModule>();
+			return {
+				...actual,
+				subscribe: vi.fn().mockResolvedValue({
+					code: 'VALIDATION_ERROR',
+					error: 'Invalid email address',
+					success: false,
+				}),
+			};
+		});
+		const { subscribeToNewsletter } = await loadWithEnv<SubscribeToNewsletterModule>(
+			'@/actions/subscribe-to-newsletter',
+			CLEVERREACH_ENV,
+		);
+
+		const result = await subscribeToNewsletter(null, emailFormData('person@example.com'));
+
+		expect(result).toStrictEqual({
+			error: 'Invalid email address',
+			message: 'Bitte überprüfe Deine Eingaben.',
+			success: false,
+			title: 'Fehler',
+		});
+		expect(mock.calls).toStrictEqual([]);
+	});
+
+	it('falls back to the raw error string for a code with no german mapping', async () => {
+		mockedHeaders.mockResolvedValue(new Headers());
+		mock = createFetchMock();
+		const { subscribeToNewsletter } = await loadWithEnv<SubscribeToNewsletterModule>(
+			'@/actions/subscribe-to-newsletter',
+			CLEVERREACH_ENV,
+		);
+
+		mock.enqueueJson({ access_token: 'token-abc', expires_in: 3600 });
+		mock.enqueue({
+			body: JSON.stringify({ error: { code: 1004, message: 'Custom failure message' } }),
+			status: 400,
+		});
+
+		const result = await subscribeToNewsletter(null, emailFormData('person@example.com'));
+
+		expect(result).toStrictEqual({
+			error: 'Custom failure message',
+			message: 'Custom failure message',
+			success: false,
+			title: 'Fehler',
+		});
+		expect(mock.unqueued).toStrictEqual([]);
+	});
+});
+
+describe('completing the subscription', () => {
+	let mock: ReturnType<typeof createFetchMock> | undefined;
+
+	afterEach(() => {
+		mock?.restore();
+		vi.restoreAllMocks();
+	});
+
+	it('returns the success title and message', async () => {
+		mockedHeaders.mockResolvedValue(new Headers());
+		mock = createFetchMock();
+		const { subscribeToNewsletter } = await loadWithEnv<SubscribeToNewsletterModule>(
+			'@/actions/subscribe-to-newsletter',
+			CLEVERREACH_ENV,
+		);
+
+		mock.enqueueJson({ access_token: 'token-abc', expires_in: 3600 });
+		mock.enqueueJson({});
+		mock.enqueueJson({});
+
+		const result = await subscribeToNewsletter(null, emailFormData('person@example.com'));
+
+		expect(result).toStrictEqual({
+			message:
+				'Bitte bestätige Deine Anmeldung über den Link in der E-Mail, die wir Dir gesendet haben.',
+			success: true,
+			title: 'Vielen Dank!',
+		});
+		expect(mock.unqueued).toStrictEqual([]);
+	});
+});

--- a/apps/web/src/actions/subscribe-to-newsletter.test.ts
+++ b/apps/web/src/actions/subscribe-to-newsletter.test.ts
@@ -55,6 +55,7 @@ describe('validating the submitted email before contacting cleverreach', () => {
 	afterEach(() => {
 		mock?.restore();
 		vi.restoreAllMocks();
+		mockedHeaders.mockReset();
 	});
 
 	// `subscriberSchema` in `src/lib/cleverreach.ts` defines the field as
@@ -129,6 +130,7 @@ describe('resolving the request metadata for the DOI email', () => {
 	afterEach(() => {
 		mock?.restore();
 		vi.restoreAllMocks();
+		mockedHeaders.mockReset();
 	});
 
 	it('takes the first ip from a multi-value x-forwarded-for header, trimmed', async () => {
@@ -197,6 +199,7 @@ describe('mapping a cleverreach failure to its german message', () => {
 		mock?.restore();
 		vi.doUnmock('@/lib/cleverreach');
 		vi.restoreAllMocks();
+		mockedHeaders.mockReset();
 	});
 
 	it('maps ALREADY_SUBSCRIBED to its german message', async () => {
@@ -319,6 +322,7 @@ describe('completing the subscription', () => {
 	afterEach(() => {
 		mock?.restore();
 		vi.restoreAllMocks();
+		mockedHeaders.mockReset();
 	});
 
 	it('returns the success title and message', async () => {

--- a/apps/web/src/actions/subscribe-to-newsletter.test.ts
+++ b/apps/web/src/actions/subscribe-to-newsletter.test.ts
@@ -9,6 +9,10 @@ import { createFetchMock, type FetchCall } from '../../test-utils/fetch-mock';
 
 type SubscribeToNewsletterModule = typeof subscribeToNewsletterModule;
 type CleverreachModule = typeof cleverreachModule;
+type NewsletterErrorState = Extract<
+	subscribeToNewsletterModule.NewsletterFormState,
+	{ success: false }
+>;
 
 // `getRequestMetadata` in `subscribe-to-newsletter.ts` reads the referer, user agent and
 // `x-forwarded-for` headers through `await headers()`, so `next/headers` has to be mocked. The
@@ -53,6 +57,13 @@ describe('validating the submitted email before contacting cleverreach', () => {
 		vi.restoreAllMocks();
 	});
 
+	// `subscriberSchema` in `src/lib/cleverreach.ts` defines the field as
+	// `z.email('Invalid email address')`, so this is the exact message `treeifyError` puts under
+	// `properties.email.errors[0]` for both a missing and a malformed email. Hard-coded here rather
+	// than imported, per the "never derive an expected value from a constant the implementation also
+	// imports" rule.
+	const EXPECTED_FIELD_ERROR = 'Invalid email address';
+
 	it('returns the validation error state when the email field is missing, without any fetch', async () => {
 		mock = createFetchMock();
 		const { subscribeToNewsletter } = await loadWithEnv<SubscribeToNewsletterModule>(
@@ -63,7 +74,7 @@ describe('validating the submitted email before contacting cleverreach', () => {
 		const result = await subscribeToNewsletter(null, new FormData());
 
 		expect(result).toStrictEqual({
-			error: undefined,
+			error: EXPECTED_FIELD_ERROR,
 			message: 'Bitte überprüfe Deine Eingaben.',
 			success: false,
 			title: 'Fehler',
@@ -81,12 +92,34 @@ describe('validating the submitted email before contacting cleverreach', () => {
 		const result = await subscribeToNewsletter(null, emailFormData('not-an-email'));
 
 		expect(result).toStrictEqual({
-			error: undefined,
+			error: EXPECTED_FIELD_ERROR,
 			message: 'Bitte überprüfe Deine Eingaben.',
 			success: false,
 			title: 'Fehler',
 		});
 		expect(mock.calls).toStrictEqual([]);
+	});
+
+	// Regression case: `validateEmail` previously read `treeifyError(...).errors[0]` — the
+	// object-level issues array, which zod 4 leaves empty for a per-field issue like this one — so
+	// `error` was always `undefined`. An exact-message assertion alone would not have caught that
+	// (a `toStrictEqual` with `error: undefined` passes just as well as one with the real string), so
+	// this asserts the shape of the defect directly: a non-empty string, regardless of its content.
+	it('returns a non-empty error string for an invalid email address', async () => {
+		mock = createFetchMock();
+		const { subscribeToNewsletter } = await loadWithEnv<SubscribeToNewsletterModule>(
+			'@/actions/subscribe-to-newsletter',
+			CLEVERREACH_ENV,
+		);
+
+		const result = await subscribeToNewsletter(null, emailFormData('not-an-email'));
+		// `result.success` is `false` for this input, established by the exact-message test above;
+		// narrowing to the error branch here (rather than a conditional) keeps `.error` typed as
+		// `string` for the two assertions below.
+		const errorState = result as NewsletterErrorState;
+
+		expect(errorState.error).toBeTypeOf('string');
+		expect(errorState.error.length).toBeGreaterThan(0);
 	});
 });
 

--- a/apps/web/src/actions/subscribe-to-newsletter.ts
+++ b/apps/web/src/actions/subscribe-to-newsletter.ts
@@ -18,7 +18,7 @@ function validateEmail(formData: FormData): { error: string } | { email: string 
 
 	if (!validation.success) {
 		const fieldErrors = treeifyError(validation.error);
-		return { error: fieldErrors.errors[0] };
+		return { error: fieldErrors.properties?.email?.errors[0] ?? 'Invalid email address' };
 	}
 
 	return { email: validation.data.email };

--- a/apps/web/src/actions/upload-to-linear.test.ts
+++ b/apps/web/src/actions/upload-to-linear.test.ts
@@ -23,10 +23,17 @@ const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
 // message first via `console.error('Action error:', e.message)`.
 const GENERIC_SERVER_ERROR = 'Something went wrong while executing the operation.';
 
-/** A `File` whose `size` getter is overridden, so a >10MB fixture never allocates real bytes. */
-class OversizedFile extends File {
+/** A `File` whose `size` getter is overridden to a fixed value, so a large fixture never allocates real bytes. */
+class SizedFile extends File {
+	readonly #fixedSize: number;
+
+	public constructor(filename: string, type: string, fixedSize: number) {
+		super([], filename, { type });
+		this.#fixedSize = fixedSize;
+	}
+
 	public override get size(): number {
-		return MAX_FILE_SIZE_BYTES + 1;
+		return this.#fixedSize;
 	}
 }
 
@@ -81,7 +88,7 @@ describe('validating the uploaded file', () => {
 			LINEAR_ENV,
 		);
 
-		const file = new OversizedFile([], 'huge.png', { type: 'image/png' });
+		const file = new SizedFile('huge.png', 'image/png', MAX_FILE_SIZE_BYTES + 1);
 		const result = await uploadToLinear({ file });
 
 		expect(result).toStrictEqual({
@@ -90,6 +97,33 @@ describe('validating the uploaded file', () => {
 			},
 		});
 		expect(mock.calls).toStrictEqual([]);
+	});
+
+	it('accepts a file exactly at the 10MB limit, reaching the linear api', async () => {
+		mock = createFetchMock();
+		const { uploadToLinear } = await loadWithEnv<UploadToLinearModule>(
+			'@/actions/upload-to-linear',
+			LINEAR_ENV,
+		);
+		mock.enqueueJson({
+			data: {
+				fileUpload: {
+					success: true,
+					uploadFile: {
+						assetUrl: 'https://uploads.linear.app/asset-1',
+						headers: [],
+						uploadUrl: 'https://uploads.linear.app/put-url',
+					},
+				},
+			},
+		});
+		mock.enqueue({ body: '', status: 200 });
+
+		const file = new SizedFile('limit.png', 'image/png', MAX_FILE_SIZE_BYTES);
+		const result = await uploadToLinear({ file });
+
+		expect(result).toStrictEqual({ data: { assetUrl: 'https://uploads.linear.app/asset-1' } });
+		expect(mock.unqueued).toStrictEqual([]);
 	});
 
 	it.each(ALLOWED_TYPES)('accepts a %s file, reaching the linear api', async (type) => {
@@ -114,7 +148,7 @@ describe('validating the uploaded file', () => {
 
 		const result = await uploadToLinear({ file: imageFile([1, 2, 3], type) });
 
-		expect(result.validationErrors).toBeUndefined();
+		expect(result).toStrictEqual({ data: { assetUrl: 'https://uploads.linear.app/asset-1' } });
 		expect(mock.unqueued).toStrictEqual([]);
 	});
 });

--- a/apps/web/src/actions/upload-to-linear.test.ts
+++ b/apps/web/src/actions/upload-to-linear.test.ts
@@ -166,6 +166,7 @@ describe('completing an upload to linear', () => {
 			method: 'POST',
 			url: LINEAR_API_URL,
 		});
+		expect(mock.unqueued).toStrictEqual([]);
 	});
 
 	it('puts the file bytes to the returned upload url, merging linear headers over content-type', async () => {

--- a/apps/web/src/actions/upload-to-linear.test.ts
+++ b/apps/web/src/actions/upload-to-linear.test.ts
@@ -1,0 +1,316 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type * as uploadToLinearModule from '@/actions/upload-to-linear';
+
+import { loadWithEnv } from '../../test-utils/env';
+import { createFetchMock, type FetchCall } from '../../test-utils/fetch-mock';
+
+type UploadToLinearModule = typeof uploadToLinearModule;
+
+const LINEAR_ENV = { LINEAR_API_KEY: 'test-api-key' };
+
+const LINEAR_API_URL = 'https://api.linear.app/graphql';
+
+// Matches `ALLOWED_TYPES` in `upload-to-linear.ts` — kept as a literal here rather than imported,
+// since that constant is not exported.
+const ALLOWED_TYPES = ['image/png', 'image/jpeg', 'image/gif', 'image/webp'];
+
+// Matches `MAX_FILE_SIZE` in `upload-to-linear.ts` (10MB), likewise kept as a literal.
+const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
+
+// `next-safe-action`'s default `handleServerError` (see `create-linear-issue.test.ts` for the full
+// citation) masks every thrown `Error` behind this fixed message in the envelope, logging the real
+// message first via `console.error('Action error:', e.message)`.
+const GENERIC_SERVER_ERROR = 'Something went wrong while executing the operation.';
+
+/** A `File` whose `size` getter is overridden, so a >10MB fixture never allocates real bytes. */
+class OversizedFile extends File {
+	public override get size(): number {
+		return MAX_FILE_SIZE_BYTES + 1;
+	}
+}
+
+function imageFile(bytes: number[], type = 'image/png', name = 'photo.png'): File {
+	return new File([new Uint8Array(bytes)], name, { type });
+}
+
+/**
+ * Parses a recorded fetch call's JSON body as the Linear GraphQL request it is expected to be.
+ *
+ * @param call - The recorded fetch call to read the body from.
+ * @returns The parsed `{ query, variables }` payload.
+ */
+function parseGraphqlBody(call: FetchCall): { query: string; variables: Record<string, unknown> } {
+	if (!call.body) {
+		throw new Error(`Expected a JSON string body for ${call.url}`);
+	}
+	// oxlint-disable-next-line typescript/no-unsafe-type-assertion -- `JSON.parse` widens to `any`
+	// here, so this narrows a JSON body this test file itself constructed, not an external payload.
+	return JSON.parse(call.body) as { query: string; variables: Record<string, unknown> };
+}
+
+describe('validating the uploaded file', () => {
+	let mock: ReturnType<typeof createFetchMock> | undefined;
+
+	afterEach(() => {
+		mock?.restore();
+		vi.restoreAllMocks();
+	});
+
+	it('rejects a non-image file type without any fetch', async () => {
+		mock = createFetchMock();
+		const { uploadToLinear } = await loadWithEnv<UploadToLinearModule>(
+			'@/actions/upload-to-linear',
+			LINEAR_ENV,
+		);
+
+		const result = await uploadToLinear({ file: imageFile([1, 2, 3], 'text/plain', 'notes.txt') });
+
+		expect(result).toStrictEqual({
+			validationErrors: {
+				file: { _errors: ['Invalid file type. Only images are allowed.'] },
+			},
+		});
+		expect(mock.calls).toStrictEqual([]);
+	});
+
+	it('rejects a file over the 10MB limit without any fetch', async () => {
+		mock = createFetchMock();
+		const { uploadToLinear } = await loadWithEnv<UploadToLinearModule>(
+			'@/actions/upload-to-linear',
+			LINEAR_ENV,
+		);
+
+		const file = new OversizedFile([], 'huge.png', { type: 'image/png' });
+		const result = await uploadToLinear({ file });
+
+		expect(result).toStrictEqual({
+			validationErrors: {
+				file: { _errors: ['File too large. Maximum size is 10MB.'] },
+			},
+		});
+		expect(mock.calls).toStrictEqual([]);
+	});
+
+	it.each(ALLOWED_TYPES)('accepts a %s file, reaching the linear api', async (type) => {
+		mock = createFetchMock();
+		const { uploadToLinear } = await loadWithEnv<UploadToLinearModule>(
+			'@/actions/upload-to-linear',
+			LINEAR_ENV,
+		);
+		mock.enqueueJson({
+			data: {
+				fileUpload: {
+					success: true,
+					uploadFile: {
+						assetUrl: 'https://uploads.linear.app/asset-1',
+						headers: [],
+						uploadUrl: 'https://uploads.linear.app/put-url',
+					},
+				},
+			},
+		});
+		mock.enqueue({ body: '', status: 200 });
+
+		const result = await uploadToLinear({ file: imageFile([1, 2, 3], type) });
+
+		expect(result.validationErrors).toBeUndefined();
+		expect(mock.unqueued).toStrictEqual([]);
+	});
+});
+
+describe('completing an upload to linear', () => {
+	let mock: ReturnType<typeof createFetchMock> | undefined;
+
+	afterEach(() => {
+		mock?.restore();
+		vi.restoreAllMocks();
+	});
+
+	it('requests an upload url via the graphql mutation, authenticated with the linear api key', async () => {
+		mock = createFetchMock();
+		const { uploadToLinear } = await loadWithEnv<UploadToLinearModule>(
+			'@/actions/upload-to-linear',
+			LINEAR_ENV,
+		);
+		mock.enqueueJson({
+			data: {
+				fileUpload: {
+					success: true,
+					uploadFile: {
+						assetUrl: 'https://uploads.linear.app/asset-1',
+						headers: [{ key: 'x-goog-meta-source', value: 'tsg-website' }],
+						uploadUrl: 'https://uploads.linear.app/put-url',
+					},
+				},
+			},
+		});
+		mock.enqueue({ body: '', status: 200 });
+
+		const result = await uploadToLinear({
+			file: imageFile([1, 2, 3, 4], 'image/png', 'photo.png'),
+		});
+
+		expect(result).toStrictEqual({ data: { assetUrl: 'https://uploads.linear.app/asset-1' } });
+
+		const { variables } = parseGraphqlBody(mock.calls[0]);
+		expect(variables).toStrictEqual({ contentType: 'image/png', filename: 'photo.png', size: 4 });
+		expect({
+			authorization: mock.calls[0].headers.authorization,
+			contentType: mock.calls[0].headers['content-type'],
+			method: mock.calls[0].method,
+			url: mock.calls[0].url,
+		}).toStrictEqual({
+			authorization: 'test-api-key',
+			contentType: 'application/json',
+			method: 'POST',
+			url: LINEAR_API_URL,
+		});
+	});
+
+	it('puts the file bytes to the returned upload url, merging linear headers over content-type', async () => {
+		mock = createFetchMock();
+		const { uploadToLinear } = await loadWithEnv<UploadToLinearModule>(
+			'@/actions/upload-to-linear',
+			LINEAR_ENV,
+		);
+		mock.enqueueJson({
+			data: {
+				fileUpload: {
+					success: true,
+					uploadFile: {
+						assetUrl: 'https://uploads.linear.app/asset-1',
+						headers: [{ key: 'x-goog-meta-source', value: 'tsg-website' }],
+						uploadUrl: 'https://uploads.linear.app/put-url',
+					},
+				},
+			},
+		});
+		mock.enqueue({ body: '', status: 200 });
+
+		await uploadToLinear({ file: imageFile([1, 2, 3, 4], 'image/png', 'photo.png') });
+
+		expect(mock.calls).toHaveLength(2);
+		expect({
+			contentType: mock.calls[1].headers['content-type'],
+			method: mock.calls[1].method,
+			sourceHeader: mock.calls[1].headers['x-goog-meta-source'],
+			url: mock.calls[1].url,
+		}).toStrictEqual({
+			contentType: 'image/png',
+			method: 'PUT',
+			sourceHeader: 'tsg-website',
+			url: 'https://uploads.linear.app/put-url',
+		});
+		expect(mock.calls[1].bodyBytes).toStrictEqual(new Uint8Array([1, 2, 3, 4]));
+		expect(mock.unqueued).toStrictEqual([]);
+	});
+
+	it("overrides the file's content-type when linear returns its own Content-Type header", async () => {
+		mock = createFetchMock();
+		const { uploadToLinear } = await loadWithEnv<UploadToLinearModule>(
+			'@/actions/upload-to-linear',
+			LINEAR_ENV,
+		);
+		mock.enqueueJson({
+			data: {
+				fileUpload: {
+					success: true,
+					uploadFile: {
+						assetUrl: 'https://uploads.linear.app/asset-1',
+						headers: [{ key: 'Content-Type', value: 'application/vnd.linear.custom' }],
+						uploadUrl: 'https://uploads.linear.app/put-url',
+					},
+				},
+			},
+		});
+		mock.enqueue({ body: '', status: 200 });
+
+		await uploadToLinear({ file: imageFile([1, 2, 3], 'image/png', 'photo.png') });
+
+		expect(mock.calls[1].headers['content-type']).toBe('application/vnd.linear.custom');
+		expect(mock.unqueued).toStrictEqual([]);
+	});
+});
+
+describe('surfacing an upload failure', () => {
+	let mock: ReturnType<typeof createFetchMock> | undefined;
+
+	afterEach(() => {
+		mock?.restore();
+		vi.restoreAllMocks();
+	});
+
+	it('surfaces "Failed to get upload URL: <status> - ..." when uploadFile is missing, masked behind the generic envelope', async () => {
+		mock = createFetchMock();
+		const { uploadToLinear } = await loadWithEnv<UploadToLinearModule>(
+			'@/actions/upload-to-linear',
+			LINEAR_ENV,
+		);
+		const errorSpy = vi.spyOn(console, 'error').mockReturnValue();
+
+		mock.enqueueJson({ data: { fileUpload: { success: true, uploadFile: null } } });
+
+		const result = await uploadToLinear({ file: imageFile([1, 2, 3]) });
+
+		expect(result).toStrictEqual({ serverError: GENERIC_SERVER_ERROR });
+		expect(errorSpy).toHaveBeenCalledWith('Linear fileUpload error:', undefined);
+		expect(errorSpy).toHaveBeenCalledWith(
+			'Action error:',
+			expect.stringContaining('Failed to get upload URL: 200 - '),
+		);
+		expect(mock.unqueued).toStrictEqual([]);
+	});
+
+	it('surfaces the same failure for a graphql errors array, after logging it', async () => {
+		mock = createFetchMock();
+		const { uploadToLinear } = await loadWithEnv<UploadToLinearModule>(
+			'@/actions/upload-to-linear',
+			LINEAR_ENV,
+		);
+		const errorSpy = vi.spyOn(console, 'error').mockReturnValue();
+
+		mock.enqueueJson({ errors: [{ message: 'file size exceeds plan limit' }] });
+
+		const result = await uploadToLinear({ file: imageFile([1, 2, 3]) });
+
+		expect(result).toStrictEqual({ serverError: GENERIC_SERVER_ERROR });
+		expect(errorSpy).toHaveBeenCalledWith('Linear fileUpload error:', [
+			{ message: 'file size exceeds plan limit' },
+		]);
+		expect(errorSpy).toHaveBeenCalledWith(
+			'Action error:',
+			expect.stringContaining('Failed to get upload URL: 200 - '),
+		);
+		expect(mock.unqueued).toStrictEqual([]);
+	});
+
+	it('surfaces "Failed to upload file: <status>" when the storage put fails', async () => {
+		mock = createFetchMock();
+		const { uploadToLinear } = await loadWithEnv<UploadToLinearModule>(
+			'@/actions/upload-to-linear',
+			LINEAR_ENV,
+		);
+		const errorSpy = vi.spyOn(console, 'error').mockReturnValue();
+
+		mock.enqueueJson({
+			data: {
+				fileUpload: {
+					success: true,
+					uploadFile: {
+						assetUrl: 'https://uploads.linear.app/asset-1',
+						headers: [],
+						uploadUrl: 'https://uploads.linear.app/put-url',
+					},
+				},
+			},
+		});
+		mock.enqueue({ body: 'Bad Gateway', status: 502 });
+
+		const result = await uploadToLinear({ file: imageFile([1, 2, 3]) });
+
+		expect(result).toStrictEqual({ serverError: GENERIC_SERVER_ERROR });
+		expect(errorSpy).toHaveBeenCalledExactlyOnceWith('Action error:', 'Failed to upload file: 502');
+		expect(mock.unqueued).toStrictEqual([]);
+	});
+});

--- a/apps/web/src/lib/cleverreach.test.ts
+++ b/apps/web/src/lib/cleverreach.test.ts
@@ -150,6 +150,40 @@ describe('requesting the cleverreach access token', () => {
 		expect(mock.unqueued).toStrictEqual([]);
 	});
 
+	it('refetches the token exactly at the five-minute expiry boundary', async () => {
+		vi.useFakeTimers();
+		const start = new Date('2026-01-01T00:00:00.000Z');
+		vi.setSystemTime(start);
+
+		mock = createFetchMock();
+		const { subscribe } = await loadWithEnv<CleverreachModule>(
+			'@/lib/cleverreach',
+			CLEVERREACH_ENV,
+		);
+
+		mock.enqueueJson({ access_token: 'token-1', expires_in: 3600 });
+		mock.enqueueJson({});
+		mock.enqueueJson({});
+		await subscribe(SUBSCRIBER_INPUT);
+
+		// Advance to the exact instant where `now + FIVE_MINUTES === expiresAt`
+		// (expiresAt = start + 3_600_000ms). `cleverreach.ts`'s cache check is
+		// `tokenCache.expiresAt > Date.now() + FIVE_MINUTES`, a strict `>`, so at this exact boundary
+		// the comparison is false and the cache is treated as stale — a mutation to `>=` would keep the
+		// cached token here instead, dropping the second token call below to one.
+		vi.setSystemTime(new Date(start.getTime() + 3_600_000 - FIVE_MINUTE_BUFFER_MS));
+
+		mock.enqueueJson({ access_token: 'token-2', expires_in: 3600 });
+		mock.enqueueJson({});
+		mock.enqueueJson({});
+		await subscribe(SUBSCRIBER_INPUT);
+
+		const tokenCalls = mock.calls.filter((call) => call.url.endsWith('oauth/token.php'));
+
+		expect(tokenCalls).toHaveLength(2);
+		expect(mock.unqueued).toStrictEqual([]);
+	});
+
 	it('returns INTERNAL_ERROR and logs the failure when the token response is not ok', async () => {
 		const errorSpy = vi.spyOn(console, 'error').mockReturnValue();
 		mock = createFetchMock();

--- a/apps/web/src/lib/cleverreach.test.ts
+++ b/apps/web/src/lib/cleverreach.test.ts
@@ -49,14 +49,14 @@ describe('requesting the cleverreach access token', () => {
 		expect(tokenCall.url).toBe('https://rest.cleverreach.com/oauth/token.php');
 		expect(tokenCall.method).toBe('POST');
 		expect(tokenCall.headers['content-type']).toBe('application/x-www-form-urlencoded');
-		// `cleverreach.ts` sends `body: new URLSearchParams({...})`, not a string. `createFetchMock`
-		// only records a call's body when `typeof init.body === 'string'` (see
-		// `apps/web/test-utils/fetch-mock.ts`), so `tokenCall.body` is `undefined` here even though
-		// a real `fetch` would serialize the `URLSearchParams` to
-		// `client_id=...&client_secret=...&grant_type=client_credentials`. The request content
-		// itself cannot be asserted through this mock's public `calls` interface for this call; see
-		// the task report for this finding.
-		expect(tokenCall.body).toBeUndefined();
+		// `tokenCall.body` is the `URLSearchParams`, serialized to text by the fetch mock (see
+		// `resolveBody` in `apps/web/test-utils/fetch-mock.ts`); parse it back to assert every field
+		// in one call rather than three separate `toContain` checks.
+		expect(Object.fromEntries(new URLSearchParams(tokenCall.body))).toStrictEqual({
+			client_id: 'test-client-id',
+			client_secret: 'test-client-secret',
+			grant_type: 'client_credentials',
+		});
 		expect(mock.unqueued).toStrictEqual([]);
 	});
 

--- a/apps/web/src/lib/cleverreach.test.ts
+++ b/apps/web/src/lib/cleverreach.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type * as cleverreachModule from '@/lib/cleverreach';
+
+import { loadWithEnv } from '../../test-utils/env';
+import { createFetchMock } from '../../test-utils/fetch-mock';
+
+type CleverreachModule = typeof cleverreachModule;
+
+const CLEVERREACH_ENV = {
+	CLEVERREACH_CLIENT_ID: 'test-client-id',
+	CLEVERREACH_CLIENT_SECRET: 'test-client-secret',
+	CLEVERREACH_FORM_ID: 'test-form-id',
+	CLEVERREACH_LIST_ID: 'test-list-id',
+};
+
+const SUBSCRIBER_INPUT = { email: 'person@example.com' };
+
+// `cleverreach.ts` computes `FIVE_MINUTES` as `timeSpanInMilliSeconds('minute') * 5`. Read from
+// `packages/shared/src/utils/date.ts`, `timeSpanInMilliSeconds('minute')` is `60_000`, so the
+// buffer is `300_000` ms. Hard-coded here rather than imported, per the "never build an expected
+// value from a constant the implementation also imports" rule.
+const FIVE_MINUTE_BUFFER_MS = 300_000;
+
+describe('requesting the cleverreach access token', () => {
+	let mock: ReturnType<typeof createFetchMock> | undefined;
+
+	afterEach(() => {
+		mock?.restore();
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+	});
+
+	it('requests the token first, with client credentials in a form-encoded body', async () => {
+		mock = createFetchMock();
+		const { subscribe } = await loadWithEnv<CleverreachModule>(
+			'@/lib/cleverreach',
+			CLEVERREACH_ENV,
+		);
+
+		mock.enqueueJson({ access_token: 'token-abc', expires_in: 3600 });
+		mock.enqueueJson({});
+		mock.enqueueJson({});
+
+		await subscribe(SUBSCRIBER_INPUT);
+
+		const tokenCall = mock.calls[0];
+
+		expect(tokenCall.url).toBe('https://rest.cleverreach.com/oauth/token.php');
+		expect(tokenCall.method).toBe('POST');
+		expect(tokenCall.headers['content-type']).toBe('application/x-www-form-urlencoded');
+		// `cleverreach.ts` sends `body: new URLSearchParams({...})`, not a string. `createFetchMock`
+		// only records a call's body when `typeof init.body === 'string'` (see
+		// `apps/web/test-utils/fetch-mock.ts`), so `tokenCall.body` is `undefined` here even though
+		// a real `fetch` would serialize the `URLSearchParams` to
+		// `client_id=...&client_secret=...&grant_type=client_credentials`. The request content
+		// itself cannot be asserted through this mock's public `calls` interface for this call; see
+		// the task report for this finding.
+		expect(tokenCall.body).toBeUndefined();
+		expect(mock.unqueued).toStrictEqual([]);
+	});
+
+	it('reuses a cached token across a second subscribe call', async () => {
+		mock = createFetchMock();
+		const { subscribe } = await loadWithEnv<CleverreachModule>(
+			'@/lib/cleverreach',
+			CLEVERREACH_ENV,
+		);
+
+		mock.enqueueJson({ access_token: 'token-abc', expires_in: 3600 });
+		mock.enqueueJson({});
+		mock.enqueueJson({});
+		mock.enqueueJson({});
+		mock.enqueueJson({});
+
+		await subscribe(SUBSCRIBER_INPUT);
+		await subscribe(SUBSCRIBER_INPUT);
+
+		const tokenCalls = mock.calls.filter((call) => call.url.endsWith('oauth/token.php'));
+
+		expect(tokenCalls).toHaveLength(1);
+		expect(mock.calls).toHaveLength(5);
+		expect(mock.unqueued).toStrictEqual([]);
+	});
+
+	it('refetches the token once it is within the five-minute expiry buffer', async () => {
+		vi.useFakeTimers();
+		const start = new Date('2026-01-01T00:00:00.000Z');
+		vi.setSystemTime(start);
+
+		mock = createFetchMock();
+		const { subscribe } = await loadWithEnv<CleverreachModule>(
+			'@/lib/cleverreach',
+			CLEVERREACH_ENV,
+		);
+
+		mock.enqueueJson({ access_token: 'token-1', expires_in: 3600 });
+		mock.enqueueJson({});
+		mock.enqueueJson({});
+		await subscribe(SUBSCRIBER_INPUT);
+
+		// expires_in (3600s = 3_600_000ms) minus the five-minute buffer leaves the token valid for
+		// 3_300_000ms; advance one millisecond past that so the cache is no longer considered fresh.
+		vi.setSystemTime(new Date(start.getTime() + 3_600_000 - FIVE_MINUTE_BUFFER_MS + 1));
+
+		mock.enqueueJson({ access_token: 'token-2', expires_in: 3600 });
+		mock.enqueueJson({});
+		mock.enqueueJson({});
+		await subscribe(SUBSCRIBER_INPUT);
+
+		const tokenCalls = mock.calls.filter((call) => call.url.endsWith('oauth/token.php'));
+
+		expect(tokenCalls).toHaveLength(2);
+		expect(mock.unqueued).toStrictEqual([]);
+	});
+
+	it('returns INTERNAL_ERROR and logs the failure when the token response is not ok', async () => {
+		const errorSpy = vi.spyOn(console, 'error').mockReturnValue();
+		mock = createFetchMock();
+		const { subscribe } = await loadWithEnv<CleverreachModule>(
+			'@/lib/cleverreach',
+			CLEVERREACH_ENV,
+		);
+
+		mock.enqueue({ body: 'invalid_client', status: 401 });
+
+		const result = await subscribe(SUBSCRIBER_INPUT);
+
+		expect(result.success).toBe(false);
+		expect(result).toMatchObject({
+			code: 'INTERNAL_ERROR',
+			error: 'An unexpected error occurred. Please try again later.',
+		});
+		expect(errorSpy).toHaveBeenCalledWith(
+			'CleverReach subscription error:',
+			expect.objectContaining({
+				message: 'CleverReach authentication failed: invalid_client',
+			}),
+		);
+		expect(mock.unqueued).toStrictEqual([]);
+	});
+
+	it('returns INTERNAL_ERROR when the token payload fails accessTokenSchema', async () => {
+		const errorSpy = vi.spyOn(console, 'error').mockReturnValue();
+		mock = createFetchMock();
+		const { subscribe } = await loadWithEnv<CleverreachModule>(
+			'@/lib/cleverreach',
+			CLEVERREACH_ENV,
+		);
+
+		// expires_in must be a number; a string fails accessTokenSchema's parse.
+		mock.enqueueJson({ access_token: 'token-abc', expires_in: '3600' });
+
+		const result = await subscribe(SUBSCRIBER_INPUT);
+
+		expect(result.success).toBe(false);
+		expect(result).toMatchObject({
+			code: 'INTERNAL_ERROR',
+			error: 'An unexpected error occurred. Please try again later.',
+		});
+		expect(errorSpy).toHaveBeenCalledWith('CleverReach subscription error:', expect.anything());
+		expect(mock.unqueued).toStrictEqual([]);
+	});
+});

--- a/apps/web/src/lib/cleverreach.test.ts
+++ b/apps/web/src/lib/cleverreach.test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import type * as cleverreachModule from '@/lib/cleverreach';
 
 import { loadWithEnv } from '../../test-utils/env';
-import { createFetchMock } from '../../test-utils/fetch-mock';
+import { createFetchMock, type FetchCall } from '../../test-utils/fetch-mock';
 
 type CleverreachModule = typeof cleverreachModule;
 
@@ -21,6 +21,42 @@ const SUBSCRIBER_INPUT = { email: 'person@example.com' };
 // buffer is `300_000` ms. Hard-coded here rather than imported, per the "never build an expected
 // value from a constant the implementation also imports" rule.
 const FIVE_MINUTE_BUFFER_MS = 300_000;
+
+// `subscriberSchema.safeParse` (zod 4) formats a failed `z.email()` check as this JSON array —
+// built here from a hard-coded object rather than by importing `subscriberSchema` and parsing
+// with it, per the "never derive an expected value from a constant the implementation also
+// imports" rule. Key order matters: it must match zod's own issue shape (origin, code, format,
+// pattern, path, message) since this is compared as a raw string, not a parsed object.
+const EXPECTED_VALIDATION_ERROR_MESSAGE = JSON.stringify(
+	[
+		{
+			origin: 'string',
+			code: 'invalid_format',
+			format: 'email',
+			pattern:
+				"/^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$/",
+			path: ['email'],
+			message: 'Invalid email address',
+		},
+	],
+	null,
+	2,
+);
+
+/**
+ * Parses a recorded fetch call's JSON body. Kept as a top-level helper (rather than an inline
+ * `call.body ?? ''` in each assertion) so no test body contains a conditional — the oxlint
+ * `vitest/no-conditional-in-test` rule flags `??`/`?.` inside `it(...)` callbacks.
+ *
+ * @param call - The recorded fetch call to read the body from.
+ * @returns The parsed JSON body.
+ */
+function parseJsonBody(call: FetchCall): unknown {
+	if (!call.body) {
+		throw new Error(`Expected a JSON string body for ${call.url}`);
+	}
+	return JSON.parse(call.body);
+}
 
 describe('requesting the cleverreach access token', () => {
 	let mock: ReturnType<typeof createFetchMock> | undefined;
@@ -159,6 +195,368 @@ describe('requesting the cleverreach access token', () => {
 			error: 'An unexpected error occurred. Please try again later.',
 		});
 		expect(errorSpy).toHaveBeenCalledWith('CleverReach subscription error:', expect.anything());
+		expect(mock.unqueued).toStrictEqual([]);
+	});
+});
+
+describe('adding a subscriber to the list', () => {
+	let mock: ReturnType<typeof createFetchMock> | undefined;
+
+	afterEach(() => {
+		mock?.restore();
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+	});
+
+	it('adds the receiver with a bearer token and a registered timestamp', async () => {
+		vi.useFakeTimers();
+		const now = new Date('2026-03-01T12:00:00.000Z');
+		vi.setSystemTime(now);
+
+		mock = createFetchMock();
+		const { subscribe } = await loadWithEnv<CleverreachModule>(
+			'@/lib/cleverreach',
+			CLEVERREACH_ENV,
+		);
+
+		mock.enqueueJson({ access_token: 'token-abc', expires_in: 3600 });
+		mock.enqueueJson({});
+		mock.enqueueJson({});
+
+		await subscribe(SUBSCRIBER_INPUT);
+
+		const receiverCall = mock.calls[1];
+
+		expect({
+			authorization: receiverCall.headers.authorization,
+			contentType: receiverCall.headers['content-type'],
+			method: receiverCall.method,
+			url: receiverCall.url,
+		}).toStrictEqual({
+			authorization: 'Bearer token-abc',
+			contentType: 'application/json',
+			method: 'POST',
+			url: 'https://rest.cleverreach.com/v3/groups.json/test-list-id/receivers',
+		});
+		expect(parseJsonBody(receiverCall)).toStrictEqual({
+			activated: 0,
+			email: 'person@example.com',
+			registered: Math.floor(now.getTime() / 1000),
+			source: 'Next.js Website',
+		});
+		expect(mock.unqueued).toStrictEqual([]);
+	});
+
+	it('returns ALREADY_SUBSCRIBED on a 409 without sending the DOI mail', async () => {
+		mock = createFetchMock();
+		const { subscribe } = await loadWithEnv<CleverreachModule>(
+			'@/lib/cleverreach',
+			CLEVERREACH_ENV,
+		);
+
+		mock.enqueueJson({ access_token: 'token-abc', expires_in: 3600 });
+		mock.enqueue({ body: JSON.stringify({}), status: 409 });
+
+		const result = await subscribe(SUBSCRIBER_INPUT);
+
+		expect(result).toStrictEqual({
+			code: 'ALREADY_SUBSCRIBED',
+			error: 'This email is already subscribed',
+			success: false,
+		});
+		expect(mock.calls).toHaveLength(2);
+		expect(mock.unqueued).toStrictEqual([]);
+	});
+
+	it('passes through the error code and message from the API response body', async () => {
+		mock = createFetchMock();
+		const { subscribe } = await loadWithEnv<CleverreachModule>(
+			'@/lib/cleverreach',
+			CLEVERREACH_ENV,
+		);
+
+		mock.enqueueJson({ access_token: 'token-abc', expires_in: 3600 });
+		mock.enqueue({
+			body: JSON.stringify({ error: { code: 1004, message: 'Custom failure message' } }),
+			status: 400,
+		});
+
+		const result = await subscribe(SUBSCRIBER_INPUT);
+
+		expect(result).toStrictEqual({
+			code: '1004',
+			error: 'Custom failure message',
+			success: false,
+		});
+		expect(mock.calls).toHaveLength(2);
+		expect(mock.unqueued).toStrictEqual([]);
+	});
+
+	it('falls back to the default error message when the error body is not JSON', async () => {
+		mock = createFetchMock();
+		const { subscribe } = await loadWithEnv<CleverreachModule>(
+			'@/lib/cleverreach',
+			CLEVERREACH_ENV,
+		);
+
+		mock.enqueueJson({ access_token: 'token-abc', expires_in: 3600 });
+		mock.enqueue({ body: 'not json', status: 500 });
+
+		const result = await subscribe(SUBSCRIBER_INPUT);
+
+		expect(result).toStrictEqual({
+			code: undefined,
+			error: 'Failed to add subscriber',
+			success: false,
+		});
+		expect(mock.calls).toHaveLength(2);
+		expect(mock.unqueued).toStrictEqual([]);
+	});
+});
+
+describe('sending the double opt-in email', () => {
+	let mock: ReturnType<typeof createFetchMock> | undefined;
+
+	afterEach(() => {
+		mock?.restore();
+		vi.restoreAllMocks();
+	});
+
+	it('sends the DOI mail with the group id and the provided metadata', async () => {
+		mock = createFetchMock();
+		const { subscribe } = await loadWithEnv<CleverreachModule>(
+			'@/lib/cleverreach',
+			CLEVERREACH_ENV,
+		);
+
+		mock.enqueueJson({ access_token: 'token-abc', expires_in: 3600 });
+		mock.enqueueJson({});
+		mock.enqueueJson({});
+
+		await subscribe(SUBSCRIBER_INPUT, {
+			referer: 'https://example.com/newsletter',
+			userAgent: 'TestAgent/1.0',
+			userIp: '203.0.113.5',
+		});
+
+		const doiCall = mock.calls[2];
+
+		expect({
+			authorization: doiCall.headers.authorization,
+			contentType: doiCall.headers['content-type'],
+			method: doiCall.method,
+			url: doiCall.url,
+		}).toStrictEqual({
+			authorization: 'Bearer token-abc',
+			contentType: 'application/json',
+			method: 'POST',
+			url: 'https://rest.cleverreach.com/v3/forms.json/test-form-id/send/activate',
+		});
+		expect(parseJsonBody(doiCall)).toStrictEqual({
+			doidata: {
+				referer: 'https://example.com/newsletter',
+				user_agent: 'TestAgent/1.0',
+				user_ip: '203.0.113.5',
+			},
+			email: 'person@example.com',
+			groups_ids: ['test-list-id'],
+		});
+		expect(mock.unqueued).toStrictEqual([]);
+	});
+
+	it('keeps the subscription successful and logs when the DOI mail fails to send', async () => {
+		const errorSpy = vi.spyOn(console, 'error').mockReturnValue();
+		mock = createFetchMock();
+		const { subscribe } = await loadWithEnv<CleverreachModule>(
+			'@/lib/cleverreach',
+			CLEVERREACH_ENV,
+		);
+
+		mock.enqueueJson({ access_token: 'token-abc', expires_in: 3600 });
+		mock.enqueueJson({});
+		mock.enqueue({ body: 'DOI backend unavailable', status: 502 });
+
+		const result = await subscribe(SUBSCRIBER_INPUT);
+
+		expect(result).toStrictEqual({
+			message: 'Please check your email to confirm your subscription',
+			success: true,
+		});
+		expect(errorSpy).toHaveBeenCalledWith(
+			'Failed to send DOI email, but receiver was added:',
+			'DOI backend unavailable',
+		);
+		expect(mock.unqueued).toStrictEqual([]);
+	});
+});
+
+describe('resolving the double opt-in metadata', () => {
+	let mock: ReturnType<typeof createFetchMock> | undefined;
+
+	afterEach(() => {
+		mock?.restore();
+		vi.restoreAllMocks();
+	});
+
+	it('uses explicit metadata over every default', async () => {
+		mock = createFetchMock();
+		const { subscribe } = await loadWithEnv<CleverreachModule>('@/lib/cleverreach', {
+			...CLEVERREACH_ENV,
+			VERCEL_PROJECT_PRODUCTION_URL: 'tsg-irlich.vercel.app',
+		});
+
+		mock.enqueueJson({ access_token: 'token-abc', expires_in: 3600 });
+		mock.enqueueJson({});
+		mock.enqueueJson({});
+
+		await subscribe(SUBSCRIBER_INPUT, {
+			referer: 'https://custom.example/referrer',
+			userAgent: 'CustomAgent/9.0',
+			userIp: '198.51.100.7',
+		});
+
+		expect(parseJsonBody(mock.calls[2])).toStrictEqual({
+			doidata: {
+				referer: 'https://custom.example/referrer',
+				user_agent: 'CustomAgent/9.0',
+				user_ip: '198.51.100.7',
+			},
+			email: 'person@example.com',
+			groups_ids: ['test-list-id'],
+		});
+		expect(mock.unqueued).toStrictEqual([]);
+	});
+
+	it('derives the referer from VERCEL_PROJECT_PRODUCTION_URL and falls back for agent and ip', async () => {
+		mock = createFetchMock();
+		const { subscribe } = await loadWithEnv<CleverreachModule>('@/lib/cleverreach', {
+			...CLEVERREACH_ENV,
+			VERCEL_PROJECT_PRODUCTION_URL: 'tsg-irlich.vercel.app',
+		});
+
+		mock.enqueueJson({ access_token: 'token-abc', expires_in: 3600 });
+		mock.enqueueJson({});
+		mock.enqueueJson({});
+
+		await subscribe(SUBSCRIBER_INPUT);
+
+		expect(parseJsonBody(mock.calls[2])).toStrictEqual({
+			doidata: {
+				referer: 'https://tsg-irlich.vercel.app',
+				user_agent: 'Mozilla/5.0',
+				user_ip: '0.0.0.0',
+			},
+			email: 'person@example.com',
+			groups_ids: ['test-list-id'],
+		});
+		expect(mock.unqueued).toStrictEqual([]);
+	});
+
+	it('leaves the referer empty when VERCEL_PROJECT_PRODUCTION_URL is unset', async () => {
+		mock = createFetchMock();
+		const { subscribe } = await loadWithEnv<CleverreachModule>('@/lib/cleverreach', {
+			...CLEVERREACH_ENV,
+			VERCEL_PROJECT_PRODUCTION_URL: undefined,
+		});
+
+		mock.enqueueJson({ access_token: 'token-abc', expires_in: 3600 });
+		mock.enqueueJson({});
+		mock.enqueueJson({});
+
+		await subscribe(SUBSCRIBER_INPUT);
+
+		expect(parseJsonBody(mock.calls[2])).toStrictEqual({
+			doidata: {
+				referer: '',
+				user_agent: 'Mozilla/5.0',
+				user_ip: '0.0.0.0',
+			},
+			email: 'person@example.com',
+			groups_ids: ['test-list-id'],
+		});
+		expect(mock.unqueued).toStrictEqual([]);
+	});
+});
+
+describe('validating and completing a subscription', () => {
+	let mock: ReturnType<typeof createFetchMock> | undefined;
+
+	afterEach(() => {
+		mock?.restore();
+		vi.restoreAllMocks();
+	});
+
+	it('returns VALIDATION_ERROR for an invalid email without making any request', async () => {
+		mock = createFetchMock();
+		const { subscribe } = await loadWithEnv<CleverreachModule>(
+			'@/lib/cleverreach',
+			CLEVERREACH_ENV,
+		);
+
+		const result = await subscribe({ email: 'not-an-email' });
+
+		expect(result).toStrictEqual({
+			code: 'VALIDATION_ERROR',
+			error: EXPECTED_VALIDATION_ERROR_MESSAGE,
+			success: false,
+		});
+		expect(mock.calls).toStrictEqual([]);
+		expect(mock.unqueued).toStrictEqual([]);
+	});
+
+	it('returns INTERNAL_ERROR when a request fails unexpectedly partway through the flow', async () => {
+		const errorSpy = vi.spyOn(console, 'error').mockReturnValue();
+		mock = createFetchMock();
+		const { subscribe } = await loadWithEnv<CleverreachModule>(
+			'@/lib/cleverreach',
+			CLEVERREACH_ENV,
+		);
+
+		// Only the token response is queued: the addReceiver call runs out of queue and the mock
+		// itself throws, exercising subscribe's own try/catch rather than a modeled API error. This
+		// is the one case in the file where a short queue is the point of the test, not a mistake —
+		// see the `unqueued` assertion below instead of the usual `toStrictEqual([])`.
+		mock.enqueueJson({ access_token: 'token-abc', expires_in: 3600 });
+
+		const result = await subscribe(SUBSCRIBER_INPUT);
+
+		expect(result).toStrictEqual({
+			code: 'INTERNAL_ERROR',
+			error: 'An unexpected error occurred. Please try again later.',
+			success: false,
+		});
+		expect(errorSpy).toHaveBeenCalledWith(
+			'CleverReach subscription error:',
+			expect.objectContaining({
+				message:
+					'No mock response queued for https://rest.cleverreach.com/v3/groups.json/test-list-id/receivers',
+			}),
+		);
+		expect(mock.unqueued).toHaveLength(1);
+	});
+
+	it('completes the subscription and hits the token, receiver and DOI endpoints in order', async () => {
+		mock = createFetchMock();
+		const { subscribe } = await loadWithEnv<CleverreachModule>(
+			'@/lib/cleverreach',
+			CLEVERREACH_ENV,
+		);
+
+		mock.enqueueJson({ access_token: 'token-abc', expires_in: 3600 });
+		mock.enqueueJson({});
+		mock.enqueueJson({});
+
+		const result = await subscribe(SUBSCRIBER_INPUT);
+
+		expect(result).toStrictEqual({
+			message: 'Please check your email to confirm your subscription',
+			success: true,
+		});
+		expect(mock.calls.map((call) => call.url)).toStrictEqual([
+			'https://rest.cleverreach.com/oauth/token.php',
+			'https://rest.cleverreach.com/v3/groups.json/test-list-id/receivers',
+			'https://rest.cleverreach.com/v3/forms.json/test-form-id/send/activate',
+		]);
 		expect(mock.unqueued).toStrictEqual([]);
 	});
 });

--- a/apps/web/test-utils/fetch-mock.ts
+++ b/apps/web/test-utils/fetch-mock.ts
@@ -2,6 +2,7 @@ import { vi } from 'vitest';
 
 interface FetchCall {
 	body: string | undefined;
+	bodyBytes: Uint8Array | undefined;
 	headers: Record<string, string>;
 	method: string;
 	url: string;
@@ -31,6 +32,44 @@ function resolveUrl(input: RequestInfo | URL): string {
 }
 
 /**
+ * Splits a `fetch` call's `body` init option into a text form and a binary form, mirroring how
+ * `Request` itself would serialize it.
+ *
+ * A plain `string` body (the common case — a `JSON.stringify(...)` payload) is recorded as-is. A
+ * `URLSearchParams` body (used for `application/x-www-form-urlencoded` requests) is text too, so
+ * it is recorded through `String(...)`, which serializes it the same way `fetch` would put it on
+ * the wire. An `ArrayBuffer` or `ArrayBufferView` body (used for binary uploads, for example a
+ * file's raw bytes) is recorded as a `Uint8Array` in `bodyBytes` instead, with `body` left
+ * `undefined`. Any other body type — a `Blob`, a `FormData`, a `ReadableStream` — leaves both
+ * `body` and `bodyBytes` `undefined`; extend this function if a test needs to see through one of
+ * those.
+ *
+ * @param body - The `body` init option a `fetch` call was made with.
+ * @returns The text and binary forms of the body, whichever one applies.
+ */
+function resolveBody(body: BodyInit | null | undefined): {
+	body: string | undefined;
+	bodyBytes: Uint8Array | undefined;
+} {
+	if (typeof body === 'string') {
+		return { body, bodyBytes: undefined };
+	}
+	if (body instanceof URLSearchParams) {
+		return { body: String(body), bodyBytes: undefined };
+	}
+	if (body instanceof ArrayBuffer) {
+		return { body: undefined, bodyBytes: new Uint8Array(body) };
+	}
+	if (ArrayBuffer.isView(body)) {
+		return {
+			body: undefined,
+			bodyBytes: new Uint8Array(body.buffer, body.byteOffset, body.byteLength),
+		};
+	}
+	return { body: undefined, bodyBytes: undefined };
+}
+
+/**
  * Replaces the global `fetch` with a queue of canned responses and records every request.
  *
  * Responses are handed out in the order they were enqueued, which keeps the tests of the multi
@@ -39,6 +78,9 @@ function resolveUrl(input: RequestInfo | URL): string {
  * Recorded `headers` are normalized through the `Headers` constructor, same as the real `fetch`
  * does, which lowercases every header name — assert against lowercase keys (`authorization`,
  * `content-type`), not the casing the code under test sent them with.
+ *
+ * Recorded `body`/`bodyBytes` split text bodies from binary ones — see `resolveBody`'s doc comment
+ * for exactly which body types land in which field, and which are not captured at all.
  *
  * A request made once the queue is empty still throws, so a missing `enqueue` fails fast when
  * nothing under test swallows the error. It is also recorded on `unqueued` before the throw, so a
@@ -64,7 +106,7 @@ function createFetchMock(): {
 		const url = resolveUrl(input);
 
 		const call = {
-			body: typeof init?.body === 'string' ? init.body : undefined,
+			...resolveBody(init?.body),
 			headers: Object.fromEntries(new Headers(init?.headers).entries()),
 			method: init?.method ?? 'GET',
 			url,

--- a/apps/web/test-utils/fetch-mock.ts
+++ b/apps/web/test-utils/fetch-mock.ts
@@ -1,7 +1,17 @@
 import { vi } from 'vitest';
 
 interface FetchCall {
+	/**
+	 * The call's `body` as text — populated for a `string` body (e.g. a `JSON.stringify(...)`
+	 * payload) and a `URLSearchParams` body; `undefined` for every other body type, including when
+	 * `bodyBytes` is populated. See `resolveBody` for the full mapping.
+	 */
 	body: string | undefined;
+	/**
+	 * The call's `body` as raw bytes — populated for an `ArrayBuffer` or `ArrayBufferView` body
+	 * (e.g. a file upload); `undefined` for every other body type, including when `body` is
+	 * populated. See `resolveBody` for the full mapping.
+	 */
 	bodyBytes: Uint8Array | undefined;
 	headers: Record<string, string>;
 	method: string;

--- a/docs/superpowers/plans/2026-08-26-web-296-unit-tests-pr3-server-actions.md
+++ b/docs/superpowers/plans/2026-08-26-web-296-unit-tests-pr3-server-actions.md
@@ -1,0 +1,319 @@
+# WEB-296 Unit Tests — PR 3 (Server Actions) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Cover the four server actions and the CleverReach client with unit tests, mocking at the HTTP boundary so the response parsing stays under test.
+
+**Architecture:** Tests only. Every external call in this layer goes through `fetch` (CleverReach REST, Linear GraphQL, Linear's S3 PUT); only Resend is an SDK. So `fetch` is stubbed through PR 1's `apps/web/test-utils/fetch-mock.ts`, and just two modules are mocked: `@/lib/resend` and `next/headers`. The actions are wrapped by `next-safe-action`, so tests assert its envelope rather than a bare return value. `'use server'` is inert under Vitest.
+
+**Tech Stack:** Vitest 4, Zod 4, `next-safe-action` 8, pnpm 11 workspaces, Turbo, GitButler CLI (`but`).
+
+**Spec:** `docs/superpowers/specs/2026-08-25-web-296-unit-tests-design.md`, section "PR 3 — Server Actions und CleverReach"
+
+**Base branch:** `next`, which now contains PR 1 (#471, merged). PR 2 (#472) is open and touches none of the files here, so this branch starts from `next`. New branch: `test/web-296-unit-tests-server-actions`.
+
+## Global Constraints
+
+- Node `^24.19.0`, pnpm `11.22.0` — `.nvmrc` and `packageManager` untouched.
+- Tests live next to their source; `.test.ts` only, so everything lands in the `node` project.
+- Explicit imports from `vitest`. No `globals: true`.
+- `describe` titles start lowercase and are never identical to an imported identifier. `beforeEach`/`afterEach`/`beforeAll`/`afterAll` sit inside a `describe` block.
+- Never widen the test-file override in `oxlint.config.ts`; use a narrow inline comment if a file needs a suppression.
+- No new dependency. No change to any `vitest.config.ts`, `turbo.json`, CI file, `sonar-project.properties`, or production source — if a test uncovers a real bug, report it and stop; the controller decides.
+- Commits through GitButler with explicit file paths: `but commit -b test/web-296-unit-tests-server-actions -m "…" <paths>`. Conventional Commits, no `Co-Authored-By`, no generator trailer.
+- After every task: `pnpm run lint`, `pnpm run format:check`, `pnpm run typecheck` clean and `pnpm run test` green.
+- **Expected values are derived from the implementation, never from this plan's prose.** PR 2's plan was wrong four times; the implementers caught it because they checked. If the code contradicts a value below, that is a finding: report it and write what the code really does.
+- **No assertion may build its expected value by calling the function under test or importing a constant the implementation also imports.** Hard-code literals — including URLs, error messages and the `409` status.
+- **Assert the failure, not just that something failed.** PR 2's final review named bare `.toThrow()` and boolean-only `success` checks as its weakest assertions. Here, assert the error message or the returned `code`, and for `next-safe-action` results assert which key is populated.
+
+## Infrastructure this PR consumes (all from PR 1)
+
+- `apps/web/test-utils/fetch-mock.ts` — `createFetchMock()` returns `{ calls, enqueue, enqueueJson, restore, unqueued }`. Responses are handed out FIFO in enqueue order, not routed by URL. `calls` records `{ body, headers, method, url }` for every request; **recorded header names are lowercased**, because the mock normalizes through `Headers` as real `fetch` does — assert `authorization`, not `Authorization`.
+- `unqueued` exists for this PR specifically: `subscribe()` in `cleverreach.ts` wraps its flow in a `try`/`catch` that returns `INTERNAL_ERROR`, so a short mock queue looks exactly like a genuine failure. **Every test whose subject swallows errors must assert `expect(mock.unqueued).toEqual([])`.**
+- `apps/web/test-utils/env.ts` — `loadWithEnv(specifier, vars)` resets the module registry and stubs env vars. Required here for two reasons: these modules read env at call time, and `cleverreach.ts` holds a module-level `tokenCache` that must not leak between cases. Import the module under test as `import type` only.
+
+---
+
+### Task 1: Branch
+
+**Files:** commit this plan.
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: branch `test/web-296-unit-tests-server-actions` off `next`.
+
+- [ ] **Step 1: Confirm the base**
+
+Run: `git log --oneline -1 origin/next` and `but status`
+Expected: `next` contains PR 1's merge commit; the working tree is clean.
+
+- [ ] **Step 2: Create the branch and commit the plan**
+
+`but branch new` does NOT stack by default and `but commit -b` creates a sibling — PR 2 hit exactly that. Create the branch explicitly, then commit:
+
+```bash
+but branch new test/web-296-unit-tests-server-actions
+but commit -b test/web-296-unit-tests-server-actions \
+  -m "docs: add the server action test plan for WEB-296" \
+  docs/superpowers/plans/2026-08-26-web-296-unit-tests-pr3-server-actions.md
+```
+
+- [ ] **Step 3: Verify**
+
+Run: `but status` and `git log --oneline origin/next..test/web-296-unit-tests-server-actions`
+Expected: exactly one commit, carrying only the plan file.
+
+---
+
+### Task 2: `lib/cleverreach.ts` — the access token
+
+**Files:**
+- Create: `apps/web/src/lib/cleverreach.test.ts`
+
+**Interfaces:**
+- Consumes: `createFetchMock`, `loadWithEnv`.
+- Produces: the file Task 3 extends. Task 3 appends `describe` blocks to it rather than creating a second file.
+
+`getAccessToken` is not exported. Reach it through `subscribe`, which calls it first, and assert on `mock.calls[0]` — the request to `/oauth/token.php`. This is the subtlest test in the PR: the token lives in a module-level `tokenCache`, and the module also computes a five-minute expiry buffer from `timeSpanInMilliSeconds('minute')`.
+
+- [ ] **Step 1: Set up the file**
+
+Load the module through `loadWithEnv` in every case with all four CleverReach variables set to fixed values, so the token cache starts empty each time. Use fake timers where expiry matters, and remember to restore them in an `afterEach` inside the `describe`.
+
+- [ ] **Step 2: Cases**
+
+- A successful flow requests the token first: `mock.calls[0].url` is `'https://rest.cleverreach.com/oauth/token.php'`, `method` is `'POST'`, the `content-type` header is `'application/x-www-form-urlencoded'`, and the body contains `grant_type=client_credentials` plus the client id and secret from the stubbed env.
+- The token is reused: drive two `subscribe` calls in one module instance and assert the token endpoint was hit exactly once (count entries in `calls` whose url ends `oauth/token.php`).
+- A token near expiry is refetched: with fake timers, advance beyond `expires_in` minus the five-minute buffer, drive a second `subscribe`, and assert a second token request happened. Derive the buffer from the code, not from this sentence.
+- A non-ok token response makes `subscribe` return `INTERNAL_ERROR` — assert the returned `code`, and assert the thrown message reached `console.error` (spy on it) so the failure is attributed, not merely counted.
+- A token payload that fails `accessTokenSchema` (for example `expires_in` as a string) also yields `INTERNAL_ERROR`.
+- Every case asserts `mock.unqueued` is empty.
+
+- [ ] **Step 3: Run, gate, commit**
+
+```bash
+pnpm --filter web test src/lib/cleverreach.test.ts
+pnpm run lint && pnpm run format:check && pnpm run typecheck
+but commit -b test/web-296-unit-tests-server-actions \
+  -m "test(web): cover the cleverreach access token handling" \
+  apps/web/src/lib/cleverreach.test.ts
+```
+
+---
+
+### Task 3: `lib/cleverreach.ts` — subscription flow
+
+**Files:**
+- Modify: `apps/web/src/lib/cleverreach.test.ts`
+
+**Interfaces:**
+- Consumes: the file and its helpers from Task 2.
+- Produces: nothing.
+
+- [ ] **Step 1: `addReceiver` cases (through `subscribe`)**
+
+- Happy path: after the token, the second call is a POST to `/v3/groups.json/<listId>/receivers` with a bearer `authorization` header (lowercase key) and a JSON body carrying `email`, `activated: 0`, `source` and a `registered` unix timestamp. Pin the timestamp with fake timers rather than asserting loosely.
+- A `409` response returns `{ code: 'ALREADY_SUBSCRIBED', success: false }` — assert both the code and the German-free error string the module produces.
+- Another error status whose body parses as `{ error: { code, message } }` passes that code and message through — assert both.
+- An error body that is not JSON falls back to `'Failed to add subscriber'`.
+- A failed `addReceiver` means the DOI mail is never requested: assert the call count.
+
+- [ ] **Step 2: `sendDoiEmail` and `resolveDoiMetadata`**
+
+- Happy path: the third call is a POST to `/v3/forms.json/<formId>/send/activate` whose body carries `email`, `groups_ids` and a `doidata` object with `referer`, `user_agent`, `user_ip`.
+- A failing DOI request does NOT fail the subscription: the result is still successful, and `console.error` was called. This is the one case where a swallowed error is the documented behavior.
+- Explicit metadata wins over the defaults.
+- With no metadata, `referer` derives from `VERCEL_PROJECT_PRODUCTION_URL`, `userAgent` falls back to `'Mozilla/5.0'` and `userIp` to `'0.0.0.0'`; with that variable unset, `referer` is `''`.
+
+- [ ] **Step 3: `subscribe` itself**
+
+- An invalid email returns `code: 'VALIDATION_ERROR'` and makes NO fetch at all — assert `calls` is empty.
+- A thrown error anywhere inside yields `INTERNAL_ERROR` with the module's message.
+- The happy path returns the confirmation message and hit all three endpoints in order — assert the order from `calls`.
+
+- [ ] **Step 4: Run, gate, commit**
+
+```bash
+pnpm --filter web test src/lib/cleverreach.test.ts
+pnpm run lint && pnpm run format:check && pnpm run typecheck
+but commit -b test/web-296-unit-tests-server-actions \
+  -m "test(web): cover the cleverreach subscription flow" \
+  apps/web/src/lib/cleverreach.test.ts
+```
+
+---
+
+### Task 4: `actions/subscribe-to-newsletter.ts`
+
+**Files:**
+- Create: `apps/web/src/actions/subscribe-to-newsletter.test.ts`
+
+**Interfaces:**
+- Consumes: `createFetchMock`, `loadWithEnv`, and a mock of `next/headers`.
+- Produces: the `next/headers` mocking pattern the later action tests reuse.
+
+This action is a plain `useActionState` function, not a `next-safe-action` client, so it returns `NewsletterFormState` directly. It reads request headers through `await headers()`, so `next/headers` must be mocked. Build the `FormData` by hand.
+
+- [ ] **Step 1: Cases**
+
+- Missing `email` in the `FormData` returns the error state with `'Bitte überprüfe Deine Eingaben.'` — assert the exact string, and that no fetch happened.
+- An invalid email does the same.
+- `x-forwarded-for` with several IPs takes the first and trims it; assert the value that reached the DOI request body.
+- Missing headers fall back to `''` referer, `'Mozilla/5.0'` user agent and `'0.0.0.0'` IP.
+- Each `result.code` maps to its German message: `ALREADY_SUBSCRIBED`, `INTERNAL_ERROR`, `VALIDATION_ERROR` — drive each by shaping the CleverReach responses, and assert the message.
+- An unknown code falls back to the raw error string.
+- The success state carries its title and message.
+
+- [ ] **Step 2: Run, gate, commit**
+
+```bash
+pnpm --filter web test src/actions/subscribe-to-newsletter.test.ts
+pnpm run lint && pnpm run format:check && pnpm run typecheck
+but commit -b test/web-296-unit-tests-server-actions \
+  -m "test(web): cover the newsletter subscription action" \
+  apps/web/src/actions/subscribe-to-newsletter.test.ts
+```
+
+---
+
+### Task 5: `actions/create-linear-issue.ts`
+
+**Files:**
+- Create: `apps/web/src/actions/create-linear-issue.test.ts`
+
+**Interfaces:**
+- Consumes: `createFetchMock`, `loadWithEnv`.
+- Produces: the `next-safe-action` envelope assertions Task 6 and Task 7 reuse.
+
+Wrapped by `next-safe-action`, so the result is an envelope. Determine the real shape by calling the action once and inspecting it — do not assume `data`/`serverError`/`validationErrors` key names from this plan; write down what the installed version actually returns and use that.
+
+- [ ] **Step 1: `buildDescription` cases (through the action)**
+
+Assert on the GraphQL request body:
+- The screenshot block appears only when `screenshotUrls` is non-empty, and renders one markdown image per URL.
+- Metadata lines skip falsy fields, and `privacy: true` renders.
+- The `Source` line is always last.
+- The title is `[TYPE] <title>` with the type upper-cased.
+- The variables carry `teamId`, `assigneeId` and `labelIds` from the stubbed env.
+
+- [ ] **Step 2: Failure paths**
+
+- A non-ok HTTP response surfaces `HTTP error: <status>` — assert the message, not merely that it failed.
+- A GraphQL body with `errors` surfaces `Failed to create issue`, and `console.error` saw the errors.
+- `issueCreate.success: false`, and separately a missing `issue`, both surface `Issue creation failed`.
+- A payload that fails `linearResponseSchema` surfaces a Zod error rather than a silent success.
+- An input failing `feedbackFormSchema` never reaches fetch — assert `calls` is empty and the envelope reports a validation failure.
+
+- [ ] **Step 3: Happy path**
+
+The envelope carries `issueId` and `issueIdentifier`; the request went to `'https://api.linear.app/graphql'` with the api key in the lowercase `authorization` header.
+
+- [ ] **Step 4: Run, gate, commit**
+
+```bash
+pnpm --filter web test src/actions/create-linear-issue.test.ts
+pnpm run lint && pnpm run format:check && pnpm run typecheck
+but commit -b test/web-296-unit-tests-server-actions \
+  -m "test(web): cover the linear issue creation action" \
+  apps/web/src/actions/create-linear-issue.test.ts
+```
+
+---
+
+### Task 6: `actions/upload-to-linear.ts`
+
+**Files:**
+- Create: `apps/web/src/actions/upload-to-linear.test.ts`
+
+**Interfaces:**
+- Consumes: `createFetchMock`, `loadWithEnv`, the envelope shape from Task 5.
+- Produces: nothing.
+
+Node 24 has `File` and `Blob` globally, so build fixtures with `new File([bytes], name, { type })`.
+
+- [ ] **Step 1: Schema cases**
+
+- A non-image type is rejected with `'Invalid file type. Only images are allowed.'`; assert the message from the envelope's validation errors, and that no fetch happened.
+- A file over 10 MB is rejected with `'File too large. Maximum size is 10MB.'`. Construct the oversize file without allocating 10 MB of real data if you can (a sparse `File` whose `size` exceeds the limit); if that is not possible, say so and allocate.
+- Each allowed type in `ALLOWED_TYPES` passes the schema.
+
+- [ ] **Step 2: Flow cases**
+
+- Happy path: two requests — a GraphQL `fileUpload` mutation, then a PUT to the returned `uploadUrl` whose headers merge Linear's headers over `Content-Type` (assert lowercase keys) and whose body is the file's bytes. The envelope carries `assetUrl`.
+- `data.fileUpload.uploadFile` missing surfaces `Failed to get upload URL: <status> - <payload>`; assert the status appears.
+- A GraphQL body with `errors` does the same, and `console.error` saw them.
+- A failing PUT surfaces `Failed to upload file: <status>`.
+- `buildUploadHeaders` behavior is observable through the PUT request's headers: a Linear header named `content-type` overrides the file's type.
+
+- [ ] **Step 3: Run, gate, commit**
+
+```bash
+pnpm --filter web test src/actions/upload-to-linear.test.ts
+pnpm run lint && pnpm run format:check && pnpm run typecheck
+but commit -b test/web-296-unit-tests-server-actions \
+  -m "test(web): cover the linear file upload action" \
+  apps/web/src/actions/upload-to-linear.test.ts
+```
+
+---
+
+### Task 7: `actions/send-contact-form.ts`
+
+**Files:**
+- Create: `apps/web/src/actions/send-contact-form.test.ts`
+
+**Interfaces:**
+- Consumes: `loadWithEnv`, a mock of `@/lib/resend`, the envelope shape from Task 5.
+- Produces: nothing.
+
+The only SDK mock in this PR. Mock `@/lib/resend` so `resend.emails.send` is a `vi.fn()` whose resolved value each case controls, and assert on its arguments. No `fetch` involved.
+
+- [ ] **Step 1: Cases**
+
+- With `NODE_ENV` production and a receiver, `to` is the receiver's email.
+- Production without a receiver falls back to `'info@tsg-irlich.de'`.
+- Outside production, `to` is forced to `'it@tsg-irlich.de'` even when a receiver is given.
+- `bcc` is `['it@tsg-irlich.de']`, `replyTo` is the sender's email, and the subject is `` `Webseiten-Kontaktformular: Neue Nachricht von ${name}` `` — assert the exact string.
+- `react` receives the props the action builds; assert the ones that come from input (`contactEmail`, `contactMessage`, `contactName`, `receiver`) and that `baseUrl` is present.
+- Resend returning `{ error }` surfaces `'Email could not be sent'`, and `console.error` saw the Resend error.
+- An input failing `contactFormSchema` never calls `send` — assert the mock was not called and the envelope reports a validation failure.
+
+- [ ] **Step 2: Run, gate, commit**
+
+```bash
+pnpm --filter web test src/actions/send-contact-form.test.ts
+pnpm run lint && pnpm run format:check && pnpm run typecheck
+but commit -b test/web-296-unit-tests-server-actions \
+  -m "test(web): cover the contact form action" \
+  apps/web/src/actions/send-contact-form.test.ts
+```
+
+---
+
+### Task 8: Close out
+
+**Files:** none.
+
+- [ ] **Step 1: Full verification**
+
+Run: `pnpm run lint && pnpm run format:check && pnpm run typecheck && pnpm run test && pnpm run build`
+Expected: all green. Record the new test total and the per-workspace split.
+
+- [ ] **Step 2: Coverage**
+
+Run: `pnpm run test:coverage`
+Note the line coverage for `apps/web/src/actions` and `apps/web/src/lib/cleverreach.ts`.
+
+- [ ] **Step 3: Report**
+
+Summarize for the pull request, in English: files covered, the test total, coverage figures, every disagreement found between this plan and real behavior, and any production bug found. Pushing the branch, opening the PR against `next` and commenting on Linear are the user's call.
+
+---
+
+## Self-Review
+
+**Spec coverage:** every item in the spec's PR 3 section maps to a task — `cleverreach.ts` split across Tasks 2 and 3 because the token cache and the subscription flow are independently tricky, then one task per action (4, 5, 6, 7).
+
+**Placeholder scan:** no TBD/TODO. The plan deliberately does NOT state the `next-safe-action` envelope's key names, and Task 5 Step 1 requires the implementer to determine them from the installed version — inventing them here is exactly the kind of prose error PR 2 caught four times.
+
+**Type consistency:** `createFetchMock`'s `{ calls, enqueue, enqueueJson, restore, unqueued }` and `loadWithEnv(specifier, vars)` match what PR 1 shipped and PR 2 used; the lowercased-header behavior is stated once, at the top, and every task that asserts a header depends on it.

--- a/docs/superpowers/plans/2026-08-26-web-296-unit-tests-pr3-server-actions.md
+++ b/docs/superpowers/plans/2026-08-26-web-296-unit-tests-pr3-server-actions.md
@@ -28,7 +28,7 @@
 
 ## Infrastructure this PR consumes (all from PR 1)
 
-- `apps/web/test-utils/fetch-mock.ts` — `createFetchMock()` returns `{ calls, enqueue, enqueueJson, restore, unqueued }`. Responses are handed out FIFO in enqueue order, not routed by URL. `calls` records `{ body, headers, method, url }` for every request; **recorded header names are lowercased**, because the mock normalizes through `Headers` as real `fetch` does — assert `authorization`, not `Authorization`.
+- `apps/web/test-utils/fetch-mock.ts` — `createFetchMock()` returns `{ calls, enqueue, enqueueJson, restore, unqueued }`. Responses are handed out FIFO in enqueue order, not routed by URL. `calls` records `{ body, bodyBytes, headers, method, url }` for every request; **recorded header names are lowercased**, because the mock normalizes through `Headers` as real `fetch` does — assert `authorization`, not `Authorization`. `body` captures a `string` request body as-is and a `URLSearchParams` body (the CleverReach token request) through `String(...)`; `bodyBytes` captures an `ArrayBuffer`/`ArrayBufferView` body (the Linear upload's file bytes) as a `Uint8Array` instead, leaving `body` `undefined`. Any other body type — a `Blob`, a `FormData`, a stream — leaves both fields `undefined`.
 - `unqueued` exists for this PR specifically: `subscribe()` in `cleverreach.ts` wraps its flow in a `try`/`catch` that returns `INTERNAL_ERROR`, so a short mock queue looks exactly like a genuine failure. **Every test whose subject swallows errors must assert `expect(mock.unqueued).toEqual([])`.**
 - `apps/web/test-utils/env.ts` — `loadWithEnv(specifier, vars)` resets the module registry and stubs env vars. Required here for two reasons: these modules read env at call time, and `cleverreach.ts` holds a module-level `tokenCache` that must not leak between cases. Import the module under test as `import type` only.
 
@@ -39,13 +39,13 @@
 **Files:** commit this plan.
 
 **Interfaces:**
+
 - Consumes: nothing.
 - Produces: branch `test/web-296-unit-tests-server-actions` off `next`.
 
 - [ ] **Step 1: Confirm the base**
 
-Run: `git log --oneline -1 origin/next` and `but status`
-Expected: `next` contains PR 1's merge commit; the working tree is clean.
+Run: `git log --oneline -1 origin/next` and `but status` Expected: `next` contains PR 1's merge commit; the working tree is clean.
 
 - [ ] **Step 2: Create the branch and commit the plan**
 
@@ -60,17 +60,18 @@ but commit -b test/web-296-unit-tests-server-actions \
 
 - [ ] **Step 3: Verify**
 
-Run: `but status` and `git log --oneline origin/next..test/web-296-unit-tests-server-actions`
-Expected: exactly one commit, carrying only the plan file.
+Run: `but status` and `git log --oneline origin/next..test/web-296-unit-tests-server-actions` Expected: exactly one commit, carrying only the plan file.
 
 ---
 
 ### Task 2: `lib/cleverreach.ts` — the access token
 
 **Files:**
+
 - Create: `apps/web/src/lib/cleverreach.test.ts`
 
 **Interfaces:**
+
 - Consumes: `createFetchMock`, `loadWithEnv`.
 - Produces: the file Task 3 extends. Task 3 appends `describe` blocks to it rather than creating a second file.
 
@@ -104,9 +105,11 @@ but commit -b test/web-296-unit-tests-server-actions \
 ### Task 3: `lib/cleverreach.ts` — subscription flow
 
 **Files:**
+
 - Modify: `apps/web/src/lib/cleverreach.test.ts`
 
 **Interfaces:**
+
 - Consumes: the file and its helpers from Task 2.
 - Produces: nothing.
 
@@ -146,9 +149,11 @@ but commit -b test/web-296-unit-tests-server-actions \
 ### Task 4: `actions/subscribe-to-newsletter.ts`
 
 **Files:**
+
 - Create: `apps/web/src/actions/subscribe-to-newsletter.test.ts`
 
 **Interfaces:**
+
 - Consumes: `createFetchMock`, `loadWithEnv`, and a mock of `next/headers`.
 - Produces: the `next/headers` mocking pattern the later action tests reuse.
 
@@ -179,9 +184,11 @@ but commit -b test/web-296-unit-tests-server-actions \
 ### Task 5: `actions/create-linear-issue.ts`
 
 **Files:**
+
 - Create: `apps/web/src/actions/create-linear-issue.test.ts`
 
 **Interfaces:**
+
 - Consumes: `createFetchMock`, `loadWithEnv`.
 - Produces: the `next-safe-action` envelope assertions Task 6 and Task 7 reuse.
 
@@ -190,6 +197,7 @@ Wrapped by `next-safe-action`, so the result is an envelope. Determine the real 
 - [ ] **Step 1: `buildDescription` cases (through the action)**
 
 Assert on the GraphQL request body:
+
 - The screenshot block appears only when `screenshotUrls` is non-empty, and renders one markdown image per URL.
 - Metadata lines skip falsy fields, and `privacy: true` renders.
 - The `Source` line is always last.
@@ -223,9 +231,11 @@ but commit -b test/web-296-unit-tests-server-actions \
 ### Task 6: `actions/upload-to-linear.ts`
 
 **Files:**
+
 - Create: `apps/web/src/actions/upload-to-linear.test.ts`
 
 **Interfaces:**
+
 - Consumes: `createFetchMock`, `loadWithEnv`, the envelope shape from Task 5.
 - Produces: nothing.
 
@@ -260,9 +270,11 @@ but commit -b test/web-296-unit-tests-server-actions \
 ### Task 7: `actions/send-contact-form.ts`
 
 **Files:**
+
 - Create: `apps/web/src/actions/send-contact-form.test.ts`
 
 **Interfaces:**
+
 - Consumes: `loadWithEnv`, a mock of `@/lib/resend`, the envelope shape from Task 5.
 - Produces: nothing.
 
@@ -296,13 +308,11 @@ but commit -b test/web-296-unit-tests-server-actions \
 
 - [ ] **Step 1: Full verification**
 
-Run: `pnpm run lint && pnpm run format:check && pnpm run typecheck && pnpm run test && pnpm run build`
-Expected: all green. Record the new test total and the per-workspace split.
+Run: `pnpm run lint && pnpm run format:check && pnpm run typecheck && pnpm run test && pnpm run build` Expected: all green. Record the new test total and the per-workspace split.
 
 - [ ] **Step 2: Coverage**
 
-Run: `pnpm run test:coverage`
-Note the line coverage for `apps/web/src/actions` and `apps/web/src/lib/cleverreach.ts`.
+Run: `pnpm run test:coverage` Note the line coverage for `apps/web/src/actions` and `apps/web/src/lib/cleverreach.ts`.
 
 - [ ] **Step 3: Report**
 


### PR DESCRIPTION
PR 3 of 5 for WEB-296, on top of the infrastructure from #471 and the pure-logic tests from #472. This one covers the layer that talks to the outside world: the four server actions and the CleverReach client.

## Approach

Every external call in this layer goes through `fetch` — CleverReach's REST API, Linear's GraphQL API, and Linear's S3-style upload PUT. Only Resend is an SDK. So the mocking happens at the HTTP boundary rather than the module boundary, which keeps the Zod response parsing, the error branching and the request construction under test instead of stubbing them away. Two modules are mocked: `@/lib/resend` and `next/headers`.

## What is covered

**`lib/cleverreach.ts`** — the access token (requested once and cached, refetched inside the five-minute expiry buffer, non-ok responses, payloads that fail the schema), adding a receiver (the `409` conflict, structured error bodies, non-JSON error bodies), the double-opt-in mail (including that its failure deliberately does **not** fail the subscription), the metadata fallbacks, and `subscribe` itself.

**`actions/subscribe-to-newsletter.ts`** — `FormData` validation, header extraction (`x-forwarded-for` with several IPs takes the first and trims it), each error code's German message, and the success state.

**`actions/create-linear-issue.ts`** — the description builder branch by branch, the `[TYPE] title` upper-casing, the mutation variables, and every failure path.

**`actions/upload-to-linear.ts`** — the file-type and size refinements including the exact 10 MB boundary, the two-request flow with the uploaded bytes asserted, header merging, and each failure path.

**`actions/send-contact-form.ts`** — all three recipient branches, the full Resend payload including `from`, and the failure path.

Line coverage is 100% for `apps/web/src/actions` and for `apps/web/src/lib/cleverreach.ts`. Total suite: 242 tests.

## One bug the tests found

`apps/web/src/actions/subscribe-to-newsletter.ts` read `treeifyError(validation.error).errors[0]`, but Zod 4 puts field-level issues under `.properties.<field>.errors` — so that top-level array is always empty and the returned `error` was always `undefined`. Invisible in the UI, because the message shown to the user is a separate hard-coded string, but the field was dead. Fixed, and a test now asserts the error is a non-empty string.

## Notes for reviewers

**`next-safe-action` masks thrown messages.** Its default `handleServerError` logs the real message and returns `"Something went wrong while executing the operation."`, so the envelope never carries `HTTP error: 503` or `Failed to create issue`. Those assertions therefore go through a `console.error` spy — the only channel that exposes the real message without changing production code. If we ever configure `handleServerError`, those assertions will break, and that is the correct signal rather than a false negative.

**The fetch mock now records request bodies it previously dropped.** It only kept string bodies, so CleverReach's `URLSearchParams` token body and Linear's `ArrayBuffer` upload body were invisible to assertions. Text bodies now land in `body`, binary in a new `bodyBytes`.

**One note added to `apps/web/AGENTS.md`:** a `vi.fn()` created inside a `vi.mock(…)` factory is reset by neither `vi.resetModules()` nor `vi.restoreAllMocks()` — only `vi.spyOn` registrations are — so it needs an explicit `.mockReset()` in `afterEach`. PR 4 is built entirely on module mocks and would otherwise rediscover this the hard way.

**Where the coverage number is thinner than it looks.** 100% line coverage says nothing about assertion strength, so the final review was asked to name the places where a line executes without pinning behavior. Four were found and all four are now fixed in this branch: the per-type upload loop asserted only that validation passed, the email-props case type-checked `baseUrl` instead of pinning it, and neither the token expiry comparison nor the file-size refinement had a case at its exact boundary. Both boundary cases were verified by mutating the comparison and watching precisely the new case fail.

Plan and design live under `docs/superpowers/`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved newsletter signup validation messages when an email address is invalid.

* **Tests**
  * Added comprehensive coverage for newsletter subscriptions, contact-form submissions, Linear issue creation and file uploads, and newsletter provider integrations.
  * Expanded request-mocking support to verify both text and binary request bodies.

* **Documentation**
  * Added testing guidance for resetting mocks created within mock factories.
  * Added an implementation plan for server-action test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->