### PR TITLE
test: cover the components and hooks (WEB-296)

### DIFF
--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -81,13 +81,23 @@ Vitest splits this app into two projects, defined in `vitest.config.ts`, by file
 
 Static image imports (`.webp` and friends) are resolved by the `assetStub` Vite plugin in `vitest.config.ts` — without it, any module that imports an image fails to load in a test run.
 
-Three helpers live in `test-utils/`:
+`renderWithUser` (`test-utils/render.tsx`) is the entry point for a `.test.tsx` case — it wraps Testing Library's `render` and returns the usual result plus a `user` (`@testing-library/user-event`) already set up against the same document.
 
-- `setup-dom.ts` — stubs `matchMedia`, `ResizeObserver` and `IntersectionObserver`; wired as the `dom` project's `setupFiles`.
+Three more helpers live in `test-utils/`:
+
+- `setup-dom.ts` — stubs `matchMedia`, `ResizeObserver` and `IntersectionObserver`, mocks `next/image`, `next/navigation` and `motion/react`, and registers one central `afterEach` (DOM cleanup plus every mock's state reset) as the `dom` project's `setupFiles` — a test needs neither itself. A consumer's own `afterEach` should still nest inside a `describe` rather than sit at the file's root, matching the existing `vi.fn()`-reset pattern (see `form.test.tsx`).
 - `env.ts` — `loadWithEnv` resets the module registry and stubs the environment, because `src/lib/env.ts` caches validated values in a module-level `Map`. A test using it must import the module under test only as `import type` and get its runtime binding from `loadWithEnv`'s return value — see `src/utils/url.test.ts`.
 - `fetch-mock.ts` — `createFetchMock` replaces `fetch` with a queue of canned responses and records every call. Recorded headers are normalized through `Headers`, same as the real `fetch`, so they come back lowercased — assert against lowercase header names.
 
 A `vi.fn()` created inside a `vi.mock(import('…'), factory)` is not reset by `vi.resetModules()` or `vi.restoreAllMocks()` — call it explicitly in an `afterEach` (`mockedFn.mockReset()`), or its call history accumulates across cases. See `src/actions/send-contact-form.test.ts` for the pattern.
+
+`@testing-library/jest-dom` is not installed — there is no `toBeInTheDocument()`/`toHaveAttribute()`; use `.toBeNull()`/`.not.toBeNull()` and plain attribute checks instead (see `badge.test.tsx`).
+
+No animation prop (`initial`, `animate`, `transition`, `layoutId`, …) is ever observable through the `motion/react` mock, regardless of what a hook like `useReducedMotion` returns; `next/image`'s Next-only props (`fill`, `preload`, `sizes`, `loader`, `placeholder`, `blurDataURL`) are silently dropped rather than forwarded. Both are real, harness-imposed coverage gaps, not something to work around.
+
+Assert what a user can observe — role, label, text, accessible name, href — never a class name and never a test-only `data-testid`.
+
+A test that pins a known production defect rather than the intended behaviour carries a short comment directly above that `it` explaining the defect (see `src/actions/subscribe-to-newsletter.test.ts`).
 
 ## Gotchas
 

--- a/apps/web/src/components/section/contact-form.test.tsx
+++ b/apps/web/src/components/section/contact-form.test.tsx
@@ -1,0 +1,140 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { sendContactForm } from '@/actions/send-contact-form';
+
+import { renderWithUser } from '../../../test-utils/render';
+import { ContactForm } from './contact-form';
+
+// `contact-form.tsx` imports `sendContactForm` and calls it directly (wrapped in `settle()`), it
+// does not go through `next-safe-action`'s `useAction` hook — so the boundary to mock is the
+// action module itself, the same way `send-contact-form.test.ts` mocks `@/lib/resend`.
+vi.mock(import('@/actions/send-contact-form'), () => ({ sendContactForm: vi.fn() }));
+
+// `vi.mocked` only needs the reference to the mock function object; it is never invoked as a bare,
+// unbound `this`-dependent call.
+// oxlint-disable-next-line typescript/unbound-method
+const mockedSendContactForm = vi.mocked(sendContactForm);
+
+const VALID_MESSAGE = 'Dies ist eine ausführliche Testnachricht für das Kontaktformular.';
+
+function renderForm() {
+	return renderWithUser(<ContactForm />);
+}
+
+interface Deferred<T> {
+	promise: Promise<T>;
+	resolve: (value: T) => void;
+}
+
+function createDeferred<T>(): Deferred<T> {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((res) => {
+		resolve = res;
+	});
+	return { promise, resolve };
+}
+
+describe('the contact form', () => {
+	afterEach(() => {
+		mockedSendContactForm.mockReset();
+	});
+
+	it('shows the schema validation messages on an empty submission and never calls the action', async () => {
+		const { findByText, getByRole, getByText, user } = renderForm();
+
+		await user.click(getByRole('button', { name: 'Kontaktiere uns' }));
+
+		await expect(
+			findByText('Der Name muss mindestens 2 Zeichen lang sein.'),
+		).resolves.not.toBeNull();
+		expect(getByText('Die E-Mail Adresse ist ungültig.')).not.toBeNull();
+		expect(getByText('Die Nachricht muss mindestens 32 Zeichen lang sein.')).not.toBeNull();
+		expect(getByText('Bitte akzeptiere die Datenschutzbestimmungen')).not.toBeNull();
+		expect(mockedSendContactForm).not.toHaveBeenCalled();
+	});
+
+	it('calls the action exactly once with the parsed values on a valid submission', async () => {
+		mockedSendContactForm.mockResolvedValue({});
+		const { findByRole, getByLabelText, getByRole, user } = renderForm();
+
+		await user.type(getByLabelText('Name'), 'Max Mustermann');
+		await user.type(getByLabelText('E-Mail'), 'max@mustermann.de');
+		await user.type(getByLabelText('Nachricht'), VALID_MESSAGE);
+		await user.click(getByLabelText('Datenschutzbestimmungen'));
+
+		await user.click(getByRole('button', { name: 'Kontaktiere uns' }));
+
+		// The success `Alert` (see `error-alert.tsx`/`success-alert.tsx`) carries `role="alert"` but
+		// no `aria-labelledby`, so it has no accessible *name* of its own even though its `AlertTitle`
+		// is visibly "Vielen Dank!" — querying the heading is what actually resolves.
+		await findByRole('heading', { name: 'Vielen Dank!' });
+
+		expect(mockedSendContactForm).toHaveBeenCalledExactlyOnceWith({
+			email: 'max@mustermann.de',
+			message: VALID_MESSAGE,
+			name: 'Max Mustermann',
+			privacy: true,
+			receiver: undefined,
+		});
+	});
+
+	it("renders the action's server error to the user", async () => {
+		mockedSendContactForm.mockResolvedValue({ serverError: 'Der Server hat ein Problem.' });
+		const { findByRole, findByText, getByLabelText, getByRole, user } = renderForm();
+
+		await user.type(getByLabelText('Name'), 'Max Mustermann');
+		await user.type(getByLabelText('E-Mail'), 'max@mustermann.de');
+		await user.type(getByLabelText('Nachricht'), VALID_MESSAGE);
+		await user.click(getByLabelText('Datenschutzbestimmungen'));
+
+		await user.click(getByRole('button', { name: 'Kontaktiere uns' }));
+
+		await findByRole('heading', { name: 'Fehler' });
+		await expect(findByText('Der Server hat ein Problem.')).resolves.not.toBeNull();
+	});
+
+	it('renders the confirmation and clears the fields on success', async () => {
+		mockedSendContactForm.mockResolvedValue({});
+		const { findByRole, getByLabelText, getByRole, user } = renderForm();
+
+		await user.type(getByLabelText('Name'), 'Max Mustermann');
+		await user.type(getByLabelText('E-Mail'), 'max@mustermann.de');
+		await user.type(getByLabelText('Nachricht'), VALID_MESSAGE);
+		await user.click(getByLabelText('Datenschutzbestimmungen'));
+
+		await user.click(getByRole('button', { name: 'Kontaktiere uns' }));
+
+		await findByRole('heading', { name: 'Vielen Dank!' });
+
+		await user.click(getByRole('button', { name: 'Erneute Anfrage stellen' }));
+
+		expect((getByLabelText('Name') as HTMLInputElement).value).toBe('');
+		expect((getByLabelText('E-Mail') as HTMLInputElement).value).toBe('');
+		expect((getByLabelText('Nachricht') as HTMLTextAreaElement).value).toBe('');
+		expect(getByLabelText('Datenschutzbestimmungen').getAttribute('aria-checked')).toBe('false');
+	});
+
+	it('disables submission while the action is pending', async () => {
+		const deferred = createDeferred<Awaited<ReturnType<typeof sendContactForm>>>();
+		mockedSendContactForm.mockReturnValue(deferred.promise);
+		const { findByRole, getByLabelText, getByRole, user } = renderForm();
+
+		await user.type(getByLabelText('Name'), 'Max Mustermann');
+		await user.type(getByLabelText('E-Mail'), 'max@mustermann.de');
+		await user.type(getByLabelText('Nachricht'), VALID_MESSAGE);
+		await user.click(getByLabelText('Datenschutzbestimmungen'));
+
+		await user.click(getByRole('button', { name: 'Kontaktiere uns' }));
+
+		const pendingButton = await findByRole('button', { name: 'Wird gesendet...' });
+		expect(pendingButton.hasAttribute('disabled')).toBe(true);
+
+		// Resolved with a server error rather than success, so the form (and its submit button)
+		// stays mounted afterwards instead of being replaced by the success view — the pending state
+		// is a property of the form, not of the success confirmation.
+		deferred.resolve({ serverError: 'Der Server hat ein Problem.' });
+
+		const enabledButton = await findByRole('button', { name: 'Kontaktiere uns' });
+		expect(enabledButton.hasAttribute('disabled')).toBe(false);
+	});
+});

--- a/apps/web/src/components/section/newsletter.test.tsx
+++ b/apps/web/src/components/section/newsletter.test.tsx
@@ -1,0 +1,108 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { subscribeToNewsletter } from '@/actions/subscribe-to-newsletter';
+import type { NewsletterFormState } from '@/actions/subscribe-to-newsletter';
+
+import { renderWithUser } from '../../../test-utils/render';
+import { Newsletter } from './newsletter';
+
+// `newsletter.tsx` drives `useActionState` straight off `subscribeToNewsletter`, so — like
+// `contact-form.test.tsx` mocks `sendContactForm` — the boundary to mock is the action module
+// itself.
+vi.mock(import('@/actions/subscribe-to-newsletter'), () => ({ subscribeToNewsletter: vi.fn() }));
+
+// oxlint-disable-next-line typescript/unbound-method
+const mockedSubscribeToNewsletter = vi.mocked(subscribeToNewsletter);
+
+const SUCCESS_STATE: NewsletterFormState = {
+	message:
+		'Bitte bestätige Deine Anmeldung über den Link in der E-Mail, die wir Dir gesendet haben.',
+	success: true,
+	title: 'Vielen Dank!',
+};
+
+const ERROR_STATE: NewsletterFormState = {
+	error: 'ALREADY_SUBSCRIBED',
+	message: 'Diese E-Mail-Adresse ist bereits für den Newsletter registriert.',
+	success: false,
+	title: 'Fehler',
+};
+
+function renderNewsletter() {
+	return renderWithUser(<Newsletter />);
+}
+
+interface Deferred<T> {
+	promise: Promise<T>;
+	resolve: (value: T) => void;
+}
+
+function createDeferred<T>(): Deferred<T> {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((res) => {
+		resolve = res;
+	});
+	return { promise, resolve };
+}
+
+describe('newsletter', () => {
+	afterEach(() => {
+		mockedSubscribeToNewsletter.mockReset();
+	});
+
+	it('renders the title and message of the success state the action resolved with', async () => {
+		mockedSubscribeToNewsletter.mockResolvedValue(SUCCESS_STATE);
+		const { findByRole, findByText, getByRole, user } = renderNewsletter();
+
+		await user.type(getByRole('textbox', { name: 'E-Mail' }), 'max@mustermann.de');
+		await user.click(getByRole('button', { name: 'Abonnieren' }));
+
+		await findByRole('heading', { name: 'Vielen Dank!' });
+		await expect(findByText(SUCCESS_STATE.message)).resolves.not.toBeNull();
+	});
+
+	it('renders the message of the error state the action resolved with', async () => {
+		mockedSubscribeToNewsletter.mockResolvedValue(ERROR_STATE);
+		const { findByRole, findByText, getByRole, user } = renderNewsletter();
+
+		await user.type(getByRole('textbox', { name: 'E-Mail' }), 'max@mustermann.de');
+		await user.click(getByRole('button', { name: 'Abonnieren' }));
+
+		await findByRole('heading', { name: 'Fehler' });
+		await expect(findByText(ERROR_STATE.message)).resolves.not.toBeNull();
+	});
+
+	it('submits the address the user typed as the FormData the action receives', async () => {
+		mockedSubscribeToNewsletter.mockResolvedValue(SUCCESS_STATE);
+		const { findByRole, getByRole, user } = renderNewsletter();
+
+		await user.type(getByRole('textbox', { name: 'E-Mail' }), 'max@mustermann.de');
+		await user.click(getByRole('button', { name: 'Abonnieren' }));
+
+		await findByRole('heading', { name: 'Vielen Dank!' });
+
+		expect(mockedSubscribeToNewsletter).toHaveBeenCalledOnce();
+		const [, formData] = mockedSubscribeToNewsletter.mock.calls[0];
+		expect(formData.get('email')).toBe('max@mustermann.de');
+	});
+
+	it('disables the email field and the submit button while the action is pending', async () => {
+		const deferred = createDeferred<NewsletterFormState>();
+		mockedSubscribeToNewsletter.mockReturnValue(deferred.promise);
+		const { findByRole, getByRole, user } = renderNewsletter();
+
+		await user.type(getByRole('textbox', { name: 'E-Mail' }), 'max@mustermann.de');
+		await user.click(getByRole('button', { name: 'Abonnieren' }));
+
+		const pendingButton = await findByRole('button', { name: 'Wird angemeldet …' });
+
+		expect(pendingButton.hasAttribute('disabled')).toBe(true);
+		expect(getByRole('textbox', { name: 'E-Mail' }).hasAttribute('disabled')).toBe(true);
+
+		deferred.resolve(SUCCESS_STATE);
+
+		await findByRole('heading', { name: 'Vielen Dank!' });
+		const enabledButton = await findByRole('button', { name: 'Abonnieren' });
+		expect(enabledButton.hasAttribute('disabled')).toBe(false);
+	});
+});

--- a/apps/web/src/components/ui/badge/badge.test.tsx
+++ b/apps/web/src/components/ui/badge/badge.test.tsx
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+
+import { renderWithUser } from '../../../../test-utils/render';
+import { Badge } from './badge';
+
+// `variant` only ever changes `badgeVariants`' class string (see `./variants.ts`) — no role, text
+// or other user-perceivable output changes between `default` and `ghost`, so it is deliberately not
+// covered here; see the PR 4 report for the full reasoning. `asChild`, by contrast, changes what
+// element the badge renders as, which is a real, user (and screen reader) perceivable difference.
+describe('badge', () => {
+	it('renders its children as text', () => {
+		const { getByText } = renderWithUser(<Badge>Neu</Badge>);
+
+		expect(getByText('Neu').textContent).toBe('Neu');
+	});
+
+	it('renders as the wrapped element instead of a span when asChild is set', () => {
+		const { getByRole } = renderWithUser(
+			<Badge asChild>
+				<a href="https://tsg-irlich.de/kontakt">Kontakt</a>
+			</Badge>,
+		);
+
+		const link = getByRole('link', { name: 'Kontakt' });
+		expect(link.tagName).toBe('A');
+		expect(link.getAttribute('href')).toBe('https://tsg-irlich.de/kontakt');
+	});
+});

--- a/apps/web/src/components/ui/gallery.test.tsx
+++ b/apps/web/src/components/ui/gallery.test.tsx
@@ -59,6 +59,26 @@ describe('gallery', () => {
 		expect(within(dialog).getByRole('img', { name: 'Bild 2' })).not.toBeNull();
 	});
 
+	it('opens the lightbox on the only image in the single-image layout', async () => {
+		const images = buildImages(1);
+		const { findByRole, getByRole, user } = renderGallery(images);
+
+		await user.click(getByRole('button', { name: 'Bild 1 vergrößern' }));
+
+		const dialog = await findByRole('dialog', { name: 'Bild 1' });
+		expect(within(dialog).getByRole('img', { name: 'Bild 1' })).not.toBeNull();
+	});
+
+	it('opens the lightbox on the image belonging to the clicked thumbnail in the grid layout for more than three images', async () => {
+		const images = buildImages(5);
+		const { findByRole, getByRole, user } = renderGallery(images);
+
+		await user.click(getByRole('button', { name: 'Bild 4 vergrößern' }));
+
+		const dialog = await findByRole('dialog', { name: 'Bild 4' });
+		expect(within(dialog).getByRole('img', { name: 'Bild 4' })).not.toBeNull();
+	});
+
 	it('renders nothing for an empty image list', () => {
 		const images = buildImages(0);
 		const { container } = render(<Gallery images={images} />);

--- a/apps/web/src/components/ui/gallery.test.tsx
+++ b/apps/web/src/components/ui/gallery.test.tsx
@@ -1,0 +1,68 @@
+import { render, within } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import type { GalleryImage } from '@/utils/image';
+
+import { renderWithUser } from '../../../test-utils/render';
+import { Gallery } from './gallery';
+
+function buildImages(count: number): GalleryImage[] {
+	return Array.from({ length: count }, (_unused, index) => ({
+		alt: `Bild ${index + 1}`,
+		key: `image-${index + 1}`,
+		src: `/thumb/${index + 1}.jpg`,
+		srcFull: `/full/${index + 1}.jpg`,
+	}));
+}
+
+function renderGallery(images: GalleryImage[]) {
+	return renderWithUser(<Gallery images={images} />);
+}
+
+describe('gallery', () => {
+	it('renders one thumbnail per image, each queryable by its alt text', () => {
+		const images = buildImages(4);
+		const { getByRole } = renderGallery(images);
+
+		for (const image of images) {
+			expect(getByRole('img', { name: image.alt })).not.toBeNull();
+		}
+	});
+
+	it('opens the lightbox on the first image when its thumbnail is clicked', async () => {
+		const images = buildImages(2);
+		const { findByRole, getByRole, user } = renderGallery(images);
+
+		await user.click(getByRole('button', { name: 'Bild 1 vergrößern' }));
+
+		const dialog = await findByRole('dialog', { name: 'Bild 1' });
+		expect(within(dialog).getByRole('img', { name: 'Bild 1' })).not.toBeNull();
+	});
+
+	it('opens the lightbox on the third image, not a shifted one, in the three-image bespoke layout', async () => {
+		const images = buildImages(3);
+		const { findByRole, getByRole, user } = renderGallery(images);
+
+		await user.click(getByRole('button', { name: 'Bild 3 vergrößern' }));
+
+		const dialog = await findByRole('dialog', { name: 'Bild 3' });
+		expect(within(dialog).getByRole('img', { name: 'Bild 3' })).not.toBeNull();
+	});
+
+	it('opens the lightbox on the second image, not a shifted one, in the three-image bespoke layout', async () => {
+		const images = buildImages(3);
+		const { findByRole, getByRole, user } = renderGallery(images);
+
+		await user.click(getByRole('button', { name: 'Bild 2 vergrößern' }));
+
+		const dialog = await findByRole('dialog', { name: 'Bild 2' });
+		expect(within(dialog).getByRole('img', { name: 'Bild 2' })).not.toBeNull();
+	});
+
+	it('renders nothing for an empty image list', () => {
+		const images = buildImages(0);
+		const { container } = render(<Gallery images={images} />);
+
+		expect(container.firstChild).toBeNull();
+	});
+});

--- a/apps/web/src/components/ui/gallery.test.tsx
+++ b/apps/web/src/components/ui/gallery.test.tsx
@@ -79,6 +79,15 @@ describe('gallery', () => {
 		expect(within(dialog).getByRole('img', { name: 'Bild 4' })).not.toBeNull();
 	});
 
+	it('renders the thumbnails in the same order as the input images, in the grid layout for more than three images', () => {
+		const images = buildImages(5);
+		const { getAllByRole } = renderGallery(images);
+
+		const names = getAllByRole('img').map((image) => image.getAttribute('alt'));
+
+		expect(names).toStrictEqual(['Bild 1', 'Bild 2', 'Bild 3', 'Bild 4', 'Bild 5']);
+	});
+
 	it('renders nothing for an empty image list', () => {
 		const images = buildImages(0);
 		const { container } = render(<Gallery images={images} />);

--- a/apps/web/src/components/ui/gallery.test.tsx
+++ b/apps/web/src/components/ui/gallery.test.tsx
@@ -88,6 +88,18 @@ describe('gallery', () => {
 		expect(names).toStrictEqual(['Bild 1', 'Bild 2', 'Bild 3', 'Bild 4', 'Bild 5']);
 	});
 
+	it('gives each trigger in the grid layout for more than three images the accessible name of the image nested inside it', () => {
+		const images = buildImages(5);
+		const { getAllByRole } = renderGallery(images);
+
+		const triggers = getAllByRole('button', { name: /vergrößern$/u });
+
+		for (const trigger of triggers) {
+			const alt = within(trigger).getByRole('img').getAttribute('alt');
+			expect(trigger.getAttribute('aria-label')).toBe(`${alt} vergrößern`);
+		}
+	});
+
 	it('renders nothing for an empty image list', () => {
 		const images = buildImages(0);
 		const { container } = render(<Gallery images={images} />);

--- a/apps/web/src/components/ui/lightbox.test.tsx
+++ b/apps/web/src/components/ui/lightbox.test.tsx
@@ -1,0 +1,167 @@
+import { cleanup, within } from '@testing-library/react';
+import Image from 'next/image';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { renderWithUser } from '../../../test-utils/render';
+import { LightboxGallery, LightboxTrigger } from './lightbox';
+import type { LightboxImage } from './lightbox';
+
+const FIRST_IMAGE: LightboxImage = { alt: 'Erstes Bild', key: 'first', srcFull: '/full/first.jpg' };
+
+const THREE_IMAGES: LightboxImage[] = [
+	FIRST_IMAGE,
+	{
+		alt: 'Zweites Bild',
+		caption: 'Die Mannschaft beim Aufwärmen',
+		key: 'second',
+		srcFull: '/full/second.jpg',
+	},
+	{ alt: 'Drittes Bild', key: 'third', srcFull: '/full/third.jpg' },
+];
+
+function renderGallery(images: LightboxImage[]) {
+	return renderWithUser(
+		<LightboxGallery images={images}>
+			{images.map((image, index) => (
+				<LightboxTrigger index={index} key={image.key}>
+					<Image
+						alt={`${image.alt} Vorschau`}
+						height={40}
+						src={`/thumb/${image.key}.jpg`}
+						width={40}
+					/>
+				</LightboxTrigger>
+			))}
+		</LightboxGallery>,
+	);
+}
+
+describe('lightbox gallery', () => {
+	// `renderWithUser` mounts straight into `document.body` and nothing in this file imports the
+	// vitest globals, so Testing Library's own auto-cleanup (which only registers itself when it
+	// finds a global `afterEach`) never runs — without this, the second test in the file would find
+	// its trigger buttons duplicated by the first test's still-mounted tree.
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('opens on the image belonging to the clicked trigger', async () => {
+		const { findByRole, getByRole, user } = renderGallery(THREE_IMAGES);
+
+		await user.click(getByRole('button', { name: 'Erstes Bild vergrößern' }));
+
+		const dialog = await findByRole('dialog', { name: 'Erstes Bild' });
+		expect(within(dialog).getByRole('img', { name: 'Erstes Bild' })).not.toBeNull();
+	});
+
+	it('opens on the third image, not the first, when its trigger is clicked', async () => {
+		const { findByRole, getByRole, user } = renderGallery(THREE_IMAGES);
+
+		await user.click(getByRole('button', { name: 'Drittes Bild vergrößern' }));
+
+		const dialog = await findByRole('dialog', { name: 'Drittes Bild' });
+		expect(within(dialog).getByRole('img', { name: 'Drittes Bild' })).not.toBeNull();
+	});
+
+	it('moves to the next and then back to the previous image with the paging controls', async () => {
+		const { findByRole, getByRole, user } = renderGallery(THREE_IMAGES);
+
+		await user.click(getByRole('button', { name: 'Erstes Bild vergrößern' }));
+		await findByRole('dialog', { name: 'Erstes Bild' });
+
+		await user.click(getByRole('button', { name: 'Nächstes Bild' }));
+		const secondDialog = await findByRole('dialog', { name: 'Zweites Bild' });
+		expect(within(secondDialog).getByRole('img', { name: 'Zweites Bild' })).not.toBeNull();
+
+		await user.click(getByRole('button', { name: 'Vorheriges Bild' }));
+		const firstDialog = await findByRole('dialog', { name: 'Erstes Bild' });
+		expect(within(firstDialog).getByRole('img', { name: 'Erstes Bild' })).not.toBeNull();
+	});
+
+	it('wraps from the last image to the first when paging forward past the end', async () => {
+		const { findByRole, getByRole, user } = renderGallery(THREE_IMAGES);
+
+		await user.click(getByRole('button', { name: 'Drittes Bild vergrößern' }));
+		await findByRole('dialog', { name: 'Drittes Bild' });
+
+		await user.click(getByRole('button', { name: 'Nächstes Bild' }));
+
+		const dialog = await findByRole('dialog', { name: 'Erstes Bild' });
+		expect(within(dialog).getByRole('img', { name: 'Erstes Bild' })).not.toBeNull();
+	});
+
+	it('wraps from the first image to the last when paging backward past the start', async () => {
+		const { findByRole, getByRole, user } = renderGallery(THREE_IMAGES);
+
+		await user.click(getByRole('button', { name: 'Erstes Bild vergrößern' }));
+		await findByRole('dialog', { name: 'Erstes Bild' });
+
+		await user.click(getByRole('button', { name: 'Vorheriges Bild' }));
+
+		const dialog = await findByRole('dialog', { name: 'Drittes Bild' });
+		expect(within(dialog).getByRole('img', { name: 'Drittes Bild' })).not.toBeNull();
+	});
+
+	it('closes on escape', async () => {
+		const { findByRole, getByRole, queryByRole, user } = renderGallery(THREE_IMAGES);
+
+		await user.click(getByRole('button', { name: 'Erstes Bild vergrößern' }));
+		await findByRole('dialog', { name: 'Erstes Bild' });
+
+		await user.keyboard('{Escape}');
+
+		expect(queryByRole('dialog')).toBeNull();
+	});
+
+	it('pages forward and backward through the images with the arrow keys', async () => {
+		const { findByRole, getByRole, user } = renderGallery(THREE_IMAGES);
+
+		await user.click(getByRole('button', { name: 'Erstes Bild vergrößern' }));
+		await findByRole('dialog', { name: 'Erstes Bild' });
+
+		await user.keyboard('{ArrowRight}');
+		const secondDialog = await findByRole('dialog', { name: 'Zweites Bild' });
+		expect(secondDialog.getAttribute('role')).toBe('dialog');
+
+		await user.keyboard('{ArrowLeft}');
+		const firstDialog = await findByRole('dialog', { name: 'Erstes Bild' });
+		expect(firstDialog.getAttribute('role')).toBe('dialog');
+	});
+
+	it('shows the caption of an image that has one', async () => {
+		const { findByRole, getByRole, getByText, user } = renderGallery(THREE_IMAGES);
+
+		await user.click(getByRole('button', { name: 'Zweites Bild vergrößern' }));
+		await findByRole('dialog', { name: 'Zweites Bild' });
+
+		expect(getByText('Die Mannschaft beim Aufwärmen')).not.toBeNull();
+	});
+
+	it('renders no caption for an image that has none', async () => {
+		const { findByRole, getByRole, queryByText, user } = renderGallery(THREE_IMAGES);
+
+		await user.click(getByRole('button', { name: 'Erstes Bild vergrößern' }));
+		await findByRole('dialog', { name: 'Erstes Bild' });
+
+		expect(queryByText('Die Mannschaft beim Aufwärmen')).toBeNull();
+	});
+
+	it('hides the paging controls for a gallery with a single image', async () => {
+		const { findByRole, getByRole, queryByRole, user } = renderGallery([FIRST_IMAGE]);
+
+		await user.click(getByRole('button', { name: 'Erstes Bild vergrößern' }));
+		await findByRole('dialog', { name: 'Erstes Bild' });
+
+		expect(queryByRole('button', { name: 'Nächstes Bild' })).toBeNull();
+		expect(queryByRole('button', { name: 'Vorheriges Bild' })).toBeNull();
+	});
+
+	it('exposes a dialog role with an accessible name matching the open image', async () => {
+		const { findByRole, getByRole, user } = renderGallery(THREE_IMAGES);
+
+		await user.click(getByRole('button', { name: 'Zweites Bild vergrößern' }));
+
+		const dialog = await findByRole('dialog', { name: 'Zweites Bild' });
+		expect(dialog.getAttribute('role')).toBe('dialog');
+	});
+});

--- a/apps/web/src/components/ui/lightbox.test.tsx
+++ b/apps/web/src/components/ui/lightbox.test.tsx
@@ -1,6 +1,6 @@
-import { cleanup, within } from '@testing-library/react';
+import { within } from '@testing-library/react';
 import Image from 'next/image';
-import { afterEach, describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import { renderWithUser } from '../../../test-utils/render';
 import { LightboxGallery, LightboxTrigger } from './lightbox';
@@ -37,14 +37,6 @@ function renderGallery(images: LightboxImage[]) {
 }
 
 describe('lightbox gallery', () => {
-	// `renderWithUser` mounts straight into `document.body` and nothing in this file imports the
-	// vitest globals, so Testing Library's own auto-cleanup (which only registers itself when it
-	// finds a global `afterEach`) never runs — without this, the second test in the file would find
-	// its trigger buttons duplicated by the first test's still-mounted tree.
-	afterEach(() => {
-		cleanup();
-	});
-
 	it('opens on the image belonging to the clicked trigger', async () => {
 		const { findByRole, getByRole, user } = renderGallery(THREE_IMAGES);
 

--- a/apps/web/src/components/ui/portable-text.test.tsx
+++ b/apps/web/src/components/ui/portable-text.test.tsx
@@ -1,0 +1,167 @@
+import { render } from '@testing-library/react';
+import type { PortableTextBlock } from 'next-sanity';
+import { describe, expect, it, vi } from 'vitest';
+
+import { PortableText } from './portable-text';
+import type { PortableTextValue } from './portable-text';
+
+/** Minimal shape of a mark definition, matching what `internalLink`/`externalLink` need. */
+interface MarkDef {
+	_key: string;
+	_type: string;
+	[key: string]: unknown;
+}
+
+function textBlock(
+	key: string,
+	text: string,
+	style: PortableTextBlock['style'] = 'normal',
+): PortableTextBlock {
+	return {
+		_key: key,
+		_type: 'block',
+		children: [{ _key: `${key}-span`, _type: 'span', marks: [], text }],
+		markDefs: [],
+		style,
+	};
+}
+
+function markedBlock(key: string, text: string, markDef: MarkDef): PortableTextBlock {
+	return {
+		_key: key,
+		_type: 'block',
+		children: [{ _key: `${key}-span`, _type: 'span', marks: [markDef._key], text }],
+		markDefs: [markDef],
+		style: 'normal',
+	};
+}
+
+function renderPortableText(value: PortableTextValue) {
+	return render(<PortableText value={value} />);
+}
+
+describe('portable text', () => {
+	it('renders a blockquote block as a blockquote element', () => {
+		const { getByText } = renderPortableText([textBlock('bq', 'Ein Zitat.', 'blockquote')]);
+
+		const quote = getByText('Ein Zitat.');
+		expect(quote.closest('blockquote')).not.toBeNull();
+	});
+
+	it('renders an h2 block as a heading with an anchor link to its own key', () => {
+		const { getByRole } = renderPortableText([textBlock('section-1', 'Abschnitt', 'h2')]);
+
+		const heading = getByRole('heading', { level: 2, name: 'Abschnitt' });
+		expect(heading.id).toBe('section-1');
+
+		const anchor = getByRole('link', { name: 'Zum Abschnitt springen' });
+		expect(anchor.getAttribute('href')).toBe('#section-1');
+	});
+
+	it('renders an h3 block as a heading with an anchor link to its own key', () => {
+		const { getByRole } = renderPortableText([textBlock('section-2', 'Unterabschnitt', 'h3')]);
+
+		const heading = getByRole('heading', { level: 3, name: 'Unterabschnitt' });
+		expect(heading.id).toBe('section-2');
+
+		const anchor = getByRole('link', { name: 'Zum Abschnitt springen' });
+		expect(anchor.getAttribute('href')).toBe('#section-2');
+	});
+
+	it('renders a bullet list block as a ul with a li per item', () => {
+		const { getByRole } = renderPortableText([
+			{ ...textBlock('item-1', 'Erster Punkt'), level: 1, listItem: 'bullet' },
+			{ ...textBlock('item-2', 'Zweiter Punkt'), level: 1, listItem: 'bullet' },
+		]);
+
+		const list = getByRole('list');
+		expect(list.tagName).toBe('UL');
+		const items = list.querySelectorAll('li');
+		expect(items).toHaveLength(2);
+		expect(items[0]?.textContent).toBe('Erster Punkt');
+		expect(items[1]?.textContent).toBe('Zweiter Punkt');
+	});
+
+	it('renders a numbered list block as an ol with a li per item', () => {
+		const { getByRole } = renderPortableText([
+			{ ...textBlock('num-1', 'Erster Schritt'), level: 1, listItem: 'number' },
+			{ ...textBlock('num-2', 'Zweiter Schritt'), level: 1, listItem: 'number' },
+		]);
+
+		const list = getByRole('list');
+		expect(list.tagName).toBe('OL');
+		const items = list.querySelectorAll('li');
+		expect(items).toHaveLength(2);
+		expect(items[0]?.textContent).toBe('Erster Schritt');
+		expect(items[1]?.textContent).toBe('Zweiter Schritt');
+	});
+
+	it('resolves an internal link mark to the href built by getInternalHref', () => {
+		const { getByRole } = renderPortableText([
+			markedBlock('int', 'Zu den News', {
+				_key: 'int-mark',
+				_type: 'internalLink',
+				target: { _type: 'news.category', slug: 'aktuelles' },
+			}),
+		]);
+
+		const link = getByRole('link', { name: 'Zu den News' });
+		expect(link.getAttribute('href')).toBe('/news/aktuelles');
+	});
+
+	it('renders no link for an internal link mark whose target does not resolve', () => {
+		const { getByText, queryByRole } = renderPortableText([
+			markedBlock('int-broken', 'Toter Link', {
+				_key: 'int-mark-broken',
+				_type: 'internalLink',
+				target: null,
+			}),
+		]);
+
+		expect(queryByRole('link')).toBeNull();
+		expect(getByText('Toter Link')).not.toBeNull();
+	});
+
+	it('renders an external link mark with rel and target for a new tab', () => {
+		const { getByRole } = renderPortableText([
+			markedBlock('ext', 'TSG Sponsoren', {
+				_key: 'ext-mark',
+				_type: 'externalLink',
+				href: 'https://sponsor.example.com',
+			}),
+		]);
+
+		const link = getByRole('link', { name: 'TSG Sponsoren (öffnet in neuem Tab)' });
+		expect(link.getAttribute('href')).toBe('https://sponsor.example.com');
+		expect(link.getAttribute('rel')).toBe('noopener noreferrer');
+		expect(link.getAttribute('target')).toBe('_blank');
+	});
+
+	it('does not crash rendering an unknown block type', () => {
+		const warnSpy = vi.spyOn(console, 'warn').mockReturnValue();
+
+		expect(() =>
+			renderPortableText([{ _key: 'callout-1', _type: 'callout', text: 'Achtung!' }]),
+		).not.toThrow();
+
+		warnSpy.mockRestore();
+	});
+
+	it('does not render an alt-accessible image for an image block (no `types.image` component is registered)', () => {
+		const warnSpy = vi.spyOn(console, 'warn').mockReturnValue();
+
+		const { queryByAltText, queryByRole } = renderPortableText([
+			{
+				_key: 'image-1',
+				_type: 'image',
+				alt: 'Gruppenfoto beim Training',
+				asset: { _ref: 'image-abc123-800x600-jpg', _type: 'reference' },
+			},
+		]);
+
+		expect(queryByRole('img')).toBeNull();
+		expect(queryByAltText('Gruppenfoto beim Training')).toBeNull();
+
+		warnSpy.mockRestore();
+	});
+});

--- a/apps/web/src/components/with-logic/breadcrumb.test.tsx
+++ b/apps/web/src/components/with-logic/breadcrumb.test.tsx
@@ -5,17 +5,6 @@ import { renderWithUser } from '../../../test-utils/render';
 import { setPathname } from '../../../test-utils/setup-dom';
 import Breadcrumb from './breadcrumb';
 
-// `getBreadcrumbItemsPaths` (`breadcrumb.tsx`) builds its `path`/`title` pairs from
-// `pathname.split('/').slice(1).slice(0, LAST_INDEX)` — i.e. every segment *except the last one*.
-// The component's fallback for an omitted `currentPage` prop then reads
-// `breadcrumbItemsPaths.at(LAST_INDEX)?.title`, which is the last element of that already-truncated
-// array, not the true final URL segment. For a two-segment path like `/verein/vorstand-team` this
-// means the fallback "current page" duplicates the *second-to-last* segment's title ("Verein") and
-// the real last segment ("vorstand-team" → "Vorstand Team") never appears anywhere in the tree. In
-// this codebase `currentPage` is always supplied (`Hero` in `section/hero.tsx` passes its required
-// `title` prop straight through), so the bug is not reachable today, but it is a live defect in the
-// component's own public (optional) prop contract. Reported here, not fixed — see the last test
-// below, which pins the actual (buggy) output rather than the fallback's apparent intent.
 describe('breadcrumb', () => {
 	it('renders the home link, one link per pathname segment before the last, and the current page as plain text', () => {
 		setPathname('/verein/vorstand-team');
@@ -32,7 +21,12 @@ describe('breadcrumb', () => {
 		expect(getByText('Der Vorstand')).not.toBeNull();
 	});
 
-	it('accumulates the link paths across more than two segments and still drops the last one from the links', () => {
+	// Renamed from "accumulates the link paths across more than two segments...": the truncated
+	// array (`breadcrumbItems.slice(0, LAST_INDEX)`) only ever holds two entries for a three-segment
+	// path, so this never drives the accumulator past its second iteration — it is the same
+	// accumulation as the two-segment case above, plus one more correct entry. It does NOT reach the
+	// accumulator bug pinned below, which only surfaces from the third entry onward.
+	it('accumulates two link paths correctly for a three-segment pathname, still dropping the last segment from the links', () => {
 		setPathname('/a/b/c');
 		const { getByRole } = renderWithUser(<Breadcrumb currentPage="Current Page" />);
 
@@ -45,6 +39,27 @@ describe('breadcrumb', () => {
 			['/a/b', 'B'],
 		]);
 		expect(within(nav).queryByRole('link', { name: /c/iu })).toBeNull();
+	});
+
+	// Regression case: `getBreadcrumbItemsPaths` (`breadcrumb.tsx:25-29`) resets
+	// `breadcrumbItemsPathsLast` to the bare `/${item}` instead of the accumulated `path`, so from
+	// the third link onward the href is wrong. For `/a/b/c/d` the third link should be `/a/b/c` but
+	// is actually `/b/c` — the accumulator only remembers the single previous segment. Unreachable
+	// today (the deepest route has three segments, and the array is truncated to two links before
+	// this ever shows), so not fixed here — this pins the actual, buggy output.
+	it('documents the accumulator bug: the third link onward loses everything but the previous single segment, for a four-segment pathname', () => {
+		setPathname('/a/b/c/d');
+		const { getByRole } = renderWithUser(<Breadcrumb currentPage="Current Page" />);
+
+		const nav = getByRole('navigation', { name: 'breadcrumb' });
+		const links = within(nav).getAllByRole('link');
+
+		expect(links.map((link) => [link.getAttribute('href'), link.textContent])).toStrictEqual([
+			['/', 'Home'],
+			['/a', 'A'],
+			['/a/b', 'B'],
+			['/b/c', 'C'],
+		]);
 	});
 
 	it('humanises a hyphenated, mixed-case segment into title-cased words', () => {
@@ -63,6 +78,11 @@ describe('breadcrumb', () => {
 		expect(getByText('Der Vorstand').getAttribute('aria-current')).toBe('page');
 	});
 
+	// Regression case: the truncated array `breadcrumbItemsPaths` (`breadcrumb.tsx`) never contains
+	// the true last URL segment, so the `currentPage` fallback (`breadcrumbItemsPaths.at(LAST_INDEX)
+	// ?.title`) duplicates the *second-to-last* segment's title instead. Unreachable today —
+	// `Hero` (`section/hero.tsx`) always supplies `currentPage` — but a live defect in the
+	// component's own optional prop contract. Not fixed here; this pins the actual output.
 	it('duplicates the last *linked* segment as the fallback current page instead of the true final URL segment, when currentPage is omitted', () => {
 		setPathname('/verein/vorstand-team');
 		const { getAllByText, queryByText } = renderWithUser(<Breadcrumb />);

--- a/apps/web/src/components/with-logic/breadcrumb.test.tsx
+++ b/apps/web/src/components/with-logic/breadcrumb.test.tsx
@@ -1,0 +1,79 @@
+import { within } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { renderWithUser } from '../../../test-utils/render';
+import { setPathname } from '../../../test-utils/setup-dom';
+import Breadcrumb from './breadcrumb';
+
+// `getBreadcrumbItemsPaths` (`breadcrumb.tsx`) builds its `path`/`title` pairs from
+// `pathname.split('/').slice(1).slice(0, LAST_INDEX)` — i.e. every segment *except the last one*.
+// The component's fallback for an omitted `currentPage` prop then reads
+// `breadcrumbItemsPaths.at(LAST_INDEX)?.title`, which is the last element of that already-truncated
+// array, not the true final URL segment. For a two-segment path like `/verein/vorstand-team` this
+// means the fallback "current page" duplicates the *second-to-last* segment's title ("Verein") and
+// the real last segment ("vorstand-team" → "Vorstand Team") never appears anywhere in the tree. In
+// this codebase `currentPage` is always supplied (`Hero` in `section/hero.tsx` passes its required
+// `title` prop straight through), so the bug is not reachable today, but it is a live defect in the
+// component's own public (optional) prop contract. Reported here, not fixed — see the last test
+// below, which pins the actual (buggy) output rather than the fallback's apparent intent.
+describe('breadcrumb', () => {
+	it('renders the home link, one link per pathname segment before the last, and the current page as plain text', () => {
+		setPathname('/verein/vorstand-team');
+		const { getByRole, getByText } = renderWithUser(<Breadcrumb currentPage="Der Vorstand" />);
+
+		const nav = getByRole('navigation', { name: 'breadcrumb' });
+		const links = within(nav).getAllByRole('link');
+
+		expect(links.map((link) => [link.getAttribute('href'), link.textContent])).toStrictEqual([
+			['/', 'Home'],
+			['/verein', 'Verein'],
+		]);
+		expect(within(nav).queryByRole('link', { name: 'Der Vorstand' })).toBeNull();
+		expect(getByText('Der Vorstand')).not.toBeNull();
+	});
+
+	it('accumulates the link paths across more than two segments and still drops the last one from the links', () => {
+		setPathname('/a/b/c');
+		const { getByRole } = renderWithUser(<Breadcrumb currentPage="Current Page" />);
+
+		const nav = getByRole('navigation', { name: 'breadcrumb' });
+		const links = within(nav).getAllByRole('link');
+
+		expect(links.map((link) => [link.getAttribute('href'), link.textContent])).toStrictEqual([
+			['/', 'Home'],
+			['/a', 'A'],
+			['/a/b', 'B'],
+		]);
+		expect(within(nav).queryByRole('link', { name: /c/iu })).toBeNull();
+	});
+
+	it('humanises a hyphenated, mixed-case segment into title-cased words', () => {
+		setPathname('/MEIN-Verein/team');
+		const { getByRole } = renderWithUser(<Breadcrumb currentPage="Teamübersicht" />);
+
+		const nav = getByRole('navigation', { name: 'breadcrumb' });
+
+		expect(within(nav).getByRole('link', { name: 'Mein Verein' })).not.toBeNull();
+	});
+
+	it('marks the current page as programmatically identifiable through aria-current, regardless of its class-only styling', () => {
+		setPathname('/verein/vorstand-team');
+		const { getByText } = renderWithUser(<Breadcrumb currentPage="Der Vorstand" />);
+
+		expect(getByText('Der Vorstand').getAttribute('aria-current')).toBe('page');
+	});
+
+	it('duplicates the last *linked* segment as the fallback current page instead of the true final URL segment, when currentPage is omitted', () => {
+		setPathname('/verein/vorstand-team');
+		const { getAllByText, queryByText } = renderWithUser(<Breadcrumb />);
+
+		const vereinMatches = getAllByText('Verein');
+
+		expect(vereinMatches).toHaveLength(2);
+		expect(vereinMatches[0].tagName).toBe('A');
+		expect(vereinMatches[1].getAttribute('aria-current')).toBe('page');
+		// The true last segment's humanised label is dropped entirely — it never appears as a link
+		// (expected) nor as the current-page text (the bug).
+		expect(queryByText('Vorstand Team')).toBeNull();
+	});
+});

--- a/apps/web/src/components/with-logic/contact-link.test.tsx
+++ b/apps/web/src/components/with-logic/contact-link.test.tsx
@@ -66,6 +66,33 @@ describe('the contact link', () => {
 		);
 	});
 
+	// With no `children`, the rendered text falls back to `reverse(hrefText)` before interaction.
+	// A plain ASCII href has no grapheme clusters spanning more than one UTF-16 code unit and no
+	// parentheses, so this pins the baseline: every character reversed in place, nothing else.
+	it('renders the reversed href text before any interaction', () => {
+		const { getByRole } = renderWithUser(<ContactLink href="tel:+49 176 1234567" />);
+
+		expect(getByRole('button').textContent).toBe('7654321 671 94+');
+	});
+
+	// The 😀 emoji is a surrogate pair (two UTF-16 code units). Reversing by code unit instead of by
+	// grapheme cluster splits the pair apart and reassembles it in the wrong order, producing two lone
+	// surrogates instead of the original emoji. `reverse()` segments with `Intl.Segmenter` precisely to
+	// keep this cluster intact, so this is the case that actually pins grapheme-awareness.
+	it('keeps a multi-code-unit grapheme cluster intact when reversing, rather than reversing UTF-16 code units', () => {
+		const { getByRole } = renderWithUser(<ContactLink href="tel:+49 176 😀 1234567" />);
+
+		expect(getByRole('button').textContent).toBe('7654321 😀 671 94+');
+	});
+
+	// `reverse()` also swaps `(` for `)` (and vice versa) as it reverses, so a parenthesised area code
+	// still opens and closes the right way round instead of ending up back to front.
+	it('swaps parentheses so they still point the right way once the text is reversed', () => {
+		const { getByRole } = renderWithUser(<ContactLink href="tel:+49 (0)176 1234567" />);
+
+		expect(getByRole('button').textContent).toBe('7654321 671(0) 94+');
+	});
+
 	// `contact-link.tsx`'s `renderProps` spreads `...props` and only THEN sets `'aria-label'`, so a
 	// caller-supplied label always loses — before interaction it is forced to the generic string
 	// above regardless of what the caller passed, after interaction it is discarded outright. This is

--- a/apps/web/src/components/with-logic/contact-link.test.tsx
+++ b/apps/web/src/components/with-logic/contact-link.test.tsx
@@ -3,15 +3,6 @@ import { describe, expect, it } from 'vitest';
 import { renderWithUser } from '../../../test-utils/render';
 import { ContactLink } from './contact-link';
 
-// Accessibility observation, not a bug fixed here: `ContactLink` spreads `...props` and only then
-// sets `'aria-label'` (`contact-link.tsx`'s `renderProps`), so it always wins over anything a
-// caller passes — before interaction it is forced to the generic string below regardless of
-// whether the link is an email, a phone number or a WhatsApp link, and after interaction it is
-// removed outright. `ui/contact-button.tsx` passes a purpose-specific `aria-label` ("E-Mail",
-// "Telefon", "Whatsapp") together with an `aria-hidden` icon as the only child — once a user
-// interacts with that button once (even just by focusing or hovering it), `ContactLink` both
-// overwrites/removes that label AND the visible content is `aria-hidden`, so the button is left
-// with no accessible name at all. The last two tests below pin this against `ContactLink` directly.
 // Declared once at module scope rather than as an inline object literal in the JSX below, per the
 // `react-perf/jsx-no-new-object-as-prop` rule (still active for `.test.tsx` files despite the
 // `**/*.tsx` override in `oxlint.config.ts`).
@@ -55,6 +46,16 @@ describe('the contact link', () => {
 		expect(getByRole('link').getAttribute('href')).toBe('tel:+491761234567');
 	});
 
+	it('resolves to the exact wa.me href, unchanged, once interacted with', async () => {
+		const { getByRole, user } = renderWithUser(
+			<ContactLink href="https://wa.me/491761234567">+49 176 1234567</ContactLink>,
+		);
+
+		await user.click(getByRole('button'));
+
+		expect(getByRole('link').getAttribute('href')).toBe('https://wa.me/491761234567');
+	});
+
 	it('exposes only a generic aria-label before interaction, not identifying whether this is an email, phone or WhatsApp link', () => {
 		const { getByRole } = renderWithUser(
 			<ContactLink href="mailto:info@tsg-irlich.de">info@tsg-irlich.de</ContactLink>,
@@ -65,6 +66,33 @@ describe('the contact link', () => {
 		);
 	});
 
+	// `contact-link.tsx`'s `renderProps` spreads `...props` and only THEN sets `'aria-label'`, so a
+	// caller-supplied label always loses — before interaction it is forced to the generic string
+	// above regardless of what the caller passed, after interaction it is discarded outright. This is
+	// the mechanism the next test (no accessible name at all) rests on: a component "fixed" to defer
+	// to a caller's label when one is supplied would still pass every other case in this file
+	// unchanged, so this is the one that actually pins it.
+	it('overrides a caller-supplied aria-label with its own generic one before interaction, and discards it entirely after interaction', async () => {
+		const { getByRole, user } = renderWithUser(
+			<ContactLink aria-label="E-Mail" href="mailto:info@tsg-irlich.de">
+				info@tsg-irlich.de
+			</ContactLink>,
+		);
+
+		expect(getByRole('button').getAttribute('aria-label')).toBe(
+			'Kontaktlink - tippen zum Anzeigen',
+		);
+
+		await user.click(getByRole('button'));
+
+		expect(getByRole('link').getAttribute('aria-label')).toBeNull();
+	});
+
+	// `ui/contact-button.tsx` passes a purpose-specific `aria-label` ("E-Mail", "Telefon", "Whatsapp")
+	// together with an `aria-hidden` icon as the only child. Once a user interacts with such a button
+	// even once — including just hovering or focusing it, since `onMouseOver`/`onFocus` also call
+	// `handleInteraction` — `ContactLink` discards that label (pinned above) and the only remaining
+	// content is `aria-hidden`, leaving the button with no accessible name at all.
 	it('is left with no accessible name at all once interacted with, when its content is hidden from assistive technology (as ui/contact-button.tsx renders it)', async () => {
 		const { getByRole, user } = renderWithUser(
 			<ContactLink href="mailto:info@tsg-irlich.de">

--- a/apps/web/src/components/with-logic/contact-link.test.tsx
+++ b/apps/web/src/components/with-logic/contact-link.test.tsx
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+
+import { renderWithUser } from '../../../test-utils/render';
+import { ContactLink } from './contact-link';
+
+// Accessibility observation, not a bug fixed here: `ContactLink` spreads `...props` and only then
+// sets `'aria-label'` (`contact-link.tsx`'s `renderProps`), so it always wins over anything a
+// caller passes — before interaction it is forced to the generic string below regardless of
+// whether the link is an email, a phone number or a WhatsApp link, and after interaction it is
+// removed outright. `ui/contact-button.tsx` passes a purpose-specific `aria-label` ("E-Mail",
+// "Telefon", "Whatsapp") together with an `aria-hidden` icon as the only child — once a user
+// interacts with that button once (even just by focusing or hovering it), `ContactLink` both
+// overwrites/removes that label AND the visible content is `aria-hidden`, so the button is left
+// with no accessible name at all. The last two tests below pin this against `ContactLink` directly.
+// Declared once at module scope rather than as an inline object literal in the JSX below, per the
+// `react-perf/jsx-no-new-object-as-prop` rule (still active for `.test.tsx` files despite the
+// `**/*.tsx` override in `oxlint.config.ts`).
+const MAILTO_HEADER = { subject: 'Hallo Welt', body: 'Bitte um Rückruf' };
+
+describe('the contact link', () => {
+	it('resolves to the exact mailto href, unchanged, once interacted with', async () => {
+		const { getByRole, user } = renderWithUser(
+			<ContactLink href="mailto:info@tsg-irlich.de">info@tsg-irlich.de</ContactLink>,
+		);
+
+		const link = getByRole('button');
+		expect(link.getAttribute('href')).toBe('#');
+
+		await user.click(link);
+
+		expect(getByRole('link').getAttribute('href')).toBe('mailto:info@tsg-irlich.de');
+	});
+
+	it('builds the mailto href with its header parameters URL-encoded, once interacted with', async () => {
+		const { getByRole, user } = renderWithUser(
+			<ContactLink header={MAILTO_HEADER} href="mailto:info@tsg-irlich.de">
+				info@tsg-irlich.de
+			</ContactLink>,
+		);
+
+		await user.click(getByRole('button'));
+
+		expect(getByRole('link').getAttribute('href')).toBe(
+			'mailto:info@tsg-irlich.de?subject=Hallo%20Welt&body=Bitte%20um%20R%C3%BCckruf',
+		);
+	});
+
+	it('strips whitespace from a tel href, once interacted with', async () => {
+		const { getByRole, user } = renderWithUser(
+			<ContactLink href="tel:+49 176 1234567">+49 176 1234567</ContactLink>,
+		);
+
+		await user.click(getByRole('button'));
+
+		expect(getByRole('link').getAttribute('href')).toBe('tel:+491761234567');
+	});
+
+	it('exposes only a generic aria-label before interaction, not identifying whether this is an email, phone or WhatsApp link', () => {
+		const { getByRole } = renderWithUser(
+			<ContactLink href="mailto:info@tsg-irlich.de">info@tsg-irlich.de</ContactLink>,
+		);
+
+		expect(getByRole('button').getAttribute('aria-label')).toBe(
+			'Kontaktlink - tippen zum Anzeigen',
+		);
+	});
+
+	it('is left with no accessible name at all once interacted with, when its content is hidden from assistive technology (as ui/contact-button.tsx renders it)', async () => {
+		const { getByRole, user } = renderWithUser(
+			<ContactLink href="mailto:info@tsg-irlich.de">
+				<span aria-hidden="true">Icon</span>
+			</ContactLink>,
+		);
+
+		await user.click(getByRole('button'));
+
+		const link = getByRole('link');
+		expect(link.getAttribute('aria-label')).toBeNull();
+		expect(link.getAttribute('aria-labelledby')).toBeNull();
+		// The only content is still there in the DOM (`textContent` sees it), but hidden from
+		// assistive technology — together with the two assertions above, nothing is left to give this
+		// link an accessible name.
+		expect(link.textContent).toBe('Icon');
+		expect(link.querySelector('[aria-hidden="true"]')).not.toBeNull();
+	});
+});

--- a/apps/web/src/components/with-logic/contact-persons.test.tsx
+++ b/apps/web/src/components/with-logic/contact-persons.test.tsx
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+
+import type { ContactPerson } from '@/types/sanity.types';
+
+import { loadWithEnv } from '../../../test-utils/env';
+import { renderWithUser } from '../../../test-utils/render';
+import type * as ContactPersonsModule from './contact-persons';
+
+// `contact-persons.tsx` imports `urlForImage` from `@/lib/sanity/utils`, which imports the Sanity
+// `client` (`@/lib/sanity/client` → `@/lib/sanity/api`), and `api.ts` reads
+// `NEXT_PUBLIC_SANITY_DATASET`/`NEXT_PUBLIC_SANITY_PROJECT_ID` from `process.env` at module top
+// level, throwing immediately if either is missing — before any test in this file even runs a
+// component. `loadWithEnv` (`test-utils/env.ts`) stubs both and re-imports the module fresh, the
+// same pattern `src/utils/url.test.ts` uses for `@/lib/env.ts`'s module-level caching; the values
+// themselves are arbitrary, since no test here asserts on the built image URL.
+const SANITY_ENV = {
+	NEXT_PUBLIC_SANITY_DATASET: 'test-dataset',
+	NEXT_PUBLIC_SANITY_PROJECT_ID: 'test-project',
+};
+
+async function loadContactPersons() {
+	return loadWithEnv<typeof ContactPersonsModule>(
+		'@/components/with-logic/contact-persons',
+		SANITY_ENV,
+	);
+}
+
+const BASE_PERSON: ContactPerson = {
+	contactAs: 'both',
+	email: 'anna.schmidt@tsg-irlich.de',
+	firstName: 'Anna',
+	image: { _type: 'extendedImage', alt: '' },
+	lastName: 'Schmidt',
+	phone: '0176 1234567',
+	role: 'Vorstandsvorsitzende',
+	taskDescription: 'Ansprechpartnerin für den Vorstand.',
+};
+
+const PERSON_WITH_IMAGE: ContactPerson = {
+	...BASE_PERSON,
+	image: {
+		_type: 'extendedImage',
+		alt: 'Porträt von Anna Schmidt',
+		asset: { _ref: 'image-abc123-800x600-jpg', _type: 'reference' },
+	},
+};
+
+// Declared once at module scope, rather than as inline array literals at each call site, per the
+// `react-perf/jsx-no-new-array-as-prop` rule (still active for `.test.tsx` files despite the
+// `**/*.tsx` override in `oxlint.config.ts` — see `navigation.test.tsx`'s `renderNavigation` for
+// the same pattern).
+const NO_IMAGE_LIST: ContactPerson[] = [BASE_PERSON];
+const WITH_IMAGE_LIST: ContactPerson[] = [PERSON_WITH_IMAGE];
+const EMPTY_LIST: ContactPerson[] = [];
+
+describe('the contact persons list', () => {
+	it('falls back to the initials when a person has no image', async () => {
+		const { ContactPersons } = await loadContactPersons();
+		const { container, getByText } = renderWithUser(
+			<ContactPersons contactPersons={NO_IMAGE_LIST} />,
+		);
+
+		expect(getByText('AS')).not.toBeNull();
+		expect(container.querySelector('img')).toBeNull();
+	});
+
+	it('renders an image instead of initials once a person has one', async () => {
+		const { ContactPersons } = await loadContactPersons();
+		const { container, getByRole, queryByText } = renderWithUser(
+			<ContactPersons contactPersons={WITH_IMAGE_LIST} />,
+		);
+
+		expect(getByRole('img', { name: 'Porträt von Anna Schmidt' })).not.toBeNull();
+		expect(queryByText('AS')).toBeNull();
+		expect(container.querySelectorAll('article')).toHaveLength(1);
+	});
+
+	it('renders nothing when the list is empty', async () => {
+		const { ContactPersons } = await loadContactPersons();
+		const { container } = renderWithUser(<ContactPersons contactPersons={EMPTY_LIST} />);
+
+		expect(container.querySelectorAll('article')).toHaveLength(0);
+	});
+});

--- a/apps/web/src/components/with-logic/contact-persons.test.tsx
+++ b/apps/web/src/components/with-logic/contact-persons.test.tsx
@@ -47,6 +47,16 @@ const PERSON_WITH_IMAGE: ContactPerson = {
 const NO_IMAGE_LIST: ContactPerson[] = [BASE_PERSON];
 const WITH_IMAGE_LIST: ContactPerson[] = [PERSON_WITH_IMAGE];
 const EMPTY_LIST: ContactPerson[] = [];
+const PHONE_ONLY_LIST: ContactPerson[] = [{ ...BASE_PERSON, contactAs: 'phone' }];
+const WHATSAPP_ONLY_LIST: ContactPerson[] = [{ ...BASE_PERSON, contactAs: 'whatsapp' }];
+const EMAIL_ONLY_LIST: ContactPerson[] = [{ ...BASE_PERSON, contactAs: 'email' }];
+const NO_PHONE_LIST: ContactPerson[] = [{ ...BASE_PERSON, phone: null }];
+
+// `contact-link.tsx` forces this exact aria-label on every `ContactLink` before it has been
+// interacted with, discarding whatever `ui/contact-button.tsx` passed in (see
+// `contact-link.test.tsx`'s "overrides a caller-supplied aria-label..." case) — so every contact
+// control, whatever it links to, is queryable by this one generic name before interaction.
+const KONTAKTLINK_LABEL = 'Kontaktlink - tippen zum Anzeigen';
 
 describe('the contact persons list', () => {
 	it('falls back to the initials when a person has no image', () => {
@@ -72,5 +82,81 @@ describe('the contact persons list', () => {
 		const { container } = renderWithUser(<ContactPersons contactPersons={EMPTY_LIST} />);
 
 		expect(container.querySelectorAll('article')).toHaveLength(0);
+	});
+
+	// Each `controls[n]` reference is queried once, before any interaction, then reused after
+	// clicking it — the underlying DOM node persists across the re-render, so `getAttribute('href')`
+	// on the same reference sees the real `mailto:`/`tel:`/`wa.me` href `ContactLink` resolves to
+	// once interacted with (see `contact-link.tsx`'s `createContactLink`).
+	it('shows the phone control but not whatsapp when contactAs is "phone"', async () => {
+		const { getAllByRole, user } = renderWithUser(
+			<ContactPersons contactPersons={PHONE_ONLY_LIST} />,
+		);
+
+		const controls = getAllByRole('button', { name: KONTAKTLINK_LABEL });
+		expect(controls).toHaveLength(2);
+
+		await user.click(controls[0]);
+		expect(controls[0].getAttribute('href')).toBe('mailto:anna.schmidt@tsg-irlich.de');
+
+		await user.click(controls[1]);
+		expect(controls[1].getAttribute('href')).toBe('tel:01761234567');
+	});
+
+	it('shows the whatsapp control but not phone when contactAs is "whatsapp"', async () => {
+		const { getAllByRole, user } = renderWithUser(
+			<ContactPersons contactPersons={WHATSAPP_ONLY_LIST} />,
+		);
+
+		const controls = getAllByRole('button', { name: KONTAKTLINK_LABEL });
+		expect(controls).toHaveLength(2);
+
+		await user.click(controls[0]);
+		expect(controls[0].getAttribute('href')).toBe('mailto:anna.schmidt@tsg-irlich.de');
+
+		await user.click(controls[1]);
+		expect(controls[1].getAttribute('href')).toBe('https://wa.me/01761234567');
+	});
+
+	it('shows all three controls, email, phone and whatsapp, when contactAs is "both"', async () => {
+		const { getAllByRole, user } = renderWithUser(
+			<ContactPersons contactPersons={NO_IMAGE_LIST} />,
+		);
+
+		const controls = getAllByRole('button', { name: KONTAKTLINK_LABEL });
+		expect(controls).toHaveLength(3);
+
+		await user.click(controls[0]);
+		expect(controls[0].getAttribute('href')).toBe('mailto:anna.schmidt@tsg-irlich.de');
+
+		await user.click(controls[1]);
+		expect(controls[1].getAttribute('href')).toBe('tel:01761234567');
+
+		await user.click(controls[2]);
+		expect(controls[2].getAttribute('href')).toBe('https://wa.me/01761234567');
+	});
+
+	it('shows only the email control when contactAs is "email", even though a phone number is set', async () => {
+		const { getAllByRole, user } = renderWithUser(
+			<ContactPersons contactPersons={EMAIL_ONLY_LIST} />,
+		);
+
+		const controls = getAllByRole('button', { name: KONTAKTLINK_LABEL });
+		expect(controls).toHaveLength(1);
+
+		await user.click(controls[0]);
+		expect(controls[0].getAttribute('href')).toBe('mailto:anna.schmidt@tsg-irlich.de');
+	});
+
+	it('hides both phone and whatsapp controls when the phone number is absent, regardless of contactAs', async () => {
+		const { getAllByRole, user } = renderWithUser(
+			<ContactPersons contactPersons={NO_PHONE_LIST} />,
+		);
+
+		const controls = getAllByRole('button', { name: KONTAKTLINK_LABEL });
+		expect(controls).toHaveLength(1);
+
+		await user.click(controls[0]);
+		expect(controls[0].getAttribute('href')).toBe('mailto:anna.schmidt@tsg-irlich.de');
 	});
 });

--- a/apps/web/src/components/with-logic/contact-persons.test.tsx
+++ b/apps/web/src/components/with-logic/contact-persons.test.tsx
@@ -1,29 +1,24 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
+import type { SanityImage, SanityImageReference } from '@/types/image.types';
 import type { ContactPerson } from '@/types/sanity.types';
 
-import { loadWithEnv } from '../../../test-utils/env';
 import { renderWithUser } from '../../../test-utils/render';
-import type * as ContactPersonsModule from './contact-persons';
+import { ContactPersons } from './contact-persons';
 
-// `contact-persons.tsx` imports `urlForImage` from `@/lib/sanity/utils`, which imports the Sanity
-// `client` (`@/lib/sanity/client` → `@/lib/sanity/api`), and `api.ts` reads
-// `NEXT_PUBLIC_SANITY_DATASET`/`NEXT_PUBLIC_SANITY_PROJECT_ID` from `process.env` at module top
-// level, throwing immediately if either is missing — before any test in this file even runs a
-// component. `loadWithEnv` (`test-utils/env.ts`) stubs both and re-imports the module fresh, the
-// same pattern `src/utils/url.test.ts` uses for `@/lib/env.ts`'s module-level caching; the values
-// themselves are arbitrary, since no test here asserts on the built image URL.
-const SANITY_ENV = {
-	NEXT_PUBLIC_SANITY_DATASET: 'test-dataset',
-	NEXT_PUBLIC_SANITY_PROJECT_ID: 'test-project',
-};
-
-async function loadContactPersons() {
-	return loadWithEnv<typeof ContactPersonsModule>(
-		'@/components/with-logic/contact-persons',
-		SANITY_ENV,
-	);
-}
+// `contact-persons.tsx` reaches `urlForImage` (`@/lib/sanity/utils`), which imports the real Sanity
+// client chain (`@/lib/sanity/client` → `@/lib/sanity/api`), and `api.ts` throws at module load if
+// `NEXT_PUBLIC_SANITY_DATASET`/`NEXT_PUBLIC_SANITY_PROJECT_ID` are missing. The component's own
+// logic under test here (the initials fallback, the empty list) needs none of that — it only cares
+// whether `urlForImage` returns a truthy URL or `undefined`. An earlier version of this file went
+// through `loadWithEnv` to satisfy the real chain, which pulls in `@sanity/image-url` and resets the
+// whole module registry; that measured at ~3s for a fallback check that should be near-instant.
+// Mocking the module boundary the component actually reaches — rather than loading it for real —
+// avoids that entirely and lets `ContactPersons` be imported normally, like any other component.
+vi.mock(import('@/lib/sanity/utils'), () => ({
+	urlForImage: (image: null | SanityImage | SanityImageReference | undefined) =>
+		image?.asset?._ref ? `https://cdn.example.test/${image.asset._ref}.jpg` : undefined,
+}));
 
 const BASE_PERSON: ContactPerson = {
 	contactAs: 'both',
@@ -54,8 +49,7 @@ const WITH_IMAGE_LIST: ContactPerson[] = [PERSON_WITH_IMAGE];
 const EMPTY_LIST: ContactPerson[] = [];
 
 describe('the contact persons list', () => {
-	it('falls back to the initials when a person has no image', async () => {
-		const { ContactPersons } = await loadContactPersons();
+	it('falls back to the initials when a person has no image', () => {
 		const { container, getByText } = renderWithUser(
 			<ContactPersons contactPersons={NO_IMAGE_LIST} />,
 		);
@@ -64,8 +58,7 @@ describe('the contact persons list', () => {
 		expect(container.querySelector('img')).toBeNull();
 	});
 
-	it('renders an image instead of initials once a person has one', async () => {
-		const { ContactPersons } = await loadContactPersons();
+	it('renders an image instead of initials once a person has one', () => {
 		const { container, getByRole, queryByText } = renderWithUser(
 			<ContactPersons contactPersons={WITH_IMAGE_LIST} />,
 		);
@@ -75,8 +68,7 @@ describe('the contact persons list', () => {
 		expect(container.querySelectorAll('article')).toHaveLength(1);
 	});
 
-	it('renders nothing when the list is empty', async () => {
-		const { ContactPersons } = await loadContactPersons();
+	it('renders nothing when the list is empty', () => {
 		const { container } = renderWithUser(<ContactPersons contactPersons={EMPTY_LIST} />);
 
 		expect(container.querySelectorAll('article')).toHaveLength(0);

--- a/apps/web/src/components/with-logic/feedback/form.test.tsx
+++ b/apps/web/src/components/with-logic/feedback/form.test.tsx
@@ -1,0 +1,158 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createLinearIssue } from '@/actions/create-linear-issue';
+
+import { renderWithUser } from '../../../../test-utils/render';
+import { FeedbackForm } from './form';
+
+// `feedback/form.tsx` imports `createLinearIssue` and calls it directly (wrapped in `settle()`),
+// the same way `contact-form.tsx` calls `sendContactForm` — so the boundary to mock is the action
+// module itself, not `next-safe-action`'s `useAction`.
+vi.mock(import('@/actions/create-linear-issue'), () => ({ createLinearIssue: vi.fn() }));
+
+// `vi.mocked` only needs the reference to the mock function object; it is never invoked as a bare,
+// unbound `this`-dependent call.
+// oxlint-disable-next-line typescript/unbound-method
+const mockedCreateLinearIssue = vi.mocked(createLinearIssue);
+
+const VALID_TITLE = 'Die Suche funktioniert nicht mehr richtig';
+const VALID_DESCRIPTION = 'Beim Klicken auf den Suchbutton passiert überhaupt nichts mehr.';
+
+function renderForm() {
+	return renderWithUser(<FeedbackForm />);
+}
+
+interface Deferred<T> {
+	promise: Promise<T>;
+	resolve: (value: T) => void;
+}
+
+function createDeferred<T>(): Deferred<T> {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((res) => {
+		resolve = res;
+	});
+	return { promise, resolve };
+}
+
+describe('the feedback form', () => {
+	afterEach(() => {
+		mockedCreateLinearIssue.mockReset();
+	});
+
+	it('shows the schema validation messages on an empty submission and never calls the action', async () => {
+		const { findByText, getByRole, getByText, user } = renderForm();
+
+		await user.click(getByRole('button', { name: 'Feedback senden' }));
+
+		await expect(
+			findByText('Der Titel muss mindestens 5 Zeichen lang sein'),
+		).resolves.not.toBeNull();
+		expect(getByText('Die Beschreibung muss mindestens 20 Zeichen lang sein')).not.toBeNull();
+		expect(getByText('Bitte akzeptiere die Datenschutzbestimmungen')).not.toBeNull();
+		expect(mockedCreateLinearIssue).not.toHaveBeenCalled();
+	});
+
+	it('shows the browser, operating system and device fields by default, since the feedback type defaults to a bug report', () => {
+		const { getByRole, queryByLabelText } = renderForm();
+
+		expect(getByRole('radio', { name: 'Fehlermeldung' }).getAttribute('aria-checked')).toBe('true');
+		expect(queryByLabelText('Browser')).not.toBeNull();
+		expect(queryByLabelText('Betriebssystem')).not.toBeNull();
+		expect(queryByLabelText(/^Gerät/u)).not.toBeNull();
+	});
+
+	it('hides the browser, operating system and device fields once the feedback type is switched away from a bug report', async () => {
+		const { getByRole, queryByLabelText, user } = renderForm();
+
+		await user.click(getByRole('radio', { name: 'Verbesserungsvorschlag' }));
+
+		expect(queryByLabelText('Browser')).toBeNull();
+		expect(queryByLabelText('Betriebssystem')).toBeNull();
+		expect(queryByLabelText(/^Gerät/u)).toBeNull();
+	});
+
+	it('shows the browser, operating system and device fields again once the feedback type is switched back to a bug report', async () => {
+		const { getByRole, queryByLabelText, user } = renderForm();
+
+		await user.click(getByRole('radio', { name: 'Verbesserungsvorschlag' }));
+		await user.click(getByRole('radio', { name: 'Fehlermeldung' }));
+
+		expect(queryByLabelText('Browser')).not.toBeNull();
+		expect(queryByLabelText('Betriebssystem')).not.toBeNull();
+		expect(queryByLabelText(/^Gerät/u)).not.toBeNull();
+	});
+
+	it('calls the action exactly once with the whole payload on a valid submission and shows the confirmation', async () => {
+		mockedCreateLinearIssue.mockResolvedValue({
+			data: { issueId: 'issue-1', issueIdentifier: 'TSG-42' },
+		});
+		const { findByRole, getByLabelText, getByRole, user } = renderForm();
+
+		await user.type(getByLabelText('Titel'), VALID_TITLE);
+		await user.type(getByLabelText('Beschreibung'), VALID_DESCRIPTION);
+
+		await user.click(getByLabelText('Browser'));
+		await user.click(await findByRole('option', { name: 'Firefox' }));
+
+		await user.click(getByLabelText('Betriebssystem'));
+		await user.click(await findByRole('option', { name: 'macOS' }));
+
+		await user.type(getByLabelText(/^E-Mail/u), 'max@mustermann.de');
+		await user.click(getByLabelText('Datenschutzbestimmungen'));
+
+		await user.click(getByRole('button', { name: 'Feedback senden' }));
+
+		await findByRole('heading', { name: 'Vielen Dank!' });
+		const alert = getByRole('alert');
+		expect(alert.textContent).toContain('Deine Ticketnummer für Nachfragen lautet: TSG-42.');
+
+		expect(mockedCreateLinearIssue).toHaveBeenCalledExactlyOnceWith({
+			browser: 'firefox',
+			description: VALID_DESCRIPTION,
+			device: undefined,
+			email: 'max@mustermann.de',
+			operationSystem: 'macos',
+			privacy: true,
+			screenshotUrls: undefined,
+			title: VALID_TITLE,
+			type: 'bug',
+		});
+	});
+
+	it("renders the action's server error to the user", async () => {
+		mockedCreateLinearIssue.mockResolvedValue({ serverError: 'Der Server hat ein Problem.' });
+		const { findByRole, findByText, getByLabelText, getByRole, user } = renderForm();
+
+		await user.type(getByLabelText('Titel'), VALID_TITLE);
+		await user.type(getByLabelText('Beschreibung'), VALID_DESCRIPTION);
+		await user.click(getByLabelText('Datenschutzbestimmungen'));
+
+		await user.click(getByRole('button', { name: 'Feedback senden' }));
+
+		await findByRole('heading', { name: 'Fehler' });
+		await expect(findByText('Der Server hat ein Problem.')).resolves.not.toBeNull();
+	});
+
+	it('disables submission while the action is pending', async () => {
+		const deferred = createDeferred<Awaited<ReturnType<typeof createLinearIssue>>>();
+		mockedCreateLinearIssue.mockReturnValue(deferred.promise);
+		const { findByRole, getByLabelText, getByRole, user } = renderForm();
+
+		await user.type(getByLabelText('Titel'), VALID_TITLE);
+		await user.type(getByLabelText('Beschreibung'), VALID_DESCRIPTION);
+		await user.click(getByLabelText('Datenschutzbestimmungen'));
+
+		await user.click(getByRole('button', { name: 'Feedback senden' }));
+
+		const pendingButton = await findByRole('button', { name: 'Wird gesendet...' });
+		expect(pendingButton.hasAttribute('disabled')).toBe(true);
+
+		// Resolved with a server error rather than success, so the form (and its submit button)
+		// stays mounted afterwards instead of being replaced by the success view.
+		deferred.resolve({ serverError: 'Der Server hat ein Problem.' });
+
+		const enabledButton = await findByRole('button', { name: 'Feedback senden' });
+		expect(enabledButton.hasAttribute('disabled')).toBe(false);
+	});
+});

--- a/apps/web/src/components/with-logic/feedback/screenshot-upload.test.tsx
+++ b/apps/web/src/components/with-logic/feedback/screenshot-upload.test.tsx
@@ -1,0 +1,153 @@
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactElement } from 'react';
+import { useState } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { uploadToLinear } from '@/actions/upload-to-linear';
+
+import { renderWithUser } from '../../../../test-utils/render';
+import { ScreenshotUpload } from './screenshot-upload';
+
+// `screenshot-upload.tsx` imports `uploadToLinear` and calls it directly, the same way
+// `feedback/form.tsx` calls `createLinearIssue` — so the boundary to mock is the action module
+// itself, not `next-safe-action`'s `useAction`.
+vi.mock(import('@/actions/upload-to-linear'), () => ({ uploadToLinear: vi.fn() }));
+
+// `vi.mocked` only needs the reference to the mock function object; it is never invoked as a bare,
+// unbound `this`-dependent call.
+// oxlint-disable-next-line typescript/unbound-method
+const mockedUploadToLinear = vi.mocked(uploadToLinear);
+
+// Mirrors the `TEN_MB` constant in `screenshot-upload.tsx` (not exported) and the matching
+// `MAX_FILE_SIZE` in `src/actions/upload-to-linear.ts` — both gate at 10MB.
+const TEN_MB = 10 * 1024 * 1024;
+
+const DROP_ZONE_LABEL = /Klicken, ziehen/u;
+
+// `ScreenshotUpload` is a controlled component (`value`/`onChange` come from the parent) — this
+// stands in for `feedback/form.tsx`'s own `useState<string[]>`, the same as the real form.
+function ControlledScreenshotUpload(): ReactElement {
+	const [value, setValue] = useState<string[]>([]);
+	return <ScreenshotUpload onChange={setValue} value={value} />;
+}
+
+function renderUpload() {
+	return renderWithUser(<ControlledScreenshotUpload />);
+}
+
+function buildImageFile(name: string, byteLength = 3): File {
+	return new File([new Uint8Array(byteLength)], name, { type: 'image/png' });
+}
+
+interface Deferred<T> {
+	promise: Promise<T>;
+	resolve: (value: T) => void;
+}
+
+function createDeferred<T>(): Deferred<T> {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((res) => {
+		resolve = res;
+	});
+	return { promise, resolve };
+}
+
+describe('the screenshot upload', () => {
+	afterEach(() => {
+		mockedUploadToLinear.mockReset();
+	});
+
+	it('uploads a selected image and shows it in the preview list', async () => {
+		mockedUploadToLinear.mockResolvedValue({
+			data: { assetUrl: 'https://uploads.linear.app/one.png' },
+		});
+		const { findByRole, getByLabelText, user } = renderUpload();
+
+		const file = buildImageFile('screenshot.png');
+		await user.upload(getByLabelText(DROP_ZONE_LABEL), file);
+
+		await expect(findByRole('img', { name: 'Screenshot 1' })).resolves.not.toBeNull();
+		expect(mockedUploadToLinear).toHaveBeenCalledExactlyOnceWith({ file });
+	});
+
+	// The input carries `accept="image/png,image/jpeg,image/gif,image/webp"`, which `user.upload`
+	// honours by default and would otherwise filter the mismatched file before any event fires —
+	// masking the component's own `allowedTypes.includes(file.type)` guard. `applyAccept: false`
+	// bypasses that so this test actually exercises the guard, the same way a user bypassing the
+	// native file picker (drag-and-drop, paste) would.
+	it('rejects a file of the wrong type without calling the upload action or changing the list', async () => {
+		const { getByLabelText, queryAllByRole } = render(<ControlledScreenshotUpload />);
+		const user = userEvent.setup({ applyAccept: false });
+
+		const file = new File([new Uint8Array(3)], 'notes.pdf', { type: 'application/pdf' });
+		await user.upload(getByLabelText(DROP_ZONE_LABEL), file);
+
+		expect(mockedUploadToLinear).not.toHaveBeenCalled();
+		expect(queryAllByRole('img')).toHaveLength(0);
+	});
+
+	it('rejects an oversized file without calling the upload action or changing the list', async () => {
+		const { getByLabelText, queryAllByRole, user } = renderUpload();
+
+		const file = buildImageFile('huge.png', TEN_MB + 1);
+		await user.upload(getByLabelText(DROP_ZONE_LABEL), file);
+
+		expect(mockedUploadToLinear).not.toHaveBeenCalled();
+		expect(queryAllByRole('img')).toHaveLength(0);
+	});
+
+	it('shows the pending state while the upload is running', async () => {
+		const deferred = createDeferred<Awaited<ReturnType<typeof uploadToLinear>>>();
+		mockedUploadToLinear.mockReturnValue(deferred.promise);
+		const { findByRole, getByLabelText, queryByRole, user } = renderUpload();
+
+		const file = buildImageFile('screenshot.png');
+		await user.upload(getByLabelText(DROP_ZONE_LABEL), file);
+
+		// While pending, the uploading tile shows the file's own name as its `alt`; the final tile
+		// (added once `value` gains the asset URL) uses `Screenshot ${index + 1}` instead — so seeing
+		// the former and not the latter is the observable signal for "still uploading".
+		await expect(findByRole('img', { name: 'screenshot.png' })).resolves.not.toBeNull();
+		expect(queryByRole('img', { name: 'Screenshot 1' })).toBeNull();
+
+		deferred.resolve({ data: { assetUrl: 'https://uploads.linear.app/one.png' } });
+
+		await expect(findByRole('img', { name: 'Screenshot 1' })).resolves.not.toBeNull();
+		expect(queryByRole('img', { name: 'screenshot.png' })).toBeNull();
+	});
+
+	it('removes an uploaded entry, leaving the others intact', async () => {
+		mockedUploadToLinear
+			.mockResolvedValueOnce({ data: { assetUrl: 'https://uploads.linear.app/one.png' } })
+			.mockResolvedValueOnce({ data: { assetUrl: 'https://uploads.linear.app/two.png' } });
+		const { findByRole, getByLabelText, getByRole, queryAllByRole, queryByRole, user } =
+			renderUpload();
+
+		await user.upload(getByLabelText(DROP_ZONE_LABEL), buildImageFile('one.png'));
+		await findByRole('img', { name: 'Screenshot 1' });
+
+		await user.upload(getByLabelText(DROP_ZONE_LABEL), buildImageFile('two.png'));
+		await findByRole('img', { name: 'Screenshot 2' });
+
+		const survivingSource = getByRole('img', { name: 'Screenshot 2' }).getAttribute('src');
+
+		await user.click(getByRole('button', { name: 'Remove screenshot 1' }));
+
+		expect(queryAllByRole('img')).toHaveLength(1);
+		const remaining = getByRole('img', { name: 'Screenshot 1' });
+		expect(remaining.getAttribute('src')).toBe(survivingSource);
+		expect(queryByRole('button', { name: 'Remove screenshot 2' })).toBeNull();
+	});
+
+	it('surfaces an upload failure without leaving a half-added entry', async () => {
+		mockedUploadToLinear.mockResolvedValue({ serverError: 'Der Server hat ein Problem.' });
+		const { findByText, getByLabelText, queryAllByRole, user } = renderUpload();
+
+		const file = buildImageFile('screenshot.png');
+		await user.upload(getByLabelText(DROP_ZONE_LABEL), file);
+
+		await expect(findByText('Der Server hat ein Problem.')).resolves.not.toBeNull();
+		expect(queryAllByRole('img', { name: 'Screenshot 1' })).toHaveLength(0);
+	});
+});

--- a/apps/web/src/components/with-logic/feedback/screenshot-upload.test.tsx
+++ b/apps/web/src/components/with-logic/feedback/screenshot-upload.test.tsx
@@ -76,6 +76,11 @@ describe('the screenshot upload', () => {
 	// masking the component's own `allowedTypes.includes(file.type)` guard. `applyAccept: false`
 	// bypasses that so this test actually exercises the guard, the same way a user bypassing the
 	// native file picker (drag-and-drop, paste) would.
+	//
+	// Regression case: `processFile` in `screenshot-upload.tsx` returns bare from this guard, with
+	// no toast, no tile and no other feedback of any kind. The assertions below pin that silence
+	// accurately, but it is a known defect being documented, not the intended UX — a user who picks
+	// a PDF here gets no indication their file was rejected.
 	it('rejects a file of the wrong type without calling the upload action or changing the list', async () => {
 		const { getByLabelText, queryAllByRole } = render(<ControlledScreenshotUpload />);
 		const user = userEvent.setup({ applyAccept: false });
@@ -87,6 +92,10 @@ describe('the screenshot upload', () => {
 		expect(queryAllByRole('img')).toHaveLength(0);
 	});
 
+	// Regression case: `processFile`'s size guard also returns bare, with no toast, no tile and no
+	// other feedback of any kind. The assertions below pin that silence accurately, but it is a known
+	// defect being documented, not the intended UX — a user who picks a 20 MB image here gets no
+	// indication their file was rejected.
 	it('rejects an oversized file without calling the upload action or changing the list', async () => {
 		const { getByLabelText, queryAllByRole, user } = renderUpload();
 

--- a/apps/web/src/components/with-logic/navigation.test.tsx
+++ b/apps/web/src/components/with-logic/navigation.test.tsx
@@ -110,16 +110,9 @@ describe('navigation', () => {
 		expect(toggle.getAttribute('aria-controls')).toBeNull();
 	});
 
-	it('leaves every nav link present in the DOM regardless of whether the mobile menu has been opened or closed — there is no accessible presence/absence change to observe', async () => {
-		const { container, getByRole, user } = renderNavigation(NAV_ITEMS);
-		const toggle = getByRole('button', { name: 'Toggle menu' });
-
-		expect(linksWithHref(container, '/ueber-uns')).toHaveLength(2);
-
-		await user.click(toggle);
-		expect(linksWithHref(container, '/ueber-uns')).toHaveLength(2);
-
-		await user.click(toggle);
-		expect(linksWithHref(container, '/ueber-uns')).toHaveLength(2);
-	});
+	// The mobile menu toggle has no programmatically observable effect: no `aria-expanded`, no
+	// `aria-controls`, and the nav links never leave the DOM regardless of `isMobileOpen` — so
+	// clicking it cannot be asserted here without pinning markup (the class toggle) or an icon swap
+	// distinguishable only by class name/SVG path data, both barred by this PR's rules. That absence
+	// is itself the accessibility finding recorded for follow-up.
 });

--- a/apps/web/src/components/with-logic/navigation.test.tsx
+++ b/apps/web/src/components/with-logic/navigation.test.tsx
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest';
+
+import type { MainNavigationQueryResult } from '@/types/sanity.types';
+
+import { renderWithUser } from '../../../test-utils/render';
+import { setPathname } from '../../../test-utils/setup-dom';
+import { Navigation } from './navigation';
+
+type NavItem = NonNullable<MainNavigationQueryResult>['mainNavigation'][number];
+
+// The `mainNavigation` array items are `internalLink`/`externalLink` objects (see
+// `apps/studio/schemas/objects/internal-link.ts` and `external-link.ts`) and neither schema type
+// declares a `title` field, even though `mainNavigationQuery` (`src/lib/sanity/queries/main-
+// navigation.ts`) projects `title` directly on every item. `MainNavigationQueryResult` therefore
+// types every item's `title` as the literal `null` — there is no variant of `NavItem` with a
+// non-null title, so a type-correct fixture cannot give a nav item visible text. This is a
+// disagreement with the brief (which expects navigation items to render a visible label) and,
+// read together, a real content bug in `main-navigation.ts`/the `site-settings` schema: on the
+// current schema, every rendered `<Navigation>` item has an empty link text in production. It is
+// out of scope for this test task (fixing it would touch the GROQ query or the schema), so the
+// fixture below sets `title: null` to match the real type, and the tests identify links by `href`
+// rather than by accessible name/text.
+
+const ABOUT_US_ITEM: NavItem = {
+	_key: 'nav-about-us',
+	link: { _type: 'aboutUs', category: null, slug: 'ueber-uns' },
+	title: null,
+};
+
+const NEWS_CATEGORY_ITEM: NavItem = {
+	_key: 'nav-news',
+	link: { _type: 'news.category', category: null, slug: 'meldungen' },
+	title: null,
+};
+
+const GROUP_ITEM: NavItem = {
+	_key: 'nav-group',
+	// `group.soccer`'s department path is `/angebot/fussball` (`src/utils/groups.ts`), so
+	// `getInternalHref` resolves this to `/angebot/fussball/herren-1`.
+	link: { _type: 'group.soccer', category: null, slug: 'herren-1' },
+	title: null,
+};
+
+// `getInternalHref` returns `undefined` when the target has no resolvable slug, and the component
+// filters those items out entirely (`navigation.tsx`'s `.filter((item): item is ... => ...)`).
+const UNRESOLVABLE_SLUG_ITEM: NavItem = {
+	_key: 'nav-unresolvable',
+	link: { _type: 'contact', category: null, slug: null },
+	title: null,
+};
+
+// The discriminated union's other member: an item with no link at all is filtered out the same way.
+const NO_LINK_ITEM: NavItem = { _key: 'nav-no-link', link: null, title: null };
+
+const NAV_ITEMS: NavItem[] = [
+	ABOUT_US_ITEM,
+	NEWS_CATEGORY_ITEM,
+	GROUP_ITEM,
+	UNRESOLVABLE_SLUG_ITEM,
+	NO_LINK_ITEM,
+];
+
+function renderNavigation(navItems: NavItem[]) {
+	return renderWithUser(<Navigation navItems={navItems} />);
+}
+
+/**
+ * Every anchor in `container` whose `href` attribute is exactly `href`.
+ *
+ * @param container - The element to search within.
+ * @param href - The exact `href` attribute value to match.
+ * @returns Every matching anchor element, in document order.
+ */
+function linksWithHref(container: HTMLElement, href: string): HTMLAnchorElement[] {
+	return [...container.querySelectorAll<HTMLAnchorElement>(`a[href="${href}"]`)];
+}
+
+describe('navigation', () => {
+	it('renders the resolvable items as links with the href getInternalHref produces, once for the desktop list and once for the mobile list, and drops the unresolvable ones', () => {
+		const { container, getAllByRole } = renderNavigation(NAV_ITEMS);
+
+		expect(linksWithHref(container, '/ueber-uns')).toHaveLength(2);
+		expect(linksWithHref(container, '/news/meldungen')).toHaveLength(2);
+		expect(linksWithHref(container, '/angebot/fussball/herren-1')).toHaveLength(2);
+
+		// Total links = logo (1) + 3 desktop nav items + desktop "Kontakt aufnehmen" (1) + 3 mobile
+		// nav items + mobile "Kontakt aufnehmen" (1) = 9. Anything higher would mean one of the two
+		// unresolvable items (`UNRESOLVABLE_SLUG_ITEM`, `NO_LINK_ITEM`) leaked through as a link.
+		expect(getAllByRole('link')).toHaveLength(9);
+	});
+
+	it('exposes no attribute that would let assistive technology identify the item matching the current pathname — the active state is only expressed through a CSS class', () => {
+		setPathname('/ueber-uns');
+		const { container } = renderNavigation(NAV_ITEMS);
+
+		const activeLinks = linksWithHref(container, '/ueber-uns');
+		const inactiveLinks = linksWithHref(container, '/news/meldungen');
+
+		for (const link of [...activeLinks, ...inactiveLinks]) {
+			expect(link.getAttribute('aria-current')).toBeNull();
+		}
+	});
+
+	it('does not expose an aria-expanded (or any other) state on the mobile menu toggle button', () => {
+		const { getByRole } = renderNavigation(NAV_ITEMS);
+
+		const toggle = getByRole('button', { name: 'Toggle menu' });
+
+		expect(toggle.getAttribute('aria-expanded')).toBeNull();
+		expect(toggle.getAttribute('aria-controls')).toBeNull();
+	});
+
+	it('leaves every nav link present in the DOM regardless of whether the mobile menu has been opened or closed — there is no accessible presence/absence change to observe', async () => {
+		const { container, getByRole, user } = renderNavigation(NAV_ITEMS);
+		const toggle = getByRole('button', { name: 'Toggle menu' });
+
+		expect(linksWithHref(container, '/ueber-uns')).toHaveLength(2);
+
+		await user.click(toggle);
+		expect(linksWithHref(container, '/ueber-uns')).toHaveLength(2);
+
+		await user.click(toggle);
+		expect(linksWithHref(container, '/ueber-uns')).toHaveLength(2);
+	});
+});

--- a/apps/web/src/components/with-logic/number-ticker.test.tsx
+++ b/apps/web/src/components/with-logic/number-ticker.test.tsx
@@ -1,0 +1,108 @@
+import { act, render } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { NumberTicker } from './number-ticker';
+
+// `useSpring` (mocked in `test-utils/setup-dom.ts`) forwards its source motion value to its own
+// listeners the instant the source changes — there is no eased sequence of intermediate frames the
+// way a real spring produces. So a test here can genuinely prove that `number-ticker.tsx`'s
+// subscription wiring runs end to end (the displayed text starts at the start value, the delayed
+// `motionValue.set` fires, the `springValue.on('change', ...)` listener receives it and writes the
+// formatted string to the DOM), and that the formatting itself — locale, thousands separator,
+// decimal places — is correct. It CANNOT prove anything about the count-up motion a user would
+// actually see: no easing, no intermediate digits, no damping/stiffness behaviour. That is left
+// entirely unproven by this suite.
+//
+// Every expected string below is `Intl.NumberFormat('de-DE', { maximumFractionDigits,
+// minimumFractionDigits }).format(value)`, computed independently of `formatNumber` (not exported
+// by `number-ticker.tsx`) rather than imported from `DEFAULT_LOCALE` — 'de-DE' is `DEFAULT_LOCALE`'s
+// current value (`src/constants/time.ts`), hard-coded here per the "never build an expected value
+// from a constant the implementation also imports" rule.
+
+/**
+ * The single `<span>` `NumberTicker` renders, or a thrown error if it is missing — kept as a
+ * top-level helper (rather than an inline null-check in each test) so no test body contains a
+ * conditional, matching the `vitest/no-conditional-in-test` rule.
+ *
+ * @param container - The render result's container to search within.
+ * @returns The ticker's `<span>` element.
+ */
+function getTicker(container: HTMLElement): HTMLSpanElement {
+	const ticker = container.querySelector('span');
+	if (!ticker) {
+		throw new Error('Expected NumberTicker to render a <span>');
+	}
+	return ticker;
+}
+
+describe('the number ticker', () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('starts at zero, formatted with the de-DE thousands separator, and reaches the target after the (zero) delay', () => {
+		vi.useFakeTimers();
+		const { container } = render(<NumberTicker decimalPlaces={0} delay={0} value={1234} />);
+
+		const ticker = getTicker(container);
+
+		expect(ticker.textContent).toBe('0');
+		expect(ticker.getAttribute('aria-live')).toBe('polite');
+		expect(ticker.getAttribute('aria-atomic')).toBe('true');
+
+		act(() => {
+			vi.advanceTimersByTime(0);
+		});
+
+		expect(ticker.textContent).toBe('1.234');
+	});
+
+	it('formats both the start and the target value to the configured number of decimal places', () => {
+		vi.useFakeTimers();
+		const { container } = render(<NumberTicker decimalPlaces={2} delay={0} value={12.5} />);
+
+		const ticker = getTicker(container);
+
+		expect(ticker.textContent).toBe('0,00');
+
+		act(() => {
+			vi.advanceTimersByTime(0);
+		});
+
+		expect(ticker.textContent).toBe('12,50');
+	});
+
+	it('does not update before the full delay (in seconds) has elapsed, and updates exactly once it has', () => {
+		vi.useFakeTimers();
+		const { container } = render(<NumberTicker decimalPlaces={0} delay={2} value={100} />);
+
+		const ticker = getTicker(container);
+
+		act(() => {
+			vi.advanceTimersByTime(1999);
+		});
+		expect(ticker.textContent).toBe('0');
+
+		act(() => {
+			vi.advanceTimersByTime(1);
+		});
+		expect(ticker.textContent).toBe('100');
+	});
+
+	it('counts down from value to startValue when direction is "down"', () => {
+		vi.useFakeTimers();
+		const { container } = render(
+			<NumberTicker decimalPlaces={0} delay={0} direction="down" startValue={0} value={50} />,
+		);
+
+		const ticker = getTicker(container);
+
+		expect(ticker.textContent).toBe('50');
+
+		act(() => {
+			vi.advanceTimersByTime(0);
+		});
+
+		expect(ticker.textContent).toBe('0');
+	});
+});

--- a/apps/web/src/test-utils/setup-dom.test.tsx
+++ b/apps/web/src/test-utils/setup-dom.test.tsx
@@ -1,0 +1,39 @@
+import Image from 'next/image';
+import { usePathname } from 'next/navigation';
+import { describe, expect, it } from 'vitest';
+
+import { renderWithUser } from '../../test-utils/render';
+import { setPathname } from '../../test-utils/setup-dom';
+
+function PathnameProbe() {
+	const pathname = usePathname();
+	return <span>{pathname}</span>;
+}
+
+// Regression coverage for the global mocks `../../test-utils/setup-dom.ts` registers through
+// `setupFiles` — nothing else committed exercises them directly, so a regression in either mock
+// would otherwise only be caught incidentally by a later, unrelated test failing in a confusing way.
+//
+// This file deliberately does not live at `apps/web/test-utils/setup-dom.test.tsx`: neither Vitest
+// project's `include` glob in `vitest.config.ts` matches anything outside `src/` (the `dom` project
+// matches `src/**/*.test.tsx`), and this task may not touch `vitest.config.ts`. Placed here, under
+// `src/`, the file actually runs as part of `pnpm --filter web test`.
+describe('the next/image mock', () => {
+	it('keeps the image queryable by its accessible name', () => {
+		const { getByRole } = renderWithUser(
+			<Image alt="Vereinslogo" height={40} src="/logo.png" width={40} />,
+		);
+
+		expect(getByRole('img', { name: 'Vereinslogo' })).not.toBeNull();
+	});
+});
+
+describe('the next/navigation mock', () => {
+	it('resolves usePathname to whatever setPathname last set', () => {
+		setPathname('/kontakt');
+
+		const { getByText } = renderWithUser(<PathnameProbe />);
+
+		expect(getByText('/kontakt')).not.toBeNull();
+	});
+});

--- a/apps/web/test-utils/render.tsx
+++ b/apps/web/test-utils/render.tsx
@@ -1,0 +1,28 @@
+import { render, type RenderResult } from '@testing-library/react';
+import userEvent, { type UserEvent } from '@testing-library/user-event';
+import type { ReactElement } from 'react';
+
+interface RenderWithUserResult extends RenderResult {
+	/** A `user-event` instance set up against the same `document` the component was rendered into. */
+	user: UserEvent;
+}
+
+/**
+ * Renders `ui` through Testing Library and returns the usual render result alongside a
+ * `user-event` instance already `setup()` for it.
+ *
+ * `userEvent.setup()` and `render()` both default to the ambient `document` (there is only one in
+ * a jsdom test run, and this helper never renders into a custom container), so the two are already
+ * talking to the same document without passing it explicitly.
+ *
+ * @param ui - The element to render.
+ * @returns The Testing Library render result plus a ready-to-use `user` instance.
+ */
+function renderWithUser(ui: ReactElement): RenderWithUserResult {
+	const user = userEvent.setup();
+	const result = render(ui);
+	return { ...result, user };
+}
+
+export { renderWithUser };
+export type { RenderWithUserResult };

--- a/apps/web/test-utils/setup-dom.ts
+++ b/apps/web/test-utils/setup-dom.ts
@@ -1,3 +1,5 @@
+import { createElement, Fragment, useRef } from 'react';
+import type { ReactElement, ReactNode } from 'react';
 import { vi } from 'vitest';
 
 type MediaQueryListener = (event: MediaQueryListEvent) => void;
@@ -96,4 +98,305 @@ Element.prototype.scrollIntoView = () => {
 	// no-op
 };
 
-export { createMatchMediaStub, dispatchMediaQueryChange };
+// --- next/image --------------------------------------------------------------------------------
+
+interface StaticImageStub {
+	blurDataURL?: string;
+	blurWidth?: number;
+	height: number;
+	src: string;
+	width: number;
+}
+
+interface NextImageMockProps {
+	alt: string;
+	className?: string;
+	height?: number | string;
+	src: StaticImageStub | string;
+	width?: number | string;
+}
+
+/**
+ * Stands in for `next/image`'s `Image`: a plain `<img>` forwarding the props a test can query or
+ * assert on (`src`, `alt`, `width`, `height`, `className`) and silently dropping the Next-only ones
+ * (`fill`, `preload`, `quality`, `sizes`, `loader`, `placeholder`, `blurDataURL`, …) that would
+ * otherwise land on the DOM node and trigger a React "unknown prop" warning. `alt` is forwarded
+ * verbatim, so a test can query the image by its accessible name.
+ *
+ * A static image import resolves, through the `assetStub` Vite plugin in `vitest.config.ts`, to a
+ * `StaticImageStub` object rather than a string — its `src` field is used as the `<img>` `src` in
+ * that case.
+ *
+ * Escape hatch: this mock carries no per-test state, so a test that needs different `next/image`
+ * behaviour overrides the whole module itself with its own `vi.mock('next/image', () => ({...}))`
+ * — a mock declared in a test file is registered after this one and wins for that file. Nothing to
+ * reset between tests.
+ *
+ * @param props - The props `next/image`'s `Image` was rendered with.
+ * @param props.alt - Forwarded verbatim to the `<img>`.
+ * @param props.className - Forwarded verbatim to the `<img>`.
+ * @param props.height - Forwarded verbatim to the `<img>`.
+ * @param props.src - A URL, or the `assetStub` object a static import resolves to.
+ * @param props.width - Forwarded verbatim to the `<img>`.
+ * @returns The `<img>` standing in for `next/image`'s `Image`.
+ */
+function NextImageMock({ alt, className, height, src, width }: NextImageMockProps): ReactElement {
+	const resolvedSrc = typeof src === 'string' ? src : src.src;
+	return createElement('img', { alt, className, height, src: resolvedSrc, width });
+}
+
+vi.mock('next/image', () => ({ default: NextImageMock }));
+
+// --- next/navigation -----------------------------------------------------------------------------
+
+let currentPathname = '/';
+
+/**
+ * Escape hatch for a test that needs `usePathname()` to resolve to a specific route. Call before
+ * rendering. `currentPathname` is module state shared by every test in the run, so a test that
+ * changes it must set it back (for example to `'/'`) in an `afterEach`, or a later test silently
+ * inherits it.
+ *
+ * @param pathname - The value `usePathname()` resolves to from now on.
+ */
+function setPathname(pathname: string): void {
+	currentPathname = pathname;
+}
+
+/**
+ * Escape hatch for a test that needs to assert on, or configure the result of, a navigation call.
+ * `useRouter()` always returns this same object, so a call made through a router obtained on one
+ * render is still visible on `routerMock` after a re-render.
+ *
+ * These `vi.fn()`s are not created inside the `vi.mock(...)` factory below, but the same rule from
+ * `apps/web/AGENTS.md` still applies to them: neither `vi.resetModules()` nor `vi.restoreAllMocks()`
+ * clears a plain `vi.fn()`'s call history or implementation — only `vi.spyOn` registrations are.
+ * Call `.mockReset()` on whichever of `push`/`replace`/`back`/`prefetch` a test used, in that
+ * test's `afterEach`.
+ */
+const routerMock = {
+	back: vi.fn(),
+	prefetch: vi.fn(),
+	push: vi.fn(),
+	replace: vi.fn(),
+};
+
+vi.mock('next/navigation', () => ({
+	usePathname: () => currentPathname,
+	useRouter: () => routerMock,
+}));
+
+// --- motion/react --------------------------------------------------------------------------------
+
+/**
+ * Prop names that only mean something to a `motion` component (animation, gesture and layout
+ * props) and are dropped before reaching the plain DOM tag, so React never warns about an unknown
+ * attribute. Anything not in this set — ordinary DOM/React props such as `className`, `onClick` or
+ * `children` included — is forwarded untouched.
+ */
+const MOTION_ONLY_PROPS = new Set([
+	'animate',
+	'custom',
+	'drag',
+	'dragConstraints',
+	'dragElastic',
+	'dragMomentum',
+	'dragPropagation',
+	'dragSnapToOrigin',
+	'dragTransition',
+	'exit',
+	'initial',
+	'layout',
+	'layoutDependency',
+	'layoutId',
+	'layoutScroll',
+	'onAnimationComplete',
+	'onAnimationStart',
+	'onDirectionLock',
+	'onDrag',
+	'onDragEnd',
+	'onDragStart',
+	'onLayoutAnimationComplete',
+	'onLayoutAnimationStart',
+	'onPan',
+	'onPanEnd',
+	'onPanSessionStart',
+	'onPanStart',
+	'onUpdate',
+	'onViewportEnter',
+	'onViewportLeave',
+	'transformTemplate',
+	'transformValues',
+	'transition',
+	'variants',
+	'viewport',
+	'whileDrag',
+	'whileFocus',
+	'whileHover',
+	'whileInView',
+	'whileTap',
+]);
+
+const motionComponentCache = new Map<string, (props: Record<string, unknown>) => ReactElement>();
+
+/**
+ * Builds (and caches, per tag) the plain-tag stand-in for `motion.<tag>`. Caching keeps the
+ * component's identity stable across renders — a fresh function on every access of `motion.div`
+ * would make React remount the element on every render of whatever reads it.
+ *
+ * @param tag - The DOM tag name `motion.<tag>` was accessed as, for example `'div'`.
+ * @returns A component rendering `tag`, forwarding every prop except {@link MOTION_ONLY_PROPS}.
+ */
+function getMotionComponent(tag: string): (props: Record<string, unknown>) => ReactElement {
+	const cached = motionComponentCache.get(tag);
+	if (cached) {
+		return cached;
+	}
+
+	/**
+	 * @param props - The props the `motion.<tag>` element was rendered with.
+	 * @returns The plain `tag` element, with {@link MOTION_ONLY_PROPS} stripped from `props`.
+	 */
+	function MotionComponentMock(props: Record<string, unknown>): ReactElement {
+		const domProps: Record<string, unknown> = {};
+		for (const [key, value] of Object.entries(props)) {
+			if (!MOTION_ONLY_PROPS.has(key)) {
+				domProps[key] = value;
+			}
+		}
+		return createElement(tag, domProps);
+	}
+
+	motionComponentCache.set(tag, MotionComponentMock);
+	return MotionComponentMock;
+}
+
+/**
+ * Stands in for `motion`: `motion.div`, `motion.button`, any tag, all resolve to the plain DOM tag
+ * via {@link getMotionComponent}. Escape hatch: like `next/image`, a test file that needs different
+ * `motion` behaviour re-mocks the module itself; nothing here carries state to reset.
+ */
+const motionMock = new Proxy(
+	{},
+	{ get: (_target, tag) => getMotionComponent(String(tag)) },
+) as Record<string, (props: Record<string, unknown>) => ReactElement>;
+
+/**
+ * Stands in for `AnimatePresence`: renders its children directly with no exit-animation wrapper, so
+ * an element that would be exiting in the real component simply leaves the tree immediately.
+ *
+ * @param props - The props `AnimatePresence` was rendered with.
+ * @param props.children - The element(s) to render, unwrapped.
+ * @returns `children`, wrapped in nothing more than a `Fragment`.
+ */
+function AnimatePresenceMock({ children }: { children?: ReactNode }): ReactElement {
+	return createElement(Fragment, null, children);
+}
+
+let reducedMotion = true;
+
+/**
+ * Escape hatch for a test that needs the non-reduced-motion branch. Shared module state like
+ * `currentPathname` above — reset it (back to `true`) in an `afterEach` once a test changes it.
+ *
+ * @param value - The value `useReducedMotion()` resolves to from now on.
+ */
+function setReducedMotion(value: boolean): void {
+	reducedMotion = value;
+}
+
+let inView = true;
+
+/**
+ * Escape hatch for a test that needs `useInView` to report an element as not yet visible (for
+ * example, to assert a `NumberTicker` has not started counting). Shared module state — reset it
+ * (back to `true`) in an `afterEach` once a test changes it.
+ *
+ * @param value - The value `useInView()` resolves to from now on.
+ */
+function setInView(value: boolean): void {
+	inView = value;
+}
+
+interface MotionValueMock<T> {
+	get: () => T;
+	on: (event: 'change', callback: (value: T) => void) => () => void;
+	set: (value: T) => void;
+}
+
+function createMotionValueMock<T>(initial: T): MotionValueMock<T> {
+	let current = initial;
+	const listeners = new Set<(value: T) => void>();
+
+	return {
+		get: () => current,
+		// The `event` argument is intentionally unused: `on`'s type only ever admits `'change'`,
+		// which is the only event `number-ticker.tsx` subscribes to.
+		on: (_event, callback) => {
+			listeners.add(callback);
+			return () => {
+				listeners.delete(callback);
+			};
+		},
+		set: (value) => {
+			current = value;
+			for (const listener of listeners) {
+				listener(value);
+			}
+		},
+	};
+}
+
+/**
+ * Stands in for `useMotionValue`. Persists the created value across re-renders with `useRef` —
+ * matching the real hook, which only honours its argument on the very first call — so a `.set()`
+ * from an effect still reaches listeners subscribed on a later render.
+ *
+ * @param initial - The value to seed the motion value with on the first render.
+ * @returns The (per-component-instance, stable) motion value.
+ */
+function useMotionValueMock<T>(initial: T): MotionValueMock<T> {
+	const reference = useRef<MotionValueMock<T> | null>(null);
+	reference.current ??= createMotionValueMock(initial);
+	return reference.current;
+}
+
+/**
+ * Stands in for `useSpring`. This does not reproduce spring physics: instead of easing toward the
+ * source value over a sequence of animation frames, it forwards `source`'s value to its own
+ * listeners the instant `source` changes. `number-ticker.tsx`'s displayed start and end values are
+ * therefore correct, but the eased intermediate values a real spring would emit between them are
+ * not — a test that renders a `NumberTicker` observes the final digits appear, not a count-up.
+ *
+ * @param source - The motion value this spring tracks.
+ * @returns The (per-component-instance, stable) spring-tracking motion value.
+ */
+function useSpringMock<T>(source: MotionValueMock<T>): MotionValueMock<T> {
+	const reference = useRef<MotionValueMock<T> | null>(null);
+	if (!reference.current) {
+		const spring = createMotionValueMock(source.get());
+		source.on('change', (value) => {
+			spring.set(value);
+		});
+		reference.current = spring;
+	}
+	return reference.current;
+}
+
+vi.mock('motion/react', () => ({
+	AnimatePresence: AnimatePresenceMock,
+	motion: motionMock,
+	useInView: () => inView,
+	useMotionValue: useMotionValueMock,
+	useReducedMotion: () => reducedMotion,
+	useSpring: useSpringMock,
+}));
+
+export {
+	createMatchMediaStub,
+	dispatchMediaQueryChange,
+	routerMock,
+	setInView,
+	setPathname,
+	setReducedMotion,
+};

--- a/apps/web/test-utils/setup-dom.ts
+++ b/apps/web/test-utils/setup-dom.ts
@@ -1,6 +1,7 @@
+import { cleanup } from '@testing-library/react';
 import { createElement, Fragment, useRef } from 'react';
 import type { ReactElement, ReactNode } from 'react';
-import { vi } from 'vitest';
+import { afterEach, vi } from 'vitest';
 
 type MediaQueryListener = (event: MediaQueryListEvent) => void;
 
@@ -153,9 +154,9 @@ let currentPathname = '/';
 
 /**
  * Escape hatch for a test that needs `usePathname()` to resolve to a specific route. Call before
- * rendering. `currentPathname` is module state shared by every test in the run, so a test that
- * changes it must set it back (for example to `'/'`) in an `afterEach`, or a later test silently
- * inherits it.
+ * rendering. `currentPathname` is module state shared by every test in the run — a case may set it
+ * freely, the central `afterEach` below resets it back to `'/'` after every test, so it never leaks
+ * into the next one.
  *
  * @param pathname - The value `usePathname()` resolves to from now on.
  */
@@ -171,8 +172,8 @@ function setPathname(pathname: string): void {
  * These `vi.fn()`s are not created inside the `vi.mock(...)` factory below, but the same rule from
  * `apps/web/AGENTS.md` still applies to them: neither `vi.resetModules()` nor `vi.restoreAllMocks()`
  * clears a plain `vi.fn()`'s call history or implementation — only `vi.spyOn` registrations are.
- * Call `.mockReset()` on whichever of `push`/`replace`/`back`/`prefetch` a test used, in that
- * test's `afterEach`.
+ * The central `afterEach` below calls `.mockReset()` on all four, so a case may configure or assert
+ * on `push`/`replace`/`back`/`prefetch` freely without resetting them itself.
  */
 const routerMock = {
 	back: vi.fn(),
@@ -275,6 +276,11 @@ function getMotionComponent(tag: string): (props: Record<string, unknown>) => Re
  * Stands in for `motion`: `motion.div`, `motion.button`, any tag, all resolve to the plain DOM tag
  * via {@link getMotionComponent}. Escape hatch: like `next/image`, a test file that needs different
  * `motion` behaviour re-mocks the module itself; nothing here carries state to reset.
+ *
+ * No animation prop of any kind — `initial`, `animate`, `exit`, `transition`, `layoutId`, … — ever
+ * reaches the rendered tag, regardless of what `useReducedMotion` returns: {@link MOTION_ONLY_PROPS}
+ * strips them all unconditionally, so pinning `useReducedMotion` to `true` below does not skip an
+ * otherwise-observable branch — there is no animation to observe through this mock either way.
  */
 const motionMock = new Proxy(
 	{},
@@ -297,7 +303,8 @@ let reducedMotion = true;
 
 /**
  * Escape hatch for a test that needs the non-reduced-motion branch. Shared module state like
- * `currentPathname` above — reset it (back to `true`) in an `afterEach` once a test changes it.
+ * `currentPathname` above — the central `afterEach` below resets it back to `true` after every
+ * test, so a case may change it freely.
  *
  * @param value - The value `useReducedMotion()` resolves to from now on.
  */
@@ -309,8 +316,8 @@ let inView = true;
 
 /**
  * Escape hatch for a test that needs `useInView` to report an element as not yet visible (for
- * example, to assert a `NumberTicker` has not started counting). Shared module state — reset it
- * (back to `true`) in an `afterEach` once a test changes it.
+ * example, to assert a `NumberTicker` has not started counting). Shared module state — the central
+ * `afterEach` below resets it back to `true` after every test, so a case may change it freely.
  *
  * @param value - The value `useInView()` resolves to from now on.
  */
@@ -391,6 +398,24 @@ vi.mock('motion/react', () => ({
 	useReducedMotion: () => reducedMotion,
 	useSpring: useSpringMock,
 }));
+
+// Testing Library's own auto-cleanup only registers itself when it finds a global `afterEach`
+// (i.e. when Vitest's `globals: true` is on), which this repo deliberately keeps off — so without
+// this, every element `renderWithUser` mounts into `document.body` stays there for the rest of the
+// file, and a later case can find (and interact with) an earlier case's still-mounted tree. This is
+// the one `afterEach` every `dom` test in this project gets for free; it also resets the mock state
+// above (`routerMock`'s call history, `currentPathname`, `reducedMotion`, `inView`) so a case that
+// used one of the setters or asserted on `routerMock` never leaks into the next test.
+afterEach(() => {
+	cleanup();
+	routerMock.back.mockReset();
+	routerMock.prefetch.mockReset();
+	routerMock.push.mockReset();
+	routerMock.replace.mockReset();
+	currentPathname = '/';
+	reducedMotion = true;
+	inView = true;
+});
 
 export {
 	createMatchMediaStub,

--- a/docs/superpowers/plans/2026-08-26-web-296-unit-tests-pr4-components.md
+++ b/docs/superpowers/plans/2026-08-26-web-296-unit-tests-pr4-components.md
@@ -1,0 +1,386 @@
+# WEB-296 Unit Tests — PR 4 (Components and Hooks) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Cover the components that carry real logic with jsdom tests, asserting behaviour a user can observe rather than markup.
+
+**Architecture:** Tests only. Everything lands in `apps/web`'s `dom` Vitest project — `.test.tsx` files, which the extension-based routing sends to jsdom automatically. Rendering goes through Testing Library; interaction through `user-event`. Server actions, `next/image`, `next/navigation` and `motion` are mocked at the module boundary; no `fetch` is involved anywhere in this PR.
+
+**Tech Stack:** Vitest 4, jsdom 30, `@testing-library/react` 16.3, `@testing-library/user-event` 14.6, React 19.2, Radix UI, `motion`, `react-hook-form` + Zod 4, pnpm 11, Turbo, GitButler CLI (`but`).
+
+**Spec:** `docs/superpowers/specs/2026-08-25-web-296-unit-tests-design.md`, section "PR 4 — Komponenten und Hook"
+
+**Base branch:** `next`, which contains PR 1 (#471) and PR 2 (#472). PR 3 (#473) is open and touches only actions and the CleverReach client — no file this PR needs — so this branch starts from `next` and is independent of it. New branch: `test/web-296-unit-tests-components`.
+
+## Global Constraints
+
+- Node `^24.19.0`, pnpm `11.22.0` — `.nvmrc` and `packageManager` untouched.
+- Tests live next to their source. **Every file in this PR is a `.test.tsx`**, which is what routes it to the jsdom project; a `.test.ts` under `src/components/` or `src/hooks/` also lands in `dom`, but prefer `.tsx` since these render.
+- Explicit imports from `vitest`. No `globals: true`.
+- `describe` titles start lowercase and are never identical to an imported identifier. `beforeEach`/`afterEach`/`beforeAll`/`afterAll` sit inside a `describe` block.
+- Never widen the test-file override in `oxlint.config.ts`; use a narrow inline comment if a file needs a suppression.
+- **A `vi.fn()` created inside a `vi.mock(…)` factory is reset by neither `vi.resetModules()` nor `vi.restoreAllMocks()`** — only `vi.spyOn` registrations are. Every mocked function needs an explicit `.mockReset()` in `afterEach`. This cost PR 3 a debugging round; `apps/web/src/actions/send-contact-form.test.ts` is the worked example and `apps/web/AGENTS.md` records it.
+- No new dependency. No change to any `vitest.config.ts`, `turbo.json`, CI file, `sonar-project.properties`, or production source — if a test uncovers a real bug, report it and stop; the controller decides.
+- Commits through GitButler with explicit file paths: `but commit -b test/web-296-unit-tests-components -m "…" <paths>`. Conventional Commits, no `Co-Authored-By`, no generator trailer.
+- After every task: `pnpm run lint`, `pnpm run format:check`, `pnpm run typecheck` clean and `pnpm run test` green.
+- **Expected values are derived from the implementation, never from this plan's prose.** PR 2's plan was wrong four times and PR 3's twice; every implementer caught it by checking. If the code contradicts a value below, that is a finding — report it and write what the code really does.
+- **Assert what a user can observe, not the DOM's shape.** Query by role, label, or text; never by class name, never by `data-testid` added for the test's convenience, and never assert a Tailwind class string. A test that pins markup breaks on every redesign and proves nothing about behaviour.
+- **Assert the failure, not just that something failed.** PR 2's final review named bare `.toThrow()` and boolean-only checks as its weakest assertions; PR 3 replaced partial-object matches with whole-payload assertions for the same reason.
+
+## Infrastructure this PR consumes and extends
+
+From PR 1, already in `next`:
+
+- `apps/web/vitest.config.ts` — the `dom` project (jsdom) matches `src/**/*.test.tsx` plus `.test.ts` under `src/components/` and `src/hooks/`, and loads `apps/web/test-utils/setup-dom.ts` as its `setupFiles`. The `assetStub` plugin resolves static image imports.
+- `apps/web/test-utils/setup-dom.ts` — stubs `window.matchMedia` (one cached `MediaQueryList` per query string, with `matches` updated on dispatch), `ResizeObserver`, `IntersectionObserver`, and the Radix pointer-capture surface (`hasPointerCapture`, `setPointerCapture`, `releasePointerCapture`, `scrollIntoView`). Exports `createMatchMediaStub` and `dispatchMediaQueryChange`.
+
+**What PR 1 deliberately left for this PR:** the spec's DOM-setup paragraph also lists module mocks for `next/image`, `next/navigation` and `motion`. PR 1 shipped only the globals, because a module mock with no consumer is dead code. Task 2 adds them, and every later task builds on them.
+
+---
+
+### Task 1: Branch
+
+**Files:** commit this plan.
+
+**Interfaces:**
+
+- Consumes: nothing.
+- Produces: branch `test/web-296-unit-tests-components` off `next`.
+
+- [ ] **Step 1: Confirm the base**
+
+Run: `git fetch origin && git log --oneline -1 origin/next` and `but status` Expected: `next` contains #472's merge commit; the working tree is clean.
+
+- [ ] **Step 2: Create the branch, then commit**
+
+`but commit -b <new-branch>` creates a SIBLING rather than a stacked branch — PR 2 lost time to exactly that. Create it explicitly first:
+
+```bash
+but branch new test/web-296-unit-tests-components
+but commit -b test/web-296-unit-tests-components \
+  -m "docs: add the component test plan for WEB-296" \
+  docs/superpowers/plans/2026-08-26-web-296-unit-tests-pr4-components.md
+```
+
+- [ ] **Step 3: Verify**
+
+Run: `git log --oneline origin/next..test/web-296-unit-tests-components` Expected: exactly one commit, carrying only the plan file.
+
+---
+
+### Task 2: Shared render helpers and the module mocks
+
+**Files:**
+
+- Create: `apps/web/test-utils/render.tsx`
+- Modify: `apps/web/test-utils/setup-dom.ts`
+- Create: `apps/web/src/components/ui/badge/badge.test.tsx` (or the nearest trivial component — see Step 4)
+
+**Interfaces:**
+
+- Consumes: PR 1's `setup-dom.ts` and the `dom` project.
+- Produces, for every later task:
+  - `renderWithUser(ui: ReactElement): { user: UserEvent } & RenderResult` — renders and returns a `user-event` instance set up against the same document.
+  - Module mocks for `next/image`, `next/navigation` and `motion`, applied globally through `setupFiles`, each with a documented escape hatch for a test that needs to control them per case.
+
+This is the load-bearing task of the PR: nine later files depend on these mocks behaving well. Get the mocks minimal and honest — a mock that silently swallows behaviour makes every test above it worthless.
+
+- [ ] **Step 1: `next/image`**
+
+The real component demands Next's image config and an optimizer. Mock it to a plain `<img>` that forwards `src`, `alt`, `width`, `height` and `className`, and drops Next-only props (`fill`, `preload`, `quality`, `sizes`, `loader`, `placeholder`, `blurDataURL`) so React does not warn about unknown DOM attributes. A static import resolves to the `assetStub` object, so `src` may be an object — render `src.src` when so. Keep `alt` verbatim: several later tasks query images by their accessible name.
+
+- [ ] **Step 2: `next/navigation`**
+
+Mock `usePathname` and `useRouter`. `usePathname` returns a value a test can set; `useRouter` returns an object whose `push`, `replace`, `back` and `prefetch` are `vi.fn()`s. Export a way for a test to set the current pathname (for example a `setPathname` helper the mock closes over), and document that these mocks need `.mockReset()` in `afterEach` per the global constraint.
+
+- [ ] **Step 3: `motion`**
+
+`motion/react` is imported by `lightbox.tsx` (`AnimatePresence`, `motion`, `useReducedMotion`, and the `PanInfo`/`Transition` types) and `number-ticker.tsx` (`useInView`, `useMotionValue`, `useSpring`). Animations must not make assertions timing-dependent:
+
+- `motion.<tag>` renders the plain tag, forwarding children and standard DOM props while dropping animation props (`initial`, `animate`, `exit`, `transition`, `variants`, `drag`, `onPan*`, `whileTap`, …).
+- `AnimatePresence` renders its children directly, so an exiting element leaves the tree immediately.
+- `useReducedMotion` returns `true`, which is the branch that skips animation.
+- `useInView` returns `true` so the ticker starts; `useMotionValue`/`useSpring` need enough of their real surface (`get`, `set`, `on`/`onChange`) for `number-ticker.tsx` to work — read that file and implement exactly what it uses, no more. Where the real behaviour cannot be faithfully reproduced, say so in the report rather than papering over it: Task 8 depends on knowing whether the ticker's value is really driven or merely stubbed.
+
+- [ ] **Step 4: Prove the setup with one trivial render**
+
+Pick the simplest component in `src/components/ui/` that renders text and takes a variant prop, and write a couple of cases for it: it renders its children, and a variant prop changes something a user can perceive (its accessible role or text, not its class string — if the only observable difference IS the class, say so in the report and assert nothing about styling). The point is to prove the harness renders at all before nine files depend on it.
+
+- [ ] **Step 5: Verify the mocks are actually applied**
+
+Run one case that renders a `next/image` and one that reads `usePathname`, and confirm no React warning about unknown props appears in the output (fail the run on console noise if that is straightforward; otherwise assert on a `console.error` spy). Paste the run.
+
+- [ ] **Step 6: Gates and commit**
+
+```bash
+pnpm --filter web test
+pnpm run lint && pnpm run format:check && pnpm run typecheck
+but commit -b test/web-296-unit-tests-components \
+  -m "test(web): add the component render helpers and module mocks" \
+  apps/web/test-utils/render.tsx apps/web/test-utils/setup-dom.ts <the trivial component's test file>
+```
+
+---
+
+### Task 3: `ui/lightbox.tsx`
+
+**Files:**
+
+- Create: `apps/web/src/components/ui/lightbox.test.tsx`
+
+**Interfaces:**
+
+- Consumes: `renderWithUser`, the `motion` and `next/image` mocks, PR 1's Radix pointer-capture stubs.
+- Produces: nothing.
+
+The largest component in the PR (347 lines) and the one with real interaction logic: a Radix dialog, context, keyboard handling, paging and drag-to-dismiss. Read it fully, including how `LightboxGallery`, `LightboxTrigger` and the context fit together, before writing a line.
+
+- [ ] **Step 1: Cases**
+
+- A trigger opens the lightbox showing the image it belongs to — assert by the image's accessible name, not by index.
+- Clicking the trigger of the third image opens on that image, not the first.
+- The next and previous controls move between images; assert which image is displayed after each.
+- Behaviour at both ends: whatever the code does (wrap or clamp), assert it — derive which from the source.
+- `Escape` closes. Arrow keys page.
+- A caption renders when the image has one and is absent when it does not.
+- A single-image gallery hides the paging controls.
+- Assert the dialog's accessibility surface: it has a dialog role and an accessible name.
+
+- [ ] **Step 2: Note what you cannot test**
+
+Drag-to-dismiss goes through `motion`'s pan handlers, which the mock drops. Do not fake a pan gesture by calling internals — instead state plainly in the report that the drag path is untested and why. That is honest coverage; a faked gesture is not.
+
+- [ ] **Step 3: Gates and commit**
+
+```bash
+pnpm --filter web test src/components/ui/lightbox.test.tsx
+pnpm run lint && pnpm run format:check && pnpm run typecheck
+but commit -b test/web-296-unit-tests-components \
+  -m "test(web): cover the lightbox interaction" \
+  apps/web/src/components/ui/lightbox.test.tsx
+```
+
+---
+
+### Task 4: `ui/gallery.tsx` and `ui/portable-text.tsx`
+
+**Files:**
+
+- Create: `apps/web/src/components/ui/gallery.test.tsx`
+- Create: `apps/web/src/components/ui/portable-text.test.tsx`
+
+**Interfaces:**
+
+- Consumes: Task 2's helpers; `gallery.tsx` renders the lightbox from Task 3's module.
+- Produces: nothing.
+
+- [ ] **Step 1: `gallery.test.tsx`**
+
+- One thumbnail per image, each with its alt text as accessible name.
+- Clicking thumbnail _n_ opens the lightbox on image _n_ — the integration Task 3 tests from the other side.
+- The rounded-corners flag: only assert it if it changes something observable beyond a class; if it does not, say so and skip it rather than asserting a class name.
+- Only the first image is preloaded — assert whatever observable difference the code produces, and if the `preload` prop is dropped by the `next/image` mock, report that this is untestable through the mock instead of asserting on the mock's internals.
+- An empty image list renders nothing (or whatever the code does).
+
+- [ ] **Step 2: `portable-text.test.tsx`**
+
+`portable-text.tsx` imports `next-sanity`, which only works because PR 2 aligned `@sanity/client` — if you hit an import error here, that is a finding, not something to mock around. Cases: each mark and block type renders its element; an internal link resolves through `getInternalHref` to the right `href`; an external link gets `rel` and `target`; an unknown block type does not crash the render; an image block renders with its alt text. Build the Portable Text fixtures by hand from the types, and keep them minimal.
+
+- [ ] **Step 3: Gates and commit**
+
+```bash
+pnpm --filter web test src/components/ui/gallery.test.tsx src/components/ui/portable-text.test.tsx
+pnpm run lint && pnpm run format:check && pnpm run typecheck
+but commit -b test/web-296-unit-tests-components \
+  -m "test(web): cover the gallery and the portable text renderer" \
+  apps/web/src/components/ui/gallery.test.tsx apps/web/src/components/ui/portable-text.test.tsx
+```
+
+---
+
+### Task 5: `section/contact-form.tsx`
+
+**Files:**
+
+- Create: `apps/web/src/components/section/contact-form.test.tsx`
+
+**Interfaces:**
+
+- Consumes: Task 2's helpers; mocks `@/actions/send-contact-form`.
+- Produces: the form-testing pattern Task 6 reuses.
+
+`react-hook-form` with a Zod resolver, wrapped around `next-safe-action`'s `useAction`. Read the component and `apps/web/src/lib/validations/contact-form.ts` first. Remember that validation is asynchronous: await the message appearing rather than asserting immediately after a click.
+
+- [ ] **Step 1: Cases**
+
+- Submitting empty shows the German validation messages from the schema — assert the exact strings, hard-coded, and that the action was NOT called.
+- A valid submission calls the action exactly once with the parsed values — assert the whole argument object.
+- The action's failure path renders its error to the user.
+- Success renders the confirmation and clears the fields.
+- Submit is disabled while the action is pending — drive that from the mocked action's pending state rather than by racing a timer.
+- Every field's label is associated with its control: query by label throughout, which proves the association as a side effect.
+
+- [ ] **Step 2: Gates and commit**
+
+```bash
+pnpm --filter web test src/components/section/contact-form.test.tsx
+pnpm run lint && pnpm run format:check && pnpm run typecheck
+but commit -b test/web-296-unit-tests-components \
+  -m "test(web): cover the contact form" \
+  apps/web/src/components/section/contact-form.test.tsx
+```
+
+---
+
+### Task 6: The feedback form and its screenshot upload
+
+**Files:**
+
+- Create: `apps/web/src/components/with-logic/feedback/form.test.tsx`
+- Create: `apps/web/src/components/with-logic/feedback/screenshot-upload.test.tsx`
+
+**Interfaces:**
+
+- Consumes: Task 5's form pattern; mocks `@/actions/create-linear-issue` and `@/actions/upload-to-linear`.
+- Produces: nothing.
+
+- [ ] **Step 1: `form.test.tsx`**
+
+Same shape as Task 5, against `apps/web/src/lib/validations/feedback.ts`: the required fields' messages, the type and browser/OS selects, a valid submission calling the action once with the whole payload, the failure and success paths, and the pending state.
+
+- [ ] **Step 2: `screenshot-upload.test.tsx`**
+
+- Selecting an image file uploads it and shows it in the list. Build the file with `new File([bytes], name, { type })` and hand it over with `user.upload`.
+- A wrong file type and an oversize file are each rejected with their message, and the upload action is not called.
+- The pending state is visible while the upload runs.
+- Removing an entry takes it out of the list and leaves the rest intact.
+- An upload failure surfaces an error and does not leave a half-added entry behind.
+
+- [ ] **Step 3: Gates and commit**
+
+```bash
+pnpm --filter web test src/components/with-logic/feedback
+pnpm run lint && pnpm run format:check && pnpm run typecheck
+but commit -b test/web-296-unit-tests-components \
+  -m "test(web): cover the feedback form and screenshot upload" \
+  apps/web/src/components/with-logic/feedback/form.test.tsx \
+  apps/web/src/components/with-logic/feedback/screenshot-upload.test.tsx
+```
+
+---
+
+### Task 7: `with-logic/navigation.tsx` and `section/newsletter.tsx`
+
+**Files:**
+
+- Create: `apps/web/src/components/with-logic/navigation.test.tsx`
+- Create: `apps/web/src/components/section/newsletter.test.tsx`
+
+**Interfaces:**
+
+- Consumes: Task 2's `next/navigation` mock and PR 1's `matchMedia` stub; mocks `@/actions/subscribe-to-newsletter`.
+- Produces: nothing.
+
+- [ ] **Step 1: `navigation.test.tsx`**
+
+Read `isActivePage` and the props from `MainNavigationQueryResult`, and build a fixture from those types.
+
+- Every navigation item renders as a link with the href `getInternalHref` produces.
+- The item matching the current pathname is marked active — assert through `aria-current` if the component sets it, and if it only sets a class, say so in the report and assert the closest observable thing instead.
+- The desktop and mobile branches: drive them with `createMatchMediaStub(true|false)` from `setup-dom.ts`, and assert what differs for a user.
+- Opening and closing the mobile menu, driven by clicking its control and asserting the links' visibility.
+
+- [ ] **Step 2: `newsletter.test.tsx`**
+
+`useActionState` with a plain action, so the mocked action's resolved state drives the render.
+
+- The success state renders its title and message.
+- The error state renders its message.
+- The email field is submitted as `FormData` — assert the action received the address.
+- The pending state disables submission.
+
+- [ ] **Step 3: Gates and commit**
+
+```bash
+pnpm --filter web test src/components/with-logic/navigation.test.tsx src/components/section/newsletter.test.tsx
+pnpm run lint && pnpm run format:check && pnpm run typecheck
+but commit -b test/web-296-unit-tests-components \
+  -m "test(web): cover the navigation and the newsletter form" \
+  apps/web/src/components/with-logic/navigation.test.tsx \
+  apps/web/src/components/section/newsletter.test.tsx
+```
+
+---
+
+### Task 8: The remaining with-logic components
+
+**Files:**
+
+- Create: `apps/web/src/components/with-logic/breadcrumb.test.tsx`
+- Create: `apps/web/src/components/with-logic/number-ticker.test.tsx`
+- Create: `apps/web/src/components/with-logic/contact-link.test.tsx`
+- Create: `apps/web/src/components/with-logic/contact-persons.test.tsx`
+
+**Interfaces:**
+
+- Consumes: Task 2's helpers, particularly the `motion` mock for the ticker.
+- Produces: nothing.
+
+- [ ] **Step 1: `breadcrumb.test.tsx`**
+
+Segments derived from the pathname (set through the `next/navigation` mock), humanised labels, and the last segment rendered as text rather than a link. Assert via the `navigation` landmark and its links.
+
+- [ ] **Step 2: `number-ticker.test.tsx`**
+
+The ticker's value is driven by `useSpring`, which Task 2 mocked. Read what Task 2 actually implemented: if the mock drives the value, assert the component reaches its target under fake timers and respects its delay; if the mock only stubs the surface, then the value is not really driven and you must say so plainly — assert what is genuinely observable (the initial render, the formatting through `DEFAULT_LOCALE`, the decimal places) and report the gap rather than dressing a stub up as coverage.
+
+- [ ] **Step 3: `contact-link.test.tsx` and `contact-persons.test.tsx`**
+
+`mailto:` and `tel:` hrefs built from the data, the initials fallback when a person has no image, and an empty list rendering nothing. Assert hrefs exactly.
+
+- [ ] **Step 4: Gates and commit**
+
+```bash
+pnpm --filter web test src/components/with-logic
+pnpm run lint && pnpm run format:check && pnpm run typecheck
+but commit -b test/web-296-unit-tests-components \
+  -m "test(web): cover the breadcrumb, ticker and contact components" \
+  apps/web/src/components/with-logic/breadcrumb.test.tsx \
+  apps/web/src/components/with-logic/number-ticker.test.tsx \
+  apps/web/src/components/with-logic/contact-link.test.tsx \
+  apps/web/src/components/with-logic/contact-persons.test.tsx
+```
+
+---
+
+### Task 9: Close out
+
+**Files:** none, unless the accessibility findings warrant a documentation line.
+
+- [ ] **Step 1: Full verification**
+
+Run: `pnpm run lint && pnpm run format:check && pnpm run typecheck && pnpm run test && pnpm run build` Expected: all green. Record the test total and the per-workspace split.
+
+- [ ] **Step 2: Coverage**
+
+Run: `pnpm run test:coverage` Record the line coverage for `apps/web/src/components`, and note which of the tested components are furthest from covered.
+
+- [ ] **Step 3: Report, in English**
+
+Collect for the pull request: the components covered, the test total, coverage figures, every disagreement found between this plan and real behaviour, every place where the module mocks made something untestable (the drag gesture, the preload prop, any class-only distinction), and any accessibility gap the tests exposed — a control without an accessible name, a label not associated with its input, an active state expressed only by colour. Those are real findings worth surfacing even though fixing them is out of scope here.
+
+---
+
+## Deliberately not covered
+
+Per the spec: the shadcn/Radix wrappers (`select`, `dialog`, `drawer`, `scroll-area`, `card`, `input`, `textarea`, `toggle`, `toggle-group`, `alert`, `badge` beyond Task 2's smoke test, `button`, the breadcrumb primitives) and the presentational cards (`training-card`, `group-card`, `pricing-card`, `news-article-preview*`, `hero`, `vision`, `footer`). They spread props and CVA classes; Radix and typegen already cover that, and asserting their class strings would pin markup rather than behaviour. Interaction on those surfaces belongs to the E2E ticket under epic WEB-294.
+
+`apps/web/src/hooks/use-media-query.ts` was covered by PR 1.
+
+## Self-Review
+
+**Spec coverage:** every component in the spec's PR 4 list maps to a task — lightbox (3), gallery and portable-text (4), contact-form (5), feedback form and screenshot-upload (6), navigation and newsletter (7), breadcrumb, number-ticker, contact-link and contact-persons (8). The spec's skip list is reproduced verbatim above. `use-media-query` is noted as already done.
+
+**Placeholder scan:** no TBD/TODO. Task 2 describes each mock's required surface without dictating an implementation, because the honest shape depends on what the components actually import — and three later tasks are told to report a gap rather than fake coverage if a mock cannot reproduce real behaviour.
+
+**Type consistency:** `renderWithUser` is defined once in Task 2 and consumed by name in Tasks 3-8; `createMatchMediaStub` and `dispatchMediaQueryChange` match what PR 1 shipped; the `next/navigation` pathname setter is introduced in Task 2 and used by Tasks 7 and 8.


### PR DESCRIPTION
PR 4 of 5 for WEB-296, on top of #471, #472 and #473. This one covers the components that carry real logic, under jsdom, and builds the render harness the remaining component tests will use.

## Approach

Everything asserts what a user can observe — role, label, text, accessible name, href. No test in this PR asserts a class name, and none adds a `data-testid` for its own convenience. That rule is why several cases here document a gap instead of claiming coverage: where a component's only observable difference is a Tailwind class, the honest answer is that there is nothing to assert.

The harness lives in `apps/web/test-utils/`: `renderWithUser` for rendering with `user-event`, and `setup-dom.ts` for the global stubs, the three module mocks (`next/image`, `next/navigation`, `motion`), the DOM cleanup and the mock-state reset. `apps/web/AGENTS.md` records the conventions.

## What is covered

The lightbox (paging, keyboard, backdrop, captions, the dialog's accessible name), the gallery across all four layout branches, the portable-text renderer, the contact form, the feedback form and its screenshot upload, the navigation, the newsletter form, the breadcrumb, the number ticker, and the contact link and contact-persons components.

329 tests across the monorepo; `apps/web/src/components` at 82.35% line coverage, weighted across a tree that includes the shadcn wrappers we deliberately do not test.

Not covered, per the spec: the shadcn/Radix wrappers and the presentational cards. They spread props and CVA classes, which Radix and typegen already cover, and asserting their class strings would pin markup rather than behaviour. Interaction on those surfaces belongs to the E2E ticket.

## What the harness cannot see

Worth reading before trusting a green run on an animated component:

- **No animation prop is observable.** The `motion` mock strips them unconditionally and pins `useReducedMotion` to `true`, so no test can distinguish a reduced-motion branch from a full-motion one. An inverted `useReducedMotion` check would pass everything.
- **`next/image`'s Next-only props are dropped**, including `preload`. Inverting the gallery's first-image preload would go unnoticed.
- **The lightbox's drag-to-dismiss is untested.** `onDragEnd` and the pan handlers never reach the component through the mock, so there is no honest way to exercise that path here.
- **The mobile menu toggle has no assertable effect.** A test asserting the nav link count across toggles was deleted rather than kept: the component never adds or removes those nodes, so it would have passed with the click handler deleted. That absence is itself finding 7 below.

## Twelve findings, all reported and none fixed

This is a tests-only PR — no production file changed. Each of these needs its own change, with someone looking at the result.

**Accessibility**

1. `contact-link.tsx:85-101` — `ContactLink` applies its own `aria-label` after spreading `...props`, so the purpose-specific label `contact-button.tsx` passes ("E-Mail", "Telefon", "Whatsapp") is always discarded. `handleInteraction` fires on hover, focus, touch, context-menu and Enter/Space — not just click — and then removes the label entirely. Since a `ContactButton`'s only child is an `aria-hidden` icon, **merely tabbing to it leaves a control with no accessible name at all.** Live on the site, used throughout `ContactPersons`. This is the most serious item here and deserves its own ticket rather than a line in a PR description.
2. `navigation.tsx` — the closed mobile menu's links stay in the DOM with no `hidden`, `aria-hidden` or `inert`, clipped only by `opacity-0`/`max-h-0`. They remain in the tab order and in the accessibility tree, so a keyboard user tabs into invisible links (WCAG 2.4.3).
3. `navigation.tsx` — the mobile toggle has no `aria-expanded` and no `aria-controls`, so its state is not exposed at all.
4. `navigation.tsx` — the active nav item is indicated by colour and a border only; there is no `aria-current`.
5. `alert.tsx:14-20` — `role="alert"` with no accessible name. The announcement still works, so nothing is dropped today, but the name should come from its title.
6. `screenshot-upload.tsx:289-298` — the remove button on a **failed** upload tile has no accessible name, unlike the one on a successful tile.
7. `newsletter.tsx:64-68` — `aria-label` sits on the `<label>` rather than the input. It happens to work through label-to-control propagation, but it is why `getByLabelText` returns the label element.

**Silent failures and wrong output**

8. `screenshot-upload.tsx:52-61` — both the file-type and file-size guards `return` bare. A user who picks a PDF or a 20 MB image gets **no message, no tile, no feedback of any kind.** The two tests pinning this carry comments marking it as a documented defect.
9. `breadcrumb.tsx:66` — when `currentPage` is omitted, the fallback reads the last *linked* segment, so it duplicates the second-to-last title and the real final segment never renders. Unreachable today because `Hero` always passes `currentPage`.
10. `breadcrumb.tsx:25-29` — the path accumulator reassigns to the bare segment instead of the accumulated path, so from the third link onward hrefs are wrong: `/a/b/c/d` yields `/b/c` where `/a/b/c` belongs. Unreachable today because the deepest route produces only two links.
11. `main-navigation.ts` + `internal-link.ts`/`external-link.ts` — the GROQ query projects `title` and `navigation.tsx` renders it, but neither link schema declares that field, which is why typegen types it as `null`. Existing documents presumably still carry a stored value; **a newly added nav item would render as an empty link.** The fix is to declare `title` on both schemas and regenerate.
12. `portable-text.tsx` — the generic `link` mark's component is `async`, a Server Component. `portable-text.tsx` has no `'use client'`/`server-only` marker and is imported by `vision.dialog.tsx`, which is a client component. Unreachable today only because `blockContent` limits annotations to `internalLink`/`externalLink`; if a schema ever registers a plain `link`, server call sites would work while that client one silently breaks.

Also worth noting: `privacy: undefined` as a form default, feeding `checked={field.value}`, makes React warn on every toggle in three places — `contact-form.tsx:55`, `feedback/form.tsx:43` and `operation-system-field.tsx` (a `Select`, same root cause). One word each, but changing a form's default alters dirty-state and validation timing, so it wants a human eye.

## Notes on process

Two tests were changed after review because they could not fail: the mobile-toggle case (deleted) and a gallery case whose title claimed coverage it did not have (corrected). One test was 2955ms — 59% of the default timeout — because it loaded the whole Sanity client chain to check an initials fallback; mocking the right boundary took it to ~30ms.

Plan and design live under `docs/superpowers/`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive automated coverage for forms, navigation, galleries, lightboxes, contact components, content rendering, badges, tickers, and screenshot uploads.
  * Added regression checks for image rendering and pathname behavior.
  * Improved shared test utilities, including user interaction support, cleanup, and reusable browser/API mocks.
* **Documentation**
  * Expanded testing guidance with shared utilities, mock limitations, observable-behavior recommendations, and regression-test conventions.
  * Added an implementation plan for broader web component and hook testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->